### PR TITLE
fix(instance_server): detach pn on server deletion

### DIFF
--- a/scaleway/testdata/data-source-vpc-public-gateway-dhcp-reservation-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-vpc-public-gateway-dhcp-reservation-basic.cassette.yaml
@@ -2,18 +2,18 @@
 version: 1
 interactions:
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","subnet":"192.168.1.0/24","address":null,"pool_low":null,"pool_high":null,"enable_dynamic":null,"valid_lifetime":null,"renew_timer":null,"rebind_timer":null,"push_default_route":null,"push_dns_server":null,"dns_servers_override":null,"dns_search":null,"dns_local_name":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","address":null,"pool_low":null,"pool_high":null,"enable_dynamic":null,"valid_lifetime":null,"renew_timer":null,"rebind_timer":null,"push_default_route":null,"push_dns_server":null,"dns_servers_override":null,"dns_search":null,"dns_local_name":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
     method: POST
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "586"
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:25:47 GMT
+      - Fri, 20 Oct 2023 14:14:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 420c7c4b-0c06-4db4-afe9-5e22fb6e3902
+      - 77014efb-7c0f-49fb-9096-0f3afb81f540
     status: 200 OK
     code: 200
     duration: ""
@@ -41,12 +41,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/3465ffb2-22aa-4afb-8684-f08ec4302bc3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/ed17287e-2e94-4739-a493-5cfc6f7ad4dd
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "586"
@@ -55,7 +55,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:25:47 GMT
+      - Fri, 20 Oct 2023 14:14:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,32 +65,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0033b9b9-636e-4030-bca8-e4d418a0df9b
+      - 9a1386a4-3c20-47cf-95eb-3f5b3650507b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
     method: POST
   response:
-    body: '{"address":"163.172.141.116","created_at":"2023-07-28T14:25:48.490480Z","gateway_id":null,"id":"c0909cd1-e99f-4def-8bd0-34bdd90a95c3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"116-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-28T14:25:48.490480Z","zone":"fr-par-1"}'
+    body: '{"address":"163.172.151.40","created_at":"2023-10-20T14:14:22.812784Z","gateway_id":null,"id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"40-151-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:14:22.812784Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "371"
+      - "369"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:25:48 GMT
+      - Fri, 20 Oct 2023 14:14:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -100,7 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d694e2d-0ce3-40ff-8e2b-fc022db8a6dd
+      - 80d42bf0-df55-4015-88bf-737cfba2cb33
     status: 200 OK
     code: 200
     duration: ""
@@ -109,21 +109,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/c0909cd1-e99f-4def-8bd0-34bdd90a95c3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/a5c6f7e8-7d69-42f2-8f77-e92d394818dd
     method: GET
   response:
-    body: '{"address":"163.172.141.116","created_at":"2023-07-28T14:25:48.490480Z","gateway_id":null,"id":"c0909cd1-e99f-4def-8bd0-34bdd90a95c3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"116-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-28T14:25:48.490480Z","zone":"fr-par-1"}'
+    body: '{"address":"163.172.151.40","created_at":"2023-10-20T14:14:22.812784Z","gateway_id":null,"id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"40-151-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:14:22.812784Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "371"
+      - "369"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:25:48 GMT
+      - Fri, 20 Oct 2023 14:14:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -133,32 +133,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7442a07e-a8af-41aa-9421-1456ef736ef6
+      - dd30e6fd-a1de-45a4-9e1d-c61548cd6556
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"c0909cd1-e99f-4def-8bd0-34bdd90a95c3","enable_smtp":false,"enable_bastion":false,"bastion_port":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","enable_smtp":false,"enable_bastion":false,"bastion_port":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
     method: POST
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-28T14:25:49.111949Z","gateway_networks":[],"id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","ip":{"address":"163.172.141.116","created_at":"2023-07-28T14:25:48.490480Z","gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"c0909cd1-e99f-4def-8bd0-34bdd90a95c3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"116-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-28T14:25:48.490480Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-28T14:25:49.111949Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:14:23.136875Z","gateway_networks":[],"id":"1a2e3870-ac79-4336-a5c8-85d537c55814","ip":{"address":"163.172.151.40","created_at":"2023-10-20T14:14:22.812784Z","gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"40-151-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:14:22.812784Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:14:23.136875Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "954"
+      - "971"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:25:49 GMT
+      - Fri, 20 Oct 2023 14:14:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -168,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ede4779-2c14-44a2-bd92-17fe0c3ffa3a
+      - db8ff747-a7f2-487e-957d-4b09f052d6d8
     status: 200 OK
     code: 200
     duration: ""
@@ -177,21 +177,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/c2996cf0-0773-499a-bbb5-ff3baf57cbe5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1a2e3870-ac79-4336-a5c8-85d537c55814
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-28T14:25:49.111949Z","gateway_networks":[],"id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","ip":{"address":"163.172.141.116","created_at":"2023-07-28T14:25:48.490480Z","gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"c0909cd1-e99f-4def-8bd0-34bdd90a95c3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"116-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-28T14:25:48.490480Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-28T14:25:49.169133Z","upstream_dns_servers":[],"version":"0.5.4","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:14:23.136875Z","gateway_networks":[],"id":"1a2e3870-ac79-4336-a5c8-85d537c55814","ip":{"address":"163.172.151.40","created_at":"2023-10-20T14:14:22.812784Z","gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"40-151-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:14:22.812784Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:14:23.176334Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "957"
+      - "974"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:25:49 GMT
+      - Fri, 20 Oct 2023 14:14:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -201,32 +201,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35f3b586-8ce3-4e4d-970d-0dc0c56d6155
+      - 3dab94dc-0aaa-43e0-bb16-c484d5be4f52
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null,"vpc_id":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-07-28T14:25:47.831135Z","dhcp_enabled":true,"id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-07-28T14:25:47.831135Z","id":"0bff6f6c-3aa8-498c-a249-531d7a31abd3","subnet":"172.16.0.0/22","updated_at":"2023-07-28T14:25:47.831135Z"},{"created_at":"2023-07-28T14:25:47.831135Z","id":"4e4340a9-f40c-4e0c-b57e-3740ef5216bc","subnet":"fd46:78ab:30b8:9a8a::/64","updated_at":"2023-07-28T14:25:47.831135Z"}],"tags":[],"updated_at":"2023-07-28T14:25:47.831135Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2023-10-20T14:14:22.245911Z","dhcp_enabled":true,"id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T14:14:22.245911Z","id":"c0296ded-0a66-4433-a721-f673df956b04","subnet":"172.16.120.0/22","updated_at":"2023-10-20T14:14:22.245911Z"},{"created_at":"2023-10-20T14:14:22.245911Z","id":"ebebdf6b-cab1-4e79-a6e5-e269e008ab01","subnet":"fd5f:519c:6d46:bb1a::/64","updated_at":"2023-10-20T14:14:22.245911Z"}],"tags":[],"updated_at":"2023-10-20T14:14:22.245911Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "762"
+      - "764"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:25:49 GMT
+      - Fri, 20 Oct 2023 14:14:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee4c7cd3-40dd-4f2d-89cf-284208d2e46c
+      - bccf9ef0-6498-4957-beeb-53bd63d93433
     status: 200 OK
     code: 200
     duration: ""
@@ -245,21 +245,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bb06b91c-d5e4-4f3f-a661-a322f90debc6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/17818dee-ef3c-4c6a-b5a4-d701ee98d1e5
     method: GET
   response:
-    body: '{"created_at":"2023-07-28T14:25:47.831135Z","dhcp_enabled":true,"id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-07-28T14:25:47.831135Z","id":"0bff6f6c-3aa8-498c-a249-531d7a31abd3","subnet":"172.16.0.0/22","updated_at":"2023-07-28T14:25:47.831135Z"},{"created_at":"2023-07-28T14:25:47.831135Z","id":"4e4340a9-f40c-4e0c-b57e-3740ef5216bc","subnet":"fd46:78ab:30b8:9a8a::/64","updated_at":"2023-07-28T14:25:47.831135Z"}],"tags":[],"updated_at":"2023-07-28T14:25:47.831135Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2023-10-20T14:14:22.245911Z","dhcp_enabled":true,"id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T14:14:22.245911Z","id":"c0296ded-0a66-4433-a721-f673df956b04","subnet":"172.16.120.0/22","updated_at":"2023-10-20T14:14:22.245911Z"},{"created_at":"2023-10-20T14:14:22.245911Z","id":"ebebdf6b-cab1-4e79-a6e5-e269e008ab01","subnet":"fd5f:519c:6d46:bb1a::/64","updated_at":"2023-10-20T14:14:22.245911Z"}],"tags":[],"updated_at":"2023-10-20T14:14:22.245911Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "762"
+      - "764"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:25:49 GMT
+      - Fri, 20 Oct 2023 14:14:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba36dc94-2690-42ed-8cc1-f2125f69fdd4
+      - b4d258ee-8db8-4db8-8dc7-7e921bffcf73
     status: 200 OK
     code: 200
     duration: ""
@@ -278,21 +278,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60"],"id":"5b51710c-e543-47b5-92d2-a68a83cefbe9","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"10b2d3c3-bfa7-42d4-910b-389e95f95ccb","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1164"
+      - "1256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:25:49 GMT
+      - Fri, 20 Oct 2023 14:14:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9694cc62-e8d0-4bcb-91e6-3dc97a93a0d8
+      - bdc5c270-eabf-4d0b-b72a-2b9bd0a06f47
     status: 200 OK
     code: 200
     duration: ""
@@ -311,21 +311,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
+    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
     headers:
       Content-Length:
-      - "37931"
+      - "38421"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:25:49 GMT
+      - Fri, 20 Oct 2023 14:14:23 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
@@ -338,7 +338,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4b09009-538e-45ee-99b0-d1396984d1d5
+      - 058b72f5-a1db-4311-89c5-f4610c448a82
       X-Total-Count:
       - "56"
     status: 200 OK
@@ -349,21 +349,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
     headers:
       Content-Length:
-      - "4489"
+      - "4865"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:25:49 GMT
+      - Fri, 20 Oct 2023 14:14:23 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
@@ -376,42 +376,42 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46cabbeb-86df-4ebb-8c0a-6d987032249d
+      - 46094e57-4259-46de-91b7-c454524686bf
       X-Total-Count:
       - "56"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-srv-boring-goldwasser","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5"}'
+    body: '{"name":"tf-srv-friendly-jennings","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:25:50.249884+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:14:24.221137+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2634"
+      - "2654"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:25:50 GMT
+      - Fri, 20 Oct 2023 14:14:24 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -421,7 +421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de021c28-7a33-41c5-838b-8d3734e310c7
+      - d6d1fa21-9d8a-49a2-8b5b-c3aa6a4b015c
     status: 201 Created
     code: 201
     duration: ""
@@ -430,27 +430,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:25:50.249884+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:14:24.221137+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2634"
+      - "2654"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:25:50 GMT
+      - Fri, 20 Oct 2023 14:14:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -460,7 +460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a00601cd-a2a0-4e5e-8ce5-b40b223b39c3
+      - faa792f6-0e25-4c60-b4cf-b213acd7fd91
     status: 200 OK
     code: 200
     duration: ""
@@ -469,27 +469,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:25:50.249884+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:14:24.221137+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2634"
+      - "2654"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:25:50 GMT
+      - Fri, 20 Oct 2023 14:14:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -499,7 +499,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21e40c61-70a8-4f26-b649-af2be8985f2b
+      - a2c85ff2-f35e-4b6d-9410-5e01dea5b198
     status: 200 OK
     code: 200
     duration: ""
@@ -510,12 +510,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/f45be185-d322-46dc-883f-b995ede84e45/action","href_result":"/servers/f45be185-d322-46dc-883f-b995ede84e45","id":"73719819-b26d-4498-9c39-03de20842326","started_at":"2023-07-28T14:25:51.284831+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/action","href_result":"/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79","id":"c21f41aa-3f87-4e24-a14f-0cb69a5f5ea0","started_at":"2023-10-20T14:14:25.357848+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -524,9 +524,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:25:51 GMT
+      - Fri, 20 Oct 2023 14:14:25 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/73719819-b26d-4498-9c39-03de20842326
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/c21f41aa-3f87-4e24-a14f-0cb69a5f5ea0
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -536,7 +536,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2fd7429e-4b33-4d6b-8234-1e4d0ffa7631
+      - bf3bca6d-1b3d-451f-b257-aa62e982e778
     status: 202 Accepted
     code: 202
     duration: ""
@@ -545,27 +545,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:25:50.882063+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:14:25.024177+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2656"
+      - "2676"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:25:51 GMT
+      - Fri, 20 Oct 2023 14:14:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -575,7 +575,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84245341-7af9-4fa6-93b1-89a74e19b80c
+      - 57bf6b42-82dd-473b-b3a0-8a041c829da1
     status: 200 OK
     code: 200
     duration: ""
@@ -584,21 +584,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/c2996cf0-0773-499a-bbb5-ff3baf57cbe5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1a2e3870-ac79-4336-a5c8-85d537c55814
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-28T14:25:49.111949Z","gateway_networks":[],"id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","ip":{"address":"163.172.141.116","created_at":"2023-07-28T14:25:48.490480Z","gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"c0909cd1-e99f-4def-8bd0-34bdd90a95c3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"116-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-28T14:25:48.490480Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-28T14:25:50.016500Z","upstream_dns_servers":[],"version":"0.5.4","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:14:23.136875Z","gateway_networks":[],"id":"1a2e3870-ac79-4336-a5c8-85d537c55814","ip":{"address":"163.172.151.40","created_at":"2023-10-20T14:14:22.812784Z","gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"40-151-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:14:22.812784Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:14:23.875684Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "954"
+      - "971"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:25:54 GMT
+      - Fri, 20 Oct 2023 14:14:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -608,7 +608,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53a17285-f77c-492a-a058-1c9d94bff136
+      - 7fc520e0-65ea-4401-a5ac-2e18e6f53c2f
     status: 200 OK
     code: 200
     duration: ""
@@ -617,21 +617,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/c2996cf0-0773-499a-bbb5-ff3baf57cbe5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1a2e3870-ac79-4336-a5c8-85d537c55814
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-28T14:25:49.111949Z","gateway_networks":[],"id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","ip":{"address":"163.172.141.116","created_at":"2023-07-28T14:25:48.490480Z","gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"c0909cd1-e99f-4def-8bd0-34bdd90a95c3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"116-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-28T14:25:48.490480Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-28T14:25:50.016500Z","upstream_dns_servers":[],"version":"0.5.4","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:14:23.136875Z","gateway_networks":[],"id":"1a2e3870-ac79-4336-a5c8-85d537c55814","ip":{"address":"163.172.151.40","created_at":"2023-10-20T14:14:22.812784Z","gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"40-151-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:14:22.812784Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:14:23.875684Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "954"
+      - "971"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:25:54 GMT
+      - Fri, 20 Oct 2023 14:14:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -641,7 +641,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbccbaef-31f3-4234-9437-4ce63c507e0c
+      - 775543ed-463d-4a82-8804-5ce70a3b5b76
     status: 200 OK
     code: 200
     duration: ""
@@ -650,21 +650,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/c2996cf0-0773-499a-bbb5-ff3baf57cbe5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1a2e3870-ac79-4336-a5c8-85d537c55814
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-28T14:25:49.111949Z","gateway_networks":[],"id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","ip":{"address":"163.172.141.116","created_at":"2023-07-28T14:25:48.490480Z","gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"c0909cd1-e99f-4def-8bd0-34bdd90a95c3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"116-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-28T14:25:48.490480Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-28T14:25:50.016500Z","upstream_dns_servers":[],"version":"0.5.4","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:14:23.136875Z","gateway_networks":[],"id":"1a2e3870-ac79-4336-a5c8-85d537c55814","ip":{"address":"163.172.151.40","created_at":"2023-10-20T14:14:22.812784Z","gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"40-151-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:14:22.812784Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:14:23.875684Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "954"
+      - "971"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:25:54 GMT
+      - Fri, 20 Oct 2023 14:14:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -674,71 +674,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64ec4384-b340-4f8a-b1bf-93e4b2033d0c
+      - 062a6451-88e0-47e1-b2b0-71da92d988d8
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:25:50.882063+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2656"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:25:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9d519a27-82de-4f50-891a-f68ffe9240f4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","enable_masquerade":true,"dhcp_id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","enable_dhcp":true}'
+    body: '{"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":null,"private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"created","updated_at":"2023-07-28T14:25:56.826819Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:14:29.769171Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"0460288e-1696-4f33-ad3a-75e364a948d4","ipam_config":null,"mac_address":null,"private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","status":"created","updated_at":"2023-10-20T14:14:29.769171Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "963"
+      - "983"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:25:56 GMT
+      - Fri, 20 Oct 2023 14:14:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -748,7 +709,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab1feecf-3431-454b-8f2b-5c48a534b1c2
+      - 48bc1a48-a4d6-424e-80e0-8cd1840980b0
     status: 200 OK
     code: 200
     duration: ""
@@ -757,21 +718,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/c2996cf0-0773-499a-bbb5-ff3baf57cbe5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1a2e3870-ac79-4336-a5c8-85d537c55814
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-28T14:25:49.111949Z","gateway_networks":[{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":null,"private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"created","updated_at":"2023-07-28T14:25:56.826819Z","zone":"fr-par-1"}],"id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","ip":{"address":"163.172.141.116","created_at":"2023-07-28T14:25:48.490480Z","gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"c0909cd1-e99f-4def-8bd0-34bdd90a95c3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"116-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-28T14:25:48.490480Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-28T14:25:50.016500Z","upstream_dns_servers":[],"version":"0.5.4","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:14:23.136875Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:14:29.769171Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"0460288e-1696-4f33-ad3a-75e364a948d4","ipam_config":null,"mac_address":null,"private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","status":"created","updated_at":"2023-10-20T14:14:29.769171Z","zone":"fr-par-1"}],"id":"1a2e3870-ac79-4336-a5c8-85d537c55814","ip":{"address":"163.172.151.40","created_at":"2023-10-20T14:14:22.812784Z","gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"40-151-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:14:22.812784Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:14:29.960814Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1917"
+      - "1957"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:25:56 GMT
+      - Fri, 20 Oct 2023 14:14:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -781,7 +742,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d42910c-6d0a-4f55-b2ab-4e36a5a2a73e
+      - f8caae7c-9a09-410e-97a9-2fc9ce425b77
     status: 200 OK
     code: 200
     duration: ""
@@ -790,60 +751,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":null,"private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"created","updated_at":"2023-07-28T14:25:56.826819Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "963"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:25:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 06d4a1c9-6307-4772-8b89-b62cdb13a1d7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:25:50.882063+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"204","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:14:25.024177+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.76.78.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2656"
+      - "2784"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:26:01 GMT
+      - Fri, 20 Oct 2023 14:14:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -853,7 +781,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95c40697-96b6-4db0-ae21-fccb4968e620
+      - 099ec3b7-7896-4977-8edf-d019372d3d87
     status: 200 OK
     code: 200
     duration: ""
@@ -862,21 +790,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1a2e3870-ac79-4336-a5c8-85d537c55814
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":null,"private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"created","updated_at":"2023-07-28T14:25:56.826819Z","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:14:23.136875Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:14:29.769171Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"0460288e-1696-4f33-ad3a-75e364a948d4","ipam_config":null,"mac_address":"02:00:00:14:57:C5","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","status":"ready","updated_at":"2023-10-20T14:14:32.032283Z","zone":"fr-par-1"}],"id":"1a2e3870-ac79-4336-a5c8-85d537c55814","ip":{"address":"163.172.151.40","created_at":"2023-10-20T14:14:22.812784Z","gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"40-151-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:14:22.812784Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:14:32.158729Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "963"
+      - "1966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:26:02 GMT
+      - Fri, 20 Oct 2023 14:14:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -886,7 +814,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ffee1a6-17d5-48ac-b4ab-8216f4b89583
+      - 0da626d8-7644-4905-8dc8-c22407c5dac4
     status: 200 OK
     code: 200
     duration: ""
@@ -895,27 +823,159 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0460288e-1696-4f33-ad3a-75e364a948d4
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"address":null,"created_at":"2023-10-20T14:14:29.769171Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"0460288e-1696-4f33-ad3a-75e364a948d4","ipam_config":null,"mac_address":"02:00:00:14:57:C5","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","status":"ready","updated_at":"2023-10-20T14:14:32.032283Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:14:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2629ac3e-0c01-4068-847c-4ee998ed6894
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0460288e-1696-4f33-ad3a-75e364a948d4
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-20T14:14:29.769171Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"0460288e-1696-4f33-ad3a-75e364a948d4","ipam_config":null,"mac_address":"02:00:00:14:57:C5","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","status":"ready","updated_at":"2023-10-20T14:14:32.032283Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:14:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c06fac65-02d5-463e-b58c-c1c438e2c1ab
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1a2e3870-ac79-4336-a5c8-85d537c55814
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:14:23.136875Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:14:29.769171Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"0460288e-1696-4f33-ad3a-75e364a948d4","ipam_config":null,"mac_address":"02:00:00:14:57:C5","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","status":"ready","updated_at":"2023-10-20T14:14:32.032283Z","zone":"fr-par-1"}],"id":"1a2e3870-ac79-4336-a5c8-85d537c55814","ip":{"address":"163.172.151.40","created_at":"2023-10-20T14:14:22.812784Z","gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"40-151-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:14:22.812784Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:14:32.158729Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1966"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:14:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 741f4e51-9b76-4221-a7ae-24663ef2360a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0460288e-1696-4f33-ad3a-75e364a948d4
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-20T14:14:29.769171Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"0460288e-1696-4f33-ad3a-75e364a948d4","ipam_config":null,"mac_address":"02:00:00:14:57:C5","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","status":"ready","updated_at":"2023-10-20T14:14:32.032283Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:14:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 99d477dc-b580-44c8-b78c-3c5b1a6038db
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:25:50.882063+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"204","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:14:25.024177+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.76.78.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2656"
+      - "2784"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:26:06 GMT
+      - Fri, 20 Oct 2023 14:14:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -925,7 +985,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d41b1b2-dc39-4fde-bf95-033ca0e230b9
+      - 7a8b9822-916a-4011-b013-2ac195550eeb
     status: 200 OK
     code: 200
     duration: ""
@@ -934,60 +994,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":null,"private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"created","updated_at":"2023-07-28T14:25:56.826819Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "963"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:26:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d9742062-18f4-40da-b731-ba59d990aa50
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:25:50.882063+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"204","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:14:25.024177+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.76.78.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2656"
+      - "2784"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:26:11 GMT
+      - Fri, 20 Oct 2023 14:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +1024,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7ea51fa-6262-43dd-a1e9-308669acd7be
+      - 476e0217-a893-4915-8ce3-591f53fcebda
     status: 200 OK
     code: 200
     duration: ""
@@ -1006,60 +1033,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":null,"private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"created","updated_at":"2023-07-28T14:25:56.826819Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "963"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:26:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9f098d10-b303-4d5b-a7a3-9babeda07af4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"502","node_id":"29","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:25:50.882063+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.74.98.57","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"204","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:14:44.602659+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.76.78.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2764"
+      - "2815"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:26:17 GMT
+      - Fri, 20 Oct 2023 14:14:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1069,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98887499-9d70-47a0-9d20-970c7068a941
+      - f954e837-d1f3-48d3-8225-657501ad1218
     status: 200 OK
     code: 200
     duration: ""
@@ -1078,405 +1072,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/17818dee-ef3c-4c6a-b5a4-d701ee98d1e5
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":null,"private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"created","updated_at":"2023-07-28T14:25:56.826819Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "963"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:26:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 02ba9ec1-f6f1-4f5b-aebb-a55e30228fe7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"502","node_id":"29","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:25:50.882063+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.74.98.57","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2764"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:26:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6baf46f5-527f-45a6-9367-4cc42576e896
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":null,"private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"created","updated_at":"2023-07-28T14:25:56.826819Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "963"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:26:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6664a0bd-1fd5-4043-986c-66b9ea1e44da
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"502","node_id":"29","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:25:50.882063+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.74.98.57","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2764"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:26:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 70056f5c-a383-4799-8510-61134de13dbb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":null,"private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"created","updated_at":"2023-07-28T14:25:56.826819Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "963"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:26:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4d07bbae-a904-4470-9355-0ec83a904e0c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"502","node_id":"29","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:25:50.882063+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.74.98.57","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2764"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:26:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a188587a-48f7-4691-8624-aee1b4075c05
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":null,"private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"created","updated_at":"2023-07-28T14:25:56.826819Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "963"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:26:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6333135c-7c7d-4db8-b6f5-25fa2e39f34a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"502","node_id":"29","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:25:50.882063+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.74.98.57","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2764"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:26:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 49014f8e-1d7b-49ec-b01c-d5f154522f86
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":null,"private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"created","updated_at":"2023-07-28T14:25:56.826819Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "963"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:26:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d4a7c93f-3091-41e4-a093-e0ef689f13c6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"502","node_id":"29","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:26:41.234370+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.74.98.57","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2795"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:26:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 979bcbd7-80fb-47cf-a0f6-64d0212c1dd6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":null,"private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"created","updated_at":"2023-07-28T14:25:56.826819Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "963"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:26:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1a2ab677-1ce4-42e5-b4ce-e500dc49d42b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/bb06b91c-d5e4-4f3f-a661-a322f90debc6
-    method: GET
-  response:
-    body: '{"created_at":"2023-07-28T14:25:47.831135Z","id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","subnets":["192.168.1.0/24","fd46:78ab:30b8:9a8a::/64"],"tags":[],"updated_at":"2023-07-28T14:25:54.694092Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T14:14:22.245911Z","id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnets":["192.168.1.0/24","fd5f:519c:6d46:bb1a::/64"],"tags":[],"updated_at":"2023-10-20T14:14:31.637798Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "405"
@@ -1485,7 +1086,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:26:43 GMT
+      - Fri, 20 Oct 2023 14:14:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1495,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2225a019-8da6-4bad-9c67-7060a3efa445
+      - e76ae645-da5c-4989-8f17-a92a82956391
     status: 200 OK
     code: 200
     duration: ""
@@ -1504,27 +1105,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"502","node_id":"29","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:26:41.234370+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.74.98.57","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"204","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:14:44.602659+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.76.78.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2795"
+      - "2815"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:26:43 GMT
+      - Fri, 20 Oct 2023 14:14:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1534,23 +1135,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a713478-bdce-4be5-8ffc-b54c864c4495
+      - 1e2ec63a-9fe5-4f29-88ce-31d974ddfcbd
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6"}'
+    body: '{"private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:26:43.338949+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:14:47.348863+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1559,7 +1160,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:26:44 GMT
+      - Fri, 20 Oct 2023 14:14:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1569,7 +1170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bb1f12d-4639-4327-a0b0-5f11e1ad6048
+      - 395bf24b-cf9f-4153-be20-fe245f544a6c
     status: 201 Created
     code: 201
     duration: ""
@@ -1578,12 +1179,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45/private_nics/96213172-56c4-47dd-b73f-b5b7a8c30291
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics/de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:26:43.338949+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:14:47.782869+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1592,7 +1193,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:26:44 GMT
+      - Fri, 20 Oct 2023 14:14:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1602,7 +1203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97ccc36a-aeff-49ca-a4c9-1c2075fe5f16
+      - ef5b3d52-a20c-4e6f-ac12-88f65cf52a53
     status: 200 OK
     code: 200
     duration: ""
@@ -1611,45 +1212,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics/de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":null,"private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"created","updated_at":"2023-07-28T14:25:56.826819Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "963"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:26:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0d77996a-6a37-4fc0-aa48-3363556e81f5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45/private_nics/96213172-56c4-47dd-b73f-b5b7a8c30291
-    method: GET
-  response:
-    body: '{"private_nic":{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:26:43.338949+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:14:48.164421+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1658,7 +1226,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:26:49 GMT
+      - Fri, 20 Oct 2023 14:14:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1668,7 +1236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc502672-9147-4b8d-9b46-1a42667a8d65
+      - 0386b71a-6591-4e26-85c6-71f1a081c4cc
     status: 200 OK
     code: 200
     duration: ""
@@ -1677,45 +1245,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics/de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":null,"private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"created","updated_at":"2023-07-28T14:25:56.826819Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "963"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:26:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 501f7a6b-8090-4d9e-89fe-49c948cb2e45
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45/private_nics/96213172-56c4-47dd-b73f-b5b7a8c30291
-    method: GET
-  response:
-    body: '{"private_nic":{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:26:43.338949+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:14:48.164421+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1724,7 +1259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:26:54 GMT
+      - Fri, 20 Oct 2023 14:14:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1734,7 +1269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ff8dc5a-bfc8-4e6b-be5a-1719c87beacf
+      - 96b61eb7-dd08-4a61-9882-0f98943a993d
     status: 200 OK
     code: 200
     duration: ""
@@ -1743,45 +1278,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics/de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":null,"private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"created","updated_at":"2023-07-28T14:25:56.826819Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "963"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:26:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f60a47fa-5d65-4549-8583-cd6b93dca60c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45/private_nics/96213172-56c4-47dd-b73f-b5b7a8c30291
-    method: GET
-  response:
-    body: '{"private_nic":{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:26:43.338949+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:14:48.164421+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1790,7 +1292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:26:59 GMT
+      - Fri, 20 Oct 2023 14:15:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1800,7 +1302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7669f03d-2ccf-467e-888e-eacc2b5c3490
+      - 42a6f9c5-37cf-4bd2-a2ad-9f29f108ae63
     status: 200 OK
     code: 200
     duration: ""
@@ -1809,144 +1311,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics/de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":"02:00:00:13:7F:85","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"ready","updated_at":"2023-07-28T14:27:00.409313Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "976"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e278642b-5501-4d58-ac86-454cb0436303
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":"02:00:00:13:7F:85","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"ready","updated_at":"2023-07-28T14:27:00.409313Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "976"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3e798374-afe9-4f32-bf65-37c3b5829597
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/c2996cf0-0773-499a-bbb5-ff3baf57cbe5
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-28T14:25:49.111949Z","gateway_networks":[{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":"02:00:00:13:7F:85","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"ready","updated_at":"2023-07-28T14:27:00.409313Z","zone":"fr-par-1"}],"id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","ip":{"address":"163.172.141.116","created_at":"2023-07-28T14:25:48.490480Z","gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"c0909cd1-e99f-4def-8bd0-34bdd90a95c3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"116-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-28T14:25:48.490480Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-28T14:27:00.559840Z","upstream_dns_servers":[],"version":"0.5.4","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1930"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ba5c97a1-5fae-42c9-aeef-bbe55513fdc8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":"02:00:00:13:7F:85","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"ready","updated_at":"2023-07-28T14:27:00.409313Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "976"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fb769ca7-34f2-484b-a02c-82c0dadf9c11
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45/private_nics/96213172-56c4-47dd-b73f-b5b7a8c30291
-    method: GET
-  response:
-    body: '{"private_nic":{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:27:02.104979+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:14:48.164421+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1955,7 +1325,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:04 GMT
+      - Fri, 20 Oct 2023 14:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1965,7 +1335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ba19d9f-e540-4d8f-a903-eac3bb32ab7f
+      - e6a9b529-0d52-4021-882f-4d5eb7f226e5
     status: 200 OK
     code: 200
     duration: ""
@@ -1974,12 +1344,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45/private_nics/96213172-56c4-47dd-b73f-b5b7a8c30291
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics/de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:27:02.104979+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:14:48.164421+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1988,7 +1358,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:09 GMT
+      - Fri, 20 Oct 2023 14:15:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1998,7 +1368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b90d74e3-eac5-4494-97dc-64b0262034f8
+      - a7c3312e-7a84-45a3-8568-3b48b21dfbb9
     status: 200 OK
     code: 200
     duration: ""
@@ -2007,45 +1377,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45/private_nics/96213172-56c4-47dd-b73f-b5b7a8c30291
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics/de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:27:02.104979+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"syncing","tags":[],"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "376"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fee72d28-78ab-4bb5-9f7e-8464801aab49
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45/private_nics/96213172-56c4-47dd-b73f-b5b7a8c30291
-    method: GET
-  response:
-    body: '{"private_nic":{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:27:16.866249+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:15:18.863566+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -2054,7 +1391,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:20 GMT
+      - Fri, 20 Oct 2023 14:15:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2064,7 +1401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7abc17f4-4ac9-46b0-b6d2-6312afa34af6
+      - f3595e07-dc1a-4374-860f-e29ec7b32b92
     status: 200 OK
     code: 200
     duration: ""
@@ -2073,12 +1410,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45/private_nics/96213172-56c4-47dd-b73f-b5b7a8c30291
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics/de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:27:16.866249+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:15:18.863566+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -2087,7 +1424,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:20 GMT
+      - Fri, 20 Oct 2023 14:15:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2097,7 +1434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee0b0ff3-8d73-46f5-9e25-461259474445
+      - 97ccd0ec-803c-4aea-93ac-f54324603255
     status: 200 OK
     code: 200
     duration: ""
@@ -2106,27 +1443,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"502","node_id":"29","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:26:41.234370+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.74.98.57","private_nics":[{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:27:16.866249+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"204","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:14:44.602659+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.76.78.37","private_nics":[{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:15:18.863566+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3148"
+      - "3168"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:20 GMT
+      - Fri, 20 Oct 2023 14:15:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2136,7 +1473,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49c0a9a6-dfdf-4105-8d24-ef1664cb3122
+      - 5444c8dc-8576-47db-8606-3fd647daed5c
     status: 200 OK
     code: 200
     duration: ""
@@ -2145,9 +1482,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2159,7 +1496,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:20 GMT
+      - Fri, 20 Oct 2023 14:15:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2169,7 +1506,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 781d5334-8f0c-4928-a949-484a24d14827
+      - eeadf93b-cb4e-4aeb-99d5-209c3b3019ab
     status: 200 OK
     code: 200
     duration: ""
@@ -2178,12 +1515,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:27:16.866249+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:15:18.863566+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -2192,9 +1529,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:20 GMT
+      - Fri, 20 Oct 2023 14:15:19 GMT
       Link:
-      - </servers/f45be185-d322-46dc-883f-b995ede84e45/private_nics?page=1&per_page=50&>;
+      - </servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -2205,7 +1542,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f360e666-eb70-4c85-b596-ca0e049887f0
+      - b77a2a58-f412-482c-996e-99f93c64db04
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -2216,21 +1553,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/c0909cd1-e99f-4def-8bd0-34bdd90a95c3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/a5c6f7e8-7d69-42f2-8f77-e92d394818dd
     method: GET
   response:
-    body: '{"address":"163.172.141.116","created_at":"2023-07-28T14:25:48.490480Z","gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"c0909cd1-e99f-4def-8bd0-34bdd90a95c3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"116-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-28T14:25:48.490480Z","zone":"fr-par-1"}'
+    body: '{"address":"163.172.151.40","created_at":"2023-10-20T14:14:22.812784Z","gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"40-151-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:14:22.812784Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "405"
+      - "403"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:21 GMT
+      - Fri, 20 Oct 2023 14:15:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2240,7 +1577,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef1d2656-1872-4801-a095-793e5415e86a
+      - 894fa6b8-dc4b-4c1d-831c-ec40c84c0bd4
     status: 200 OK
     code: 200
     duration: ""
@@ -2249,45 +1586,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bb06b91c-d5e4-4f3f-a661-a322f90debc6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/ed17287e-2e94-4739-a493-5cfc6f7ad4dd
     method: GET
   response:
-    body: '{"created_at":"2023-07-28T14:25:47.831135Z","dhcp_enabled":true,"id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-07-28T14:25:47.831135Z","id":"0bff6f6c-3aa8-498c-a249-531d7a31abd3","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:54.694092Z"},{"created_at":"2023-07-28T14:25:47.831135Z","id":"4e4340a9-f40c-4e0c-b57e-3740ef5216bc","subnet":"fd46:78ab:30b8:9a8a::/64","updated_at":"2023-07-28T14:25:54.694092Z"}],"tags":[],"updated_at":"2023-07-28T14:27:00.075992Z","vpc_id":"41149703-b548-4fe4-9b47-0ff7587a941a"}'
-    headers:
-      Content-Length:
-      - "763"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fca4a69a-9900-404d-a5be-643fe164599c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/3465ffb2-22aa-4afb-8684-f08ec4302bc3
-    method: GET
-  response:
-    body: '{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "586"
@@ -2296,7 +1600,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:21 GMT
+      - Fri, 20 Oct 2023 14:15:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2306,7 +1610,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f5b4528-bea3-4688-826f-16d788196dcf
+      - 63b276fd-208c-4410-85c9-1951b5b394a3
     status: 200 OK
     code: 200
     duration: ""
@@ -2315,320 +1619,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/c2996cf0-0773-499a-bbb5-ff3baf57cbe5
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/17818dee-ef3c-4c6a-b5a4-d701ee98d1e5
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-28T14:25:49.111949Z","gateway_networks":[{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":"02:00:00:13:7F:85","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"ready","updated_at":"2023-07-28T14:27:00.409313Z","zone":"fr-par-1"}],"id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","ip":{"address":"163.172.141.116","created_at":"2023-07-28T14:25:48.490480Z","gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"c0909cd1-e99f-4def-8bd0-34bdd90a95c3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"116-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-28T14:25:48.490480Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-28T14:27:00.559840Z","upstream_dns_servers":[],"version":"0.5.4","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1930"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c87df558-dc0a-4edf-8fe1-c6e68ef55cc3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"502","node_id":"29","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:26:41.234370+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.74.98.57","private_nics":[{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:27:16.866249+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3148"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9260129f-2d9b-4340-8575-4c9820edafdc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":"02:00:00:13:7F:85","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"ready","updated_at":"2023-07-28T14:27:00.409313Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "976"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b4934e50-a4e2-4062-a049-1a856cc2075a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45/user_data
-    method: GET
-  response:
-    body: '{"user_data":[]}'
-    headers:
-      Content-Length:
-      - "17"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f88716f1-0dd1-48a9-8845-022c439aa099
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/c2996cf0-0773-499a-bbb5-ff3baf57cbe5
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-28T14:25:49.111949Z","gateway_networks":[{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":"02:00:00:13:7F:85","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"ready","updated_at":"2023-07-28T14:27:00.409313Z","zone":"fr-par-1"}],"id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","ip":{"address":"163.172.141.116","created_at":"2023-07-28T14:25:48.490480Z","gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"c0909cd1-e99f-4def-8bd0-34bdd90a95c3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"116-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-28T14:25:48.490480Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-28T14:27:00.559840Z","upstream_dns_servers":[],"version":"0.5.4","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1930"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 38c8cfb2-4c75-4254-8870-3c667d02efc4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45/private_nics
-    method: GET
-  response:
-    body: '{"private_nics":[{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:27:16.866249+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"available","tags":[],"zone":"fr-par-1"}]}'
-    headers:
-      Content-Length:
-      - "381"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:21 GMT
-      Link:
-      - </servers/f45be185-d322-46dc-883f-b995ede84e45/private_nics?page=1&per_page=50&>;
-        rel="last"
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1086cc4b-0510-4b24-819a-18b2f0c65544
-      X-Total-Count:
-      - "1"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":"02:00:00:13:7F:85","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"ready","updated_at":"2023-07-28T14:27:00.409313Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "976"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ec684c5b-d0b5-4d1e-9a4b-843a8b71e475
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/3465ffb2-22aa-4afb-8684-f08ec4302bc3
-    method: GET
-  response:
-    body: '{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "586"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 11a5ab23-19f0-4ea2-984b-d4ea7317ce02
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/c0909cd1-e99f-4def-8bd0-34bdd90a95c3
-    method: GET
-  response:
-    body: '{"address":"163.172.141.116","created_at":"2023-07-28T14:25:48.490480Z","gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"c0909cd1-e99f-4def-8bd0-34bdd90a95c3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"116-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-28T14:25:48.490480Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "405"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 852d60aa-220e-41c5-9450-e14520050a79
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bb06b91c-d5e4-4f3f-a661-a322f90debc6
-    method: GET
-  response:
-    body: '{"created_at":"2023-07-28T14:25:47.831135Z","dhcp_enabled":true,"id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-07-28T14:25:47.831135Z","id":"0bff6f6c-3aa8-498c-a249-531d7a31abd3","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:54.694092Z"},{"created_at":"2023-07-28T14:25:47.831135Z","id":"4e4340a9-f40c-4e0c-b57e-3740ef5216bc","subnet":"fd46:78ab:30b8:9a8a::/64","updated_at":"2023-07-28T14:25:54.694092Z"}],"tags":[],"updated_at":"2023-07-28T14:27:00.075992Z","vpc_id":"41149703-b548-4fe4-9b47-0ff7587a941a"}'
+    body: '{"created_at":"2023-10-20T14:14:22.245911Z","dhcp_enabled":true,"id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T14:14:22.245911Z","id":"c0296ded-0a66-4433-a721-f673df956b04","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:28.828429Z"},{"created_at":"2023-10-20T14:14:22.245911Z","id":"ebebdf6b-cab1-4e79-a6e5-e269e008ab01","subnet":"fd5f:519c:6d46:bb1a::/64","updated_at":"2023-10-20T14:14:28.831803Z"}],"tags":[],"updated_at":"2023-10-20T14:14:31.637798Z","vpc_id":"cb875747-553b-4b6e-b685-3443026330ec"}'
     headers:
       Content-Length:
       - "763"
@@ -2637,7 +1633,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:21 GMT
+      - Fri, 20 Oct 2023 14:15:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2647,7 +1643,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68946b2c-86d7-4528-90ae-f29fb079aaf6
+      - 06e6d392-678c-461c-9ad5-adbd2c1e561b
     status: 200 OK
     code: 200
     duration: ""
@@ -2656,21 +1652,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/c2996cf0-0773-499a-bbb5-ff3baf57cbe5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1a2e3870-ac79-4336-a5c8-85d537c55814
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-28T14:25:49.111949Z","gateway_networks":[{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":"02:00:00:13:7F:85","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"ready","updated_at":"2023-07-28T14:27:00.409313Z","zone":"fr-par-1"}],"id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","ip":{"address":"163.172.141.116","created_at":"2023-07-28T14:25:48.490480Z","gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"c0909cd1-e99f-4def-8bd0-34bdd90a95c3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"116-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-28T14:25:48.490480Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-28T14:27:00.559840Z","upstream_dns_servers":[],"version":"0.5.4","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:14:23.136875Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:14:29.769171Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"0460288e-1696-4f33-ad3a-75e364a948d4","ipam_config":null,"mac_address":"02:00:00:14:57:C5","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","status":"ready","updated_at":"2023-10-20T14:14:32.032283Z","zone":"fr-par-1"}],"id":"1a2e3870-ac79-4336-a5c8-85d537c55814","ip":{"address":"163.172.151.40","created_at":"2023-10-20T14:14:22.812784Z","gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"40-151-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:14:22.812784Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:14:32.158729Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1930"
+      - "1966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:21 GMT
+      - Fri, 20 Oct 2023 14:15:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2680,7 +1676,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b030ff1-cc0e-4680-b80b-a04264ce27b6
+      - a8f28418-1c0c-4a8a-b1a5-5d2b79d27286
     status: 200 OK
     code: 200
     duration: ""
@@ -2689,21 +1685,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0460288e-1696-4f33-ad3a-75e364a948d4
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":"02:00:00:13:7F:85","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"ready","updated_at":"2023-07-28T14:27:00.409313Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:14:29.769171Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"0460288e-1696-4f33-ad3a-75e364a948d4","ipam_config":null,"mac_address":"02:00:00:14:57:C5","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","status":"ready","updated_at":"2023-10-20T14:14:32.032283Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "976"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:21 GMT
+      - Fri, 20 Oct 2023 14:15:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2713,7 +1709,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 389889fd-2db3-4a19-a2d1-197481500fda
+      - 5bc91ab7-7c93-45bc-bfd8-5ec9bef00416
     status: 200 OK
     code: 200
     duration: ""
@@ -2722,27 +1718,60 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1a2e3870-ac79-4336-a5c8-85d537c55814
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:14:23.136875Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:14:29.769171Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"0460288e-1696-4f33-ad3a-75e364a948d4","ipam_config":null,"mac_address":"02:00:00:14:57:C5","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","status":"ready","updated_at":"2023-10-20T14:14:32.032283Z","zone":"fr-par-1"}],"id":"1a2e3870-ac79-4336-a5c8-85d537c55814","ip":{"address":"163.172.151.40","created_at":"2023-10-20T14:14:22.812784Z","gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"40-151-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:14:22.812784Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:14:32.158729Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1966"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:15:20 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bfa2fb83-298e-4192-bfc9-ff254fd64ab9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"502","node_id":"29","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:26:41.234370+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.74.98.57","private_nics":[{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:27:16.866249+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"204","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:14:44.602659+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.76.78.37","private_nics":[{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:15:18.863566+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3148"
+      - "3168"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:21 GMT
+      - Fri, 20 Oct 2023 14:15:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2752,7 +1781,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1b981f3-764c-4349-b421-d5181d4d0cae
+      - 789af50c-4758-4267-a1ba-9203f0551bca
     status: 200 OK
     code: 200
     duration: ""
@@ -2761,21 +1790,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/c2996cf0-0773-499a-bbb5-ff3baf57cbe5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0460288e-1696-4f33-ad3a-75e364a948d4
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-28T14:25:49.111949Z","gateway_networks":[{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":"02:00:00:13:7F:85","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"ready","updated_at":"2023-07-28T14:27:00.409313Z","zone":"fr-par-1"}],"id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","ip":{"address":"163.172.141.116","created_at":"2023-07-28T14:25:48.490480Z","gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"c0909cd1-e99f-4def-8bd0-34bdd90a95c3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"116-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-28T14:25:48.490480Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-28T14:27:00.559840Z","upstream_dns_servers":[],"version":"0.5.4","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:14:29.769171Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"0460288e-1696-4f33-ad3a-75e364a948d4","ipam_config":null,"mac_address":"02:00:00:14:57:C5","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","status":"ready","updated_at":"2023-10-20T14:14:32.032283Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1930"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:21 GMT
+      - Fri, 20 Oct 2023 14:15:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2785,7 +1814,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62290cac-eb1b-4a68-983b-7ff06333b519
+      - 302b6d64-c73a-42d1-922a-dca144b8aebc
     status: 200 OK
     code: 200
     duration: ""
@@ -2794,9 +1823,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2808,7 +1837,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:21 GMT
+      - Fri, 20 Oct 2023 14:15:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2818,7 +1847,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5782b6b4-bb3c-4048-8a01-e0d3ccd45530
+      - 4a39a11d-9608-4b4b-806f-192082c1cc34
     status: 200 OK
     code: 200
     duration: ""
@@ -2827,12 +1856,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:27:16.866249+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:15:18.863566+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -2841,9 +1870,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:22 GMT
+      - Fri, 20 Oct 2023 14:15:20 GMT
       Link:
-      - </servers/f45be185-d322-46dc-883f-b995ede84e45/private_nics?page=1&per_page=50&>;
+      - </servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -2854,7 +1883,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9464708d-e4f4-455e-944f-e2a5551cb8d1
+      - 6e095835-1ff4-46d5-a0b6-27d2aee66238
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -2865,21 +1894,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/a5c6f7e8-7d69-42f2-8f77-e92d394818dd
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":"02:00:00:13:7F:85","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"ready","updated_at":"2023-07-28T14:27:00.409313Z","zone":"fr-par-1"}'
+    body: '{"address":"163.172.151.40","created_at":"2023-10-20T14:14:22.812784Z","gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"40-151-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:14:22.812784Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "976"
+      - "403"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:22 GMT
+      - Fri, 20 Oct 2023 14:15:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2889,7 +1918,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2268c89a-3fbc-461c-a6c6-401627ce3bbc
+      - 5dca63cd-f2a5-4450-9170-7fd68d23f13b
     status: 200 OK
     code: 200
     duration: ""
@@ -2898,210 +1927,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=ad5c6f18-aec9-4e38-9373-7fcc60b4205d&mac_address=02%3A00%3A00%3A13%3A7f%3A86&order_by=created_at_asc&type=unknown
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/ed17287e-2e94-4739-a493-5cfc6f7ad4dd
     method: GET
   response:
-    body: '{"dhcp_entries":[{"created_at":"2023-07-28T14:27:02.045881Z","gateway_network_id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","hostname":"tf-srv-boring-goldwasser","id":"58cd314b-23d8-4002-9ef7-9d292ef5f261","ip_address":"192.168.1.2","mac_address":"02:00:00:13:7f:86","type":"lease","updated_at":"2023-07-28T14:27:17.792600Z","zone":"fr-par-1"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "367"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4bbc32eb-0079-49f5-a0b4-4c770d185461
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/58cd314b-23d8-4002-9ef7-9d292ef5f261
-    method: GET
-  response:
-    body: '{"created_at":"2023-07-28T14:27:02.045881Z","gateway_network_id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","hostname":"tf-srv-boring-goldwasser","id":"58cd314b-23d8-4002-9ef7-9d292ef5f261","ip_address":"192.168.1.2","mac_address":"02:00:00:13:7f:86","type":"lease","updated_at":"2023-07-28T14:27:17.792600Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "331"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 635ee50d-ee9e-4bba-8b13-62d89892de90
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=ad5c6f18-aec9-4e38-9373-7fcc60b4205d&mac_address=02%3A00%3A00%3A13%3A7f%3A86&order_by=created_at_asc&type=unknown
-    method: GET
-  response:
-    body: '{"dhcp_entries":[{"created_at":"2023-07-28T14:27:02.045881Z","gateway_network_id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","hostname":"tf-srv-boring-goldwasser","id":"58cd314b-23d8-4002-9ef7-9d292ef5f261","ip_address":"192.168.1.2","mac_address":"02:00:00:13:7f:86","type":"lease","updated_at":"2023-07-28T14:27:17.792600Z","zone":"fr-par-1"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "367"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2440ef83-f1f0-45a5-8ee4-278e48735d12
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/58cd314b-23d8-4002-9ef7-9d292ef5f261
-    method: GET
-  response:
-    body: '{"created_at":"2023-07-28T14:27:02.045881Z","gateway_network_id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","hostname":"tf-srv-boring-goldwasser","id":"58cd314b-23d8-4002-9ef7-9d292ef5f261","ip_address":"192.168.1.2","mac_address":"02:00:00:13:7f:86","type":"lease","updated_at":"2023-07-28T14:27:17.792600Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "331"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 824653d6-ea87-4750-aff2-ec4102d141fd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=ad5c6f18-aec9-4e38-9373-7fcc60b4205d&mac_address=02%3A00%3A00%3A13%3A7f%3A86&order_by=created_at_asc&type=unknown
-    method: GET
-  response:
-    body: '{"dhcp_entries":[{"created_at":"2023-07-28T14:27:02.045881Z","gateway_network_id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","hostname":"tf-srv-boring-goldwasser","id":"58cd314b-23d8-4002-9ef7-9d292ef5f261","ip_address":"192.168.1.2","mac_address":"02:00:00:13:7f:86","type":"lease","updated_at":"2023-07-28T14:27:17.792600Z","zone":"fr-par-1"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "367"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 343e693e-83e6-407c-9072-3cccd4e6e4c6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/58cd314b-23d8-4002-9ef7-9d292ef5f261
-    method: GET
-  response:
-    body: '{"created_at":"2023-07-28T14:27:02.045881Z","gateway_network_id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","hostname":"tf-srv-boring-goldwasser","id":"58cd314b-23d8-4002-9ef7-9d292ef5f261","ip_address":"192.168.1.2","mac_address":"02:00:00:13:7f:86","type":"lease","updated_at":"2023-07-28T14:27:17.792600Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "331"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c12b405d-90e9-429f-bf26-ccd2276af3f3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/3465ffb2-22aa-4afb-8684-f08ec4302bc3
-    method: GET
-  response:
-    body: '{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "586"
@@ -3110,7 +1941,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:23 GMT
+      - Fri, 20 Oct 2023 14:15:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3120,7 +1951,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 422592ed-9092-45b5-9103-36d9a8380285
+      - baafd9d2-3cf5-4367-b52a-78a64f137e9a
     status: 200 OK
     code: 200
     duration: ""
@@ -3129,45 +1960,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/c0909cd1-e99f-4def-8bd0-34bdd90a95c3
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/17818dee-ef3c-4c6a-b5a4-d701ee98d1e5
     method: GET
   response:
-    body: '{"address":"163.172.141.116","created_at":"2023-07-28T14:25:48.490480Z","gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"c0909cd1-e99f-4def-8bd0-34bdd90a95c3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"116-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-28T14:25:48.490480Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "405"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 21fb0b18-0555-4c3a-8ff2-0f76b45d32bb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bb06b91c-d5e4-4f3f-a661-a322f90debc6
-    method: GET
-  response:
-    body: '{"created_at":"2023-07-28T14:25:47.831135Z","dhcp_enabled":true,"id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-07-28T14:25:47.831135Z","id":"0bff6f6c-3aa8-498c-a249-531d7a31abd3","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:54.694092Z"},{"created_at":"2023-07-28T14:25:47.831135Z","id":"4e4340a9-f40c-4e0c-b57e-3740ef5216bc","subnet":"fd46:78ab:30b8:9a8a::/64","updated_at":"2023-07-28T14:25:54.694092Z"}],"tags":[],"updated_at":"2023-07-28T14:27:00.075992Z","vpc_id":"41149703-b548-4fe4-9b47-0ff7587a941a"}'
+    body: '{"created_at":"2023-10-20T14:14:22.245911Z","dhcp_enabled":true,"id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T14:14:22.245911Z","id":"c0296ded-0a66-4433-a721-f673df956b04","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:28.828429Z"},{"created_at":"2023-10-20T14:14:22.245911Z","id":"ebebdf6b-cab1-4e79-a6e5-e269e008ab01","subnet":"fd5f:519c:6d46:bb1a::/64","updated_at":"2023-10-20T14:14:28.831803Z"}],"tags":[],"updated_at":"2023-10-20T14:14:31.637798Z","vpc_id":"cb875747-553b-4b6e-b685-3443026330ec"}'
     headers:
       Content-Length:
       - "763"
@@ -3176,7 +1974,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:23 GMT
+      - Fri, 20 Oct 2023 14:15:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3186,7 +1984,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 396b14e9-d71a-4df2-ab21-d9b5517547f7
+      - e7ef3533-94da-4e89-bb4d-192333411b9b
     status: 200 OK
     code: 200
     duration: ""
@@ -3195,21 +1993,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/c2996cf0-0773-499a-bbb5-ff3baf57cbe5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1a2e3870-ac79-4336-a5c8-85d537c55814
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-28T14:25:49.111949Z","gateway_networks":[{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":"02:00:00:13:7F:85","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"ready","updated_at":"2023-07-28T14:27:00.409313Z","zone":"fr-par-1"}],"id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","ip":{"address":"163.172.141.116","created_at":"2023-07-28T14:25:48.490480Z","gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"c0909cd1-e99f-4def-8bd0-34bdd90a95c3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"116-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-28T14:25:48.490480Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-28T14:27:00.559840Z","upstream_dns_servers":[],"version":"0.5.4","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:14:23.136875Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:14:29.769171Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"0460288e-1696-4f33-ad3a-75e364a948d4","ipam_config":null,"mac_address":"02:00:00:14:57:C5","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","status":"ready","updated_at":"2023-10-20T14:14:32.032283Z","zone":"fr-par-1"}],"id":"1a2e3870-ac79-4336-a5c8-85d537c55814","ip":{"address":"163.172.151.40","created_at":"2023-10-20T14:14:22.812784Z","gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"40-151-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:14:22.812784Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:14:32.158729Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1930"
+      - "1966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:23 GMT
+      - Fri, 20 Oct 2023 14:15:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3219,7 +2017,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87ef5cac-25db-44fe-9052-3aa5d8dc10c8
+      - 39edae69-da8f-483b-bd26-a324b698f20e
     status: 200 OK
     code: 200
     duration: ""
@@ -3228,21 +2026,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0460288e-1696-4f33-ad3a-75e364a948d4
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":"02:00:00:13:7F:85","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"ready","updated_at":"2023-07-28T14:27:00.409313Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:14:29.769171Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"0460288e-1696-4f33-ad3a-75e364a948d4","ipam_config":null,"mac_address":"02:00:00:14:57:C5","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","status":"ready","updated_at":"2023-10-20T14:14:32.032283Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "976"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:23 GMT
+      - Fri, 20 Oct 2023 14:15:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3252,7 +2050,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bce88819-660c-4d58-b6a5-aa57a47aa6ce
+      - cac07261-6715-48de-8ac2-9573965e5441
     status: 200 OK
     code: 200
     duration: ""
@@ -3261,27 +2059,93 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1a2e3870-ac79-4336-a5c8-85d537c55814
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:14:23.136875Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:14:29.769171Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"0460288e-1696-4f33-ad3a-75e364a948d4","ipam_config":null,"mac_address":"02:00:00:14:57:C5","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","status":"ready","updated_at":"2023-10-20T14:14:32.032283Z","zone":"fr-par-1"}],"id":"1a2e3870-ac79-4336-a5c8-85d537c55814","ip":{"address":"163.172.151.40","created_at":"2023-10-20T14:14:22.812784Z","gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"40-151-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:14:22.812784Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:14:32.158729Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1966"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:15:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 71aca894-ae37-45b1-86fd-58e9dfbf2c3c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0460288e-1696-4f33-ad3a-75e364a948d4
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-20T14:14:29.769171Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"0460288e-1696-4f33-ad3a-75e364a948d4","ipam_config":null,"mac_address":"02:00:00:14:57:C5","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","status":"ready","updated_at":"2023-10-20T14:14:32.032283Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:15:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8367b2bf-e1de-4783-b360-62755e665ed0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"502","node_id":"29","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:26:41.234370+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.74.98.57","private_nics":[{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:27:16.866249+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"204","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:14:44.602659+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.76.78.37","private_nics":[{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:15:18.863566+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3148"
+      - "3168"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:23 GMT
+      - Fri, 20 Oct 2023 14:15:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3291,7 +2155,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b193ca1-4329-42c7-8ebe-aa1592acda03
+      - 9a7eeed7-400b-4b22-ae69-db7de108248a
     status: 200 OK
     code: 200
     duration: ""
@@ -3300,42 +2164,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/c2996cf0-0773-499a-bbb5-ff3baf57cbe5
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-28T14:25:49.111949Z","gateway_networks":[{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":"02:00:00:13:7F:85","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"ready","updated_at":"2023-07-28T14:27:00.409313Z","zone":"fr-par-1"}],"id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","ip":{"address":"163.172.141.116","created_at":"2023-07-28T14:25:48.490480Z","gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"c0909cd1-e99f-4def-8bd0-34bdd90a95c3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"116-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-28T14:25:48.490480Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-28T14:27:00.559840Z","upstream_dns_servers":[],"version":"0.5.4","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1930"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 14:27:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5f55cb48-739e-4138-beeb-6155c35020d9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -3347,7 +2178,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:24 GMT
+      - Fri, 20 Oct 2023 14:15:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3357,7 +2188,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9613ec55-a896-450e-b4f6-82734bc2a49d
+      - 8936b4b8-2366-4bf5-ab3f-7eeaa285fa87
     status: 200 OK
     code: 200
     duration: ""
@@ -3366,12 +2197,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:27:16.866249+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:15:18.863566+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -3380,9 +2211,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:24 GMT
+      - Fri, 20 Oct 2023 14:15:21 GMT
       Link:
-      - </servers/f45be185-d322-46dc-883f-b995ede84e45/private_nics?page=1&per_page=50&>;
+      - </servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -3393,7 +2224,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c53df81-ea49-43d5-919b-7a1f67d35100
+      - b140593d-2187-4561-b495-8d9826057b4f
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -3404,21 +2235,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=0460288e-1696-4f33-ad3a-75e364a948d4&mac_address=02%3A00%3A00%3A14%3A57%3Ac8&order_by=created_at_asc&type=unknown
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":"02:00:00:13:7F:85","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"ready","updated_at":"2023-07-28T14:27:00.409313Z","zone":"fr-par-1"}'
+    body: '{"dhcp_entries":[{"created_at":"2023-10-20T14:14:48.093471Z","gateway_network_id":"0460288e-1696-4f33-ad3a-75e364a948d4","hostname":"tf-srv-friendly-jennings","id":"45d937f2-80a4-4055-ba94-617a8d8810bb","ip_address":"192.168.1.2","mac_address":"02:00:00:14:57:c8","type":"reservation","updated_at":"2023-10-20T14:14:48.093471Z","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
-      - "976"
+      - "373"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:24 GMT
+      - Fri, 20 Oct 2023 14:15:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3428,7 +2259,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f073b8c5-07f9-480a-864b-37736a8f645c
+      - 6fd70224-2058-46a6-8f63-ba6162618b6d
     status: 200 OK
     code: 200
     duration: ""
@@ -3437,21 +2268,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=ad5c6f18-aec9-4e38-9373-7fcc60b4205d&mac_address=02%3A00%3A00%3A13%3A7f%3A86&order_by=created_at_asc&type=unknown
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/45d937f2-80a4-4055-ba94-617a8d8810bb
     method: GET
   response:
-    body: '{"dhcp_entries":[{"created_at":"2023-07-28T14:27:02.045881Z","gateway_network_id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","hostname":"tf-srv-boring-goldwasser","id":"58cd314b-23d8-4002-9ef7-9d292ef5f261","ip_address":"192.168.1.2","mac_address":"02:00:00:13:7f:86","type":"lease","updated_at":"2023-07-28T14:27:17.792600Z","zone":"fr-par-1"}],"total_count":1}'
+    body: '{"created_at":"2023-10-20T14:14:48.093471Z","gateway_network_id":"0460288e-1696-4f33-ad3a-75e364a948d4","hostname":"tf-srv-friendly-jennings","id":"45d937f2-80a4-4055-ba94-617a8d8810bb","ip_address":"192.168.1.2","mac_address":"02:00:00:14:57:c8","type":"reservation","updated_at":"2023-10-20T14:14:48.093471Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "367"
+      - "337"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:24 GMT
+      - Fri, 20 Oct 2023 14:15:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3461,7 +2292,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d10daa43-d11f-4b48-ae55-a7fe63d25ff5
+      - e9b1328b-54d8-42f9-a1b4-fe642a113d41
     status: 200 OK
     code: 200
     duration: ""
@@ -3470,21 +2301,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/58cd314b-23d8-4002-9ef7-9d292ef5f261
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=0460288e-1696-4f33-ad3a-75e364a948d4&mac_address=02%3A00%3A00%3A14%3A57%3Ac8&order_by=created_at_asc&type=unknown
     method: GET
   response:
-    body: '{"created_at":"2023-07-28T14:27:02.045881Z","gateway_network_id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","hostname":"tf-srv-boring-goldwasser","id":"58cd314b-23d8-4002-9ef7-9d292ef5f261","ip_address":"192.168.1.2","mac_address":"02:00:00:13:7f:86","type":"lease","updated_at":"2023-07-28T14:27:17.792600Z","zone":"fr-par-1"}'
+    body: '{"dhcp_entries":[{"created_at":"2023-10-20T14:14:48.093471Z","gateway_network_id":"0460288e-1696-4f33-ad3a-75e364a948d4","hostname":"tf-srv-friendly-jennings","id":"45d937f2-80a4-4055-ba94-617a8d8810bb","ip_address":"192.168.1.2","mac_address":"02:00:00:14:57:c8","type":"reservation","updated_at":"2023-10-20T14:14:48.093471Z","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
-      - "331"
+      - "373"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:24 GMT
+      - Fri, 20 Oct 2023 14:15:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3494,7 +2325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d43ba0bd-41ed-4bf9-881b-360ca233100c
+      - eb019fb1-9395-4497-aa0e-661c4115c9ed
     status: 200 OK
     code: 200
     duration: ""
@@ -3503,21 +2334,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=ad5c6f18-aec9-4e38-9373-7fcc60b4205d&mac_address=02%3A00%3A00%3A13%3A7f%3A86&order_by=created_at_asc&type=unknown
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/45d937f2-80a4-4055-ba94-617a8d8810bb
     method: GET
   response:
-    body: '{"dhcp_entries":[{"created_at":"2023-07-28T14:27:02.045881Z","gateway_network_id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","hostname":"tf-srv-boring-goldwasser","id":"58cd314b-23d8-4002-9ef7-9d292ef5f261","ip_address":"192.168.1.2","mac_address":"02:00:00:13:7f:86","type":"lease","updated_at":"2023-07-28T14:27:17.792600Z","zone":"fr-par-1"}],"total_count":1}'
+    body: '{"created_at":"2023-10-20T14:14:48.093471Z","gateway_network_id":"0460288e-1696-4f33-ad3a-75e364a948d4","hostname":"tf-srv-friendly-jennings","id":"45d937f2-80a4-4055-ba94-617a8d8810bb","ip_address":"192.168.1.2","mac_address":"02:00:00:14:57:c8","type":"reservation","updated_at":"2023-10-20T14:14:48.093471Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "367"
+      - "337"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:24 GMT
+      - Fri, 20 Oct 2023 14:15:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3527,7 +2358,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b011fb7-ecfe-44cc-becb-e82ac5880d3b
+      - 49aa2269-ffed-496d-b8ef-c86046721ea9
     status: 200 OK
     code: 200
     duration: ""
@@ -3536,21 +2367,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/58cd314b-23d8-4002-9ef7-9d292ef5f261
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=0460288e-1696-4f33-ad3a-75e364a948d4&mac_address=02%3A00%3A00%3A14%3A57%3Ac8&order_by=created_at_asc&type=unknown
     method: GET
   response:
-    body: '{"created_at":"2023-07-28T14:27:02.045881Z","gateway_network_id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","hostname":"tf-srv-boring-goldwasser","id":"58cd314b-23d8-4002-9ef7-9d292ef5f261","ip_address":"192.168.1.2","mac_address":"02:00:00:13:7f:86","type":"lease","updated_at":"2023-07-28T14:27:17.792600Z","zone":"fr-par-1"}'
+    body: '{"dhcp_entries":[{"created_at":"2023-10-20T14:14:48.093471Z","gateway_network_id":"0460288e-1696-4f33-ad3a-75e364a948d4","hostname":"tf-srv-friendly-jennings","id":"45d937f2-80a4-4055-ba94-617a8d8810bb","ip_address":"192.168.1.2","mac_address":"02:00:00:14:57:c8","type":"reservation","updated_at":"2023-10-20T14:14:48.093471Z","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
-      - "331"
+      - "373"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:24 GMT
+      - Fri, 20 Oct 2023 14:15:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3560,7 +2391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0f2e6e2-c3fc-4bbd-8ec8-99ed43cf4593
+      - 02c35500-7948-43d3-ba5a-e057f67b5e57
     status: 200 OK
     code: 200
     duration: ""
@@ -3569,21 +2400,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/45d937f2-80a4-4055-ba94-617a8d8810bb
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":"02:00:00:13:7F:85","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"ready","updated_at":"2023-07-28T14:27:00.409313Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T14:14:48.093471Z","gateway_network_id":"0460288e-1696-4f33-ad3a-75e364a948d4","hostname":"tf-srv-friendly-jennings","id":"45d937f2-80a4-4055-ba94-617a8d8810bb","ip_address":"192.168.1.2","mac_address":"02:00:00:14:57:c8","type":"reservation","updated_at":"2023-10-20T14:14:48.093471Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "976"
+      - "337"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:25 GMT
+      - Fri, 20 Oct 2023 14:15:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3593,7 +2424,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8abdd68-7b9c-4ff4-805d-a33c8c91d45c
+      - ca9d6f8d-3176-4a26-9c1c-9279a24bac5a
     status: 200 OK
     code: 200
     duration: ""
@@ -3602,27 +2433,258 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/a5c6f7e8-7d69-42f2-8f77-e92d394818dd
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"address":"163.172.151.40","created_at":"2023-10-20T14:14:22.812784Z","gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"40-151-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:14:22.812784Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "403"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:15:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c036d828-ef44-44f6-a706-2e64f7ad39cb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/ed17287e-2e94-4739-a493-5cfc6f7ad4dd
+    method: GET
+  response:
+    body: '{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "586"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:15:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4874bc1b-9ff4-4943-a37a-b3a3daa77fbc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/17818dee-ef3c-4c6a-b5a4-d701ee98d1e5
+    method: GET
+  response:
+    body: '{"created_at":"2023-10-20T14:14:22.245911Z","dhcp_enabled":true,"id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T14:14:22.245911Z","id":"c0296ded-0a66-4433-a721-f673df956b04","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:28.828429Z"},{"created_at":"2023-10-20T14:14:22.245911Z","id":"ebebdf6b-cab1-4e79-a6e5-e269e008ab01","subnet":"fd5f:519c:6d46:bb1a::/64","updated_at":"2023-10-20T14:14:28.831803Z"}],"tags":[],"updated_at":"2023-10-20T14:14:31.637798Z","vpc_id":"cb875747-553b-4b6e-b685-3443026330ec"}'
+    headers:
+      Content-Length:
+      - "763"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:15:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 21ae748a-8417-4026-a88d-055bcbfeb801
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1a2e3870-ac79-4336-a5c8-85d537c55814
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:14:23.136875Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:14:29.769171Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"0460288e-1696-4f33-ad3a-75e364a948d4","ipam_config":null,"mac_address":"02:00:00:14:57:C5","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","status":"ready","updated_at":"2023-10-20T14:14:32.032283Z","zone":"fr-par-1"}],"id":"1a2e3870-ac79-4336-a5c8-85d537c55814","ip":{"address":"163.172.151.40","created_at":"2023-10-20T14:14:22.812784Z","gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"40-151-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:14:22.812784Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:14:32.158729Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1966"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:15:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3d0f4a04-50b9-4d33-bd67-f149b101eb92
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0460288e-1696-4f33-ad3a-75e364a948d4
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-20T14:14:29.769171Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"0460288e-1696-4f33-ad3a-75e364a948d4","ipam_config":null,"mac_address":"02:00:00:14:57:C5","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","status":"ready","updated_at":"2023-10-20T14:14:32.032283Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:15:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d0dc4127-9075-4df9-8ce5-70aec6b8ad67
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1a2e3870-ac79-4336-a5c8-85d537c55814
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:14:23.136875Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:14:29.769171Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"0460288e-1696-4f33-ad3a-75e364a948d4","ipam_config":null,"mac_address":"02:00:00:14:57:C5","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","status":"ready","updated_at":"2023-10-20T14:14:32.032283Z","zone":"fr-par-1"}],"id":"1a2e3870-ac79-4336-a5c8-85d537c55814","ip":{"address":"163.172.151.40","created_at":"2023-10-20T14:14:22.812784Z","gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"40-151-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:14:22.812784Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:14:32.158729Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1966"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:15:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - aea67b01-b46d-4dad-8232-f938af0fd309
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0460288e-1696-4f33-ad3a-75e364a948d4
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-20T14:14:29.769171Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"0460288e-1696-4f33-ad3a-75e364a948d4","ipam_config":null,"mac_address":"02:00:00:14:57:C5","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","status":"ready","updated_at":"2023-10-20T14:14:32.032283Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:15:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7f425af9-4558-4b30-af96-9fbdc2fb07ca
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"502","node_id":"29","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:26:41.234370+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.74.98.57","private_nics":[{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:27:16.866249+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"204","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:14:44.602659+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.76.78.37","private_nics":[{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:15:18.863566+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3148"
+      - "3168"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:25 GMT
+      - Fri, 20 Oct 2023 14:15:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3632,7 +2694,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a90612b-cd99-431b-8406-78e52e595256
+      - ec6ecad1-ee9f-44fc-ac2d-24e5d44234bd
     status: 200 OK
     code: 200
     duration: ""
@@ -3641,9 +2703,284 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d?cleanup_dhcp=true
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/user_data
+    method: GET
+  response:
+    body: '{"user_data":[]}'
+    headers:
+      Content-Length:
+      - "17"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:15:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 60cb1dbd-14a8-4e5e-b300-a85db506af25
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics
+    method: GET
+  response:
+    body: '{"private_nics":[{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:15:18.863566+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:15:23 GMT
+      Link:
+      - </servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics?page=1&per_page=50&>;
+        rel="last"
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f9fc80f9-5082-40a7-bac2-a9a1a44c96f4
+      X-Total-Count:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=0460288e-1696-4f33-ad3a-75e364a948d4&mac_address=02%3A00%3A00%3A14%3A57%3Ac8&order_by=created_at_asc&type=unknown
+    method: GET
+  response:
+    body: '{"dhcp_entries":[{"created_at":"2023-10-20T14:14:48.093471Z","gateway_network_id":"0460288e-1696-4f33-ad3a-75e364a948d4","hostname":"tf-srv-friendly-jennings","id":"45d937f2-80a4-4055-ba94-617a8d8810bb","ip_address":"192.168.1.2","mac_address":"02:00:00:14:57:c8","type":"reservation","updated_at":"2023-10-20T14:14:48.093471Z","zone":"fr-par-1"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "373"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:15:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b545312f-7b98-4442-8824-e68b96250ac6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/45d937f2-80a4-4055-ba94-617a8d8810bb
+    method: GET
+  response:
+    body: '{"created_at":"2023-10-20T14:14:48.093471Z","gateway_network_id":"0460288e-1696-4f33-ad3a-75e364a948d4","hostname":"tf-srv-friendly-jennings","id":"45d937f2-80a4-4055-ba94-617a8d8810bb","ip_address":"192.168.1.2","mac_address":"02:00:00:14:57:c8","type":"reservation","updated_at":"2023-10-20T14:14:48.093471Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "337"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:15:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1adb8486-4742-458b-8993-6fe9f298e7ed
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=0460288e-1696-4f33-ad3a-75e364a948d4&mac_address=02%3A00%3A00%3A14%3A57%3Ac8&order_by=created_at_asc&type=unknown
+    method: GET
+  response:
+    body: '{"dhcp_entries":[{"created_at":"2023-10-20T14:14:48.093471Z","gateway_network_id":"0460288e-1696-4f33-ad3a-75e364a948d4","hostname":"tf-srv-friendly-jennings","id":"45d937f2-80a4-4055-ba94-617a8d8810bb","ip_address":"192.168.1.2","mac_address":"02:00:00:14:57:c8","type":"reservation","updated_at":"2023-10-20T14:14:48.093471Z","zone":"fr-par-1"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "373"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:15:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a3769f6d-9e69-4651-b89d-f714f82e2dc7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/45d937f2-80a4-4055-ba94-617a8d8810bb
+    method: GET
+  response:
+    body: '{"created_at":"2023-10-20T14:14:48.093471Z","gateway_network_id":"0460288e-1696-4f33-ad3a-75e364a948d4","hostname":"tf-srv-friendly-jennings","id":"45d937f2-80a4-4055-ba94-617a8d8810bb","ip_address":"192.168.1.2","mac_address":"02:00:00:14:57:c8","type":"reservation","updated_at":"2023-10-20T14:14:48.093471Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "337"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:15:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c53adf1e-1fcd-4f6d-b622-0e938bb499a4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0460288e-1696-4f33-ad3a-75e364a948d4
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-20T14:14:29.769171Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"0460288e-1696-4f33-ad3a-75e364a948d4","ipam_config":null,"mac_address":"02:00:00:14:57:C5","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","status":"ready","updated_at":"2023-10-20T14:14:32.032283Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:15:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 825e5ac5-a711-47a1-baa5-4e97efa46916
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"204","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:14:44.602659+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.76.78.37","private_nics":[{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:15:18.863566+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3168"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:15:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 51083f36-4717-473d-af26-36abc1c87e4a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0460288e-1696-4f33-ad3a-75e364a948d4?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -3653,7 +2990,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:25 GMT
+      - Fri, 20 Oct 2023 14:15:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3663,7 +3000,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0aae760a-6b8e-4177-ad14-37f354e6fd47
+      - aa3533c3-7296-4864-8445-011c473dfcfa
     status: 204 No Content
     code: 204
     duration: ""
@@ -3672,21 +3009,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0460288e-1696-4f33-ad3a-75e364a948d4
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-28T14:25:56.826819Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-28T14:25:47.830446Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-28T14:25:47.830446Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","mac_address":"02:00:00:13:7F:85","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","status":"detaching","updated_at":"2023-07-28T14:27:25.528396Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:14:29.769171Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:14:22.247261Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:14:22.247261Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"0460288e-1696-4f33-ad3a-75e364a948d4","ipam_config":null,"mac_address":"02:00:00:14:57:C5","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","status":"detaching","updated_at":"2023-10-20T14:15:25.175011Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "980"
+      - "1000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:25 GMT
+      - Fri, 20 Oct 2023 14:15:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3696,7 +3033,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bfd7e2f-3271-4f4c-995d-7fa05ca84431
+      - cc599216-bcb0-403a-b8c3-6ca7044b4037
     status: 200 OK
     code: 200
     duration: ""
@@ -3707,12 +3044,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/f45be185-d322-46dc-883f-b995ede84e45/action","href_result":"/servers/f45be185-d322-46dc-883f-b995ede84e45","id":"b15e247e-0c81-46e7-b2da-4f7a7328f614","started_at":"2023-07-28T14:27:25.848759+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/action","href_result":"/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79","id":"6c5b4acb-0af6-45b8-b3be-0eaf97bff009","started_at":"2023-10-20T14:15:25.472567+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -3721,9 +3058,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:25 GMT
+      - Fri, 20 Oct 2023 14:15:25 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/b15e247e-0c81-46e7-b2da-4f7a7328f614
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/6c5b4acb-0af6-45b8-b3be-0eaf97bff009
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3733,7 +3070,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 480056eb-5d9c-441c-b105-0883cd445aa6
+      - fc924429-8ca1-4c47-8412-6800ebeae940
     status: 202 Accepted
     code: 202
     duration: ""
@@ -3742,27 +3079,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"502","node_id":"29","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:27:25.543489+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.74.98.57","private_nics":[{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:27:16.866249+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"204","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:15:25.171456+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.76.78.37","private_nics":[{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:15:18.863566+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3116"
+      - "3136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:26 GMT
+      - Fri, 20 Oct 2023 14:15:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3772,7 +3109,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56c6845d-b122-4218-beca-41996d78a074
+      - f385859a-8c22-49b4-9a86-53d0ab39bd0d
     status: 200 OK
     code: 200
     duration: ""
@@ -3781,12 +3118,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ad5c6f18-aec9-4e38-9373-7fcc60b4205d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0460288e-1696-4f33-ad3a-75e364a948d4
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"ad5c6f18-aec9-4e38-9373-7fcc60b4205d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"0460288e-1696-4f33-ad3a-75e364a948d4","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3795,7 +3132,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:30 GMT
+      - Fri, 20 Oct 2023 14:15:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3805,7 +3142,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e42b1f65-5b15-48ec-8bd4-5b3f15c6fbdf
+      - 5e4bed26-3be5-4d5d-a861-edcd1957ee4d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3814,21 +3151,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/c2996cf0-0773-499a-bbb5-ff3baf57cbe5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1a2e3870-ac79-4336-a5c8-85d537c55814
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-28T14:25:49.111949Z","gateway_networks":[],"id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","ip":{"address":"163.172.141.116","created_at":"2023-07-28T14:25:48.490480Z","gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"c0909cd1-e99f-4def-8bd0-34bdd90a95c3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"116-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-28T14:25:48.490480Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-28T14:27:00.559840Z","upstream_dns_servers":[],"version":"0.5.4","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:14:23.136875Z","gateway_networks":[],"id":"1a2e3870-ac79-4336-a5c8-85d537c55814","ip":{"address":"163.172.151.40","created_at":"2023-10-20T14:14:22.812784Z","gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"40-151-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:14:22.812784Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:14:32.158729Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "954"
+      - "970"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:30 GMT
+      - Fri, 20 Oct 2023 14:15:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3838,7 +3175,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3715ee7-5355-4749-9b66-02a8bd21860c
+      - 1e5770bd-3361-45f3-9a12-dbf3283ad934
     status: 200 OK
     code: 200
     duration: ""
@@ -3847,12 +3184,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/3465ffb2-22aa-4afb-8684-f08ec4302bc3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/ed17287e-2e94-4739-a493-5cfc6f7ad4dd
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3861,7 +3198,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:30 GMT
+      - Fri, 20 Oct 2023 14:15:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3871,7 +3208,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe282b22-8471-42de-9978-83fe90533207
+      - 2b6edb1c-0b78-4aee-a7b6-9ff5b8afb495
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3880,21 +3217,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/c2996cf0-0773-499a-bbb5-ff3baf57cbe5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1a2e3870-ac79-4336-a5c8-85d537c55814
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-28T14:25:49.111949Z","gateway_networks":[],"id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","ip":{"address":"163.172.141.116","created_at":"2023-07-28T14:25:48.490480Z","gateway_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","id":"c0909cd1-e99f-4def-8bd0-34bdd90a95c3","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"116-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-28T14:25:48.490480Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-28T14:27:00.559840Z","upstream_dns_servers":[],"version":"0.5.4","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:14:23.136875Z","gateway_networks":[],"id":"1a2e3870-ac79-4336-a5c8-85d537c55814","ip":{"address":"163.172.151.40","created_at":"2023-10-20T14:14:22.812784Z","gateway_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","id":"a5c6f7e8-7d69-42f2-8f77-e92d394818dd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"40-151-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:14:22.812784Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:14:32.158729Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "954"
+      - "970"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:30 GMT
+      - Fri, 20 Oct 2023 14:15:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3904,7 +3241,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1f2b518-cfdd-405e-a4b4-9cde0ac97fae
+      - 074105d0-8646-4e12-91a2-9a0ca71048ba
     status: 200 OK
     code: 200
     duration: ""
@@ -3913,9 +3250,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/c2996cf0-0773-499a-bbb5-ff3baf57cbe5?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1a2e3870-ac79-4336-a5c8-85d537c55814?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -3925,7 +3262,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:30 GMT
+      - Fri, 20 Oct 2023 14:15:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3935,7 +3272,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b3b6052-de6d-4ee7-b8d7-f7b0930e5349
+      - 17dc8754-8f13-4fac-8d80-81d346c73205
     status: 204 No Content
     code: 204
     duration: ""
@@ -3944,12 +3281,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/c2996cf0-0773-499a-bbb5-ff3baf57cbe5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1a2e3870-ac79-4336-a5c8-85d537c55814
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"c2996cf0-0773-499a-bbb5-ff3baf57cbe5","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"1a2e3870-ac79-4336-a5c8-85d537c55814","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3958,7 +3295,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:30 GMT
+      - Fri, 20 Oct 2023 14:15:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3968,7 +3305,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e02a9e0-9091-4d90-92d3-847cc115d437
+      - 9dc84261-a57e-4b90-8b4e-fd9b8ac4cee7
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3977,9 +3314,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/c0909cd1-e99f-4def-8bd0-34bdd90a95c3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/a5c6f7e8-7d69-42f2-8f77-e92d394818dd
     method: DELETE
   response:
     body: ""
@@ -3989,7 +3326,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:31 GMT
+      - Fri, 20 Oct 2023 14:15:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3999,7 +3336,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 667bbd24-3bc2-4b92-afad-468e3b78f8b2
+      - efaab169-e909-4bc6-bd56-24ec337ab111
     status: 204 No Content
     code: 204
     duration: ""
@@ -4008,27 +3345,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"502","node_id":"29","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:27:25.543489+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.74.98.57","private_nics":[{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:27:16.866249+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"204","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:15:25.171456+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.76.78.37","private_nics":[{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:15:18.863566+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3116"
+      - "3136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:31 GMT
+      - Fri, 20 Oct 2023 14:15:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4038,7 +3375,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d85d05b5-2026-4b3f-a2d4-42fa9b6e0916
+      - 704cab4f-81e9-4742-b0fe-c4a6baa12b0c
     status: 200 OK
     code: 200
     duration: ""
@@ -4047,27 +3384,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"502","node_id":"29","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:27:25.543489+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.74.98.57","private_nics":[{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:27:16.866249+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"204","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:15:25.171456+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.76.78.37","private_nics":[{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:15:18.863566+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3116"
+      - "3136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:36 GMT
+      - Fri, 20 Oct 2023 14:15:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4077,7 +3414,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4825e0c-25ff-46fb-be79-7e80ca886bc9
+      - 19246a31-6a1e-4211-b6d6-b85224410d07
     status: 200 OK
     code: 200
     duration: ""
@@ -4086,27 +3423,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"502","node_id":"29","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:27:25.543489+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.74.98.57","private_nics":[{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:27:16.866249+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"204","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:15:25.171456+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.76.78.37","private_nics":[{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:15:18.863566+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3116"
+      - "3136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:42 GMT
+      - Fri, 20 Oct 2023 14:15:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4116,7 +3453,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d41b3b0-712a-4982-b490-6924bbef06ea
+      - f4b26c1e-151f-41d0-9f56-e7fa8850386d
     status: 200 OK
     code: 200
     duration: ""
@@ -4125,27 +3462,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"502","node_id":"29","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:27:25.543489+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.74.98.57","private_nics":[{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:27:16.866249+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"204","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:15:25.171456+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.76.78.37","private_nics":[{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:15:18.863566+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3116"
+      - "3136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:47 GMT
+      - Fri, 20 Oct 2023 14:15:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4155,7 +3492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74f5f27c-a22a-455b-843a-ed7950d1181c
+      - 2101c90d-a2fb-43d9-8c97-857f7020f01a
     status: 200 OK
     code: 200
     duration: ""
@@ -4164,27 +3501,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:27:49.273918+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:27:16.866249+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"204","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:15:25.171456+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.76.78.37","private_nics":[{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:15:18.863566+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2995"
+      - "3136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:52 GMT
+      - Fri, 20 Oct 2023 14:15:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4194,7 +3531,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a79d4a6-866e-494c-b5b4-f19b0852d3eb
+      - 13823408-7a22-4cbb-9164-2d7c6fcedbd2
     status: 200 OK
     code: 200
     duration: ""
@@ -4203,27 +3540,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-28T14:25:50.249884+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-boring-goldwasser","id":"f45be185-d322-46dc-883f-b995ede84e45","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1f:29:ab","maintenances":[],"modification_date":"2023-07-28T14:27:49.273918+00:00","name":"tf-srv-boring-goldwasser","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-07-28T14:26:43.338949+00:00","id":"96213172-56c4-47dd-b73f-b5b7a8c30291","mac_address":"02:00:00:13:7f:86","modification_date":"2023-07-28T14:27:16.866249+00:00","private_network_id":"bb06b91c-d5e4-4f3f-a661-a322f90debc6","server_id":"f45be185-d322-46dc-883f-b995ede84e45","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-28T14:25:50.249884+00:00","export_uri":null,"id":"41221beb-dc86-49ae-9e7f-b7a7ffa4a09c","modification_date":"2023-07-28T14:25:50.249884+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"f45be185-d322-46dc-883f-b995ede84e45","name":"tf-srv-boring-goldwasser"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"204","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:15:25.171456+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.76.78.37","private_nics":[{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:15:18.863566+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2995"
+      - "3136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:52 GMT
+      - Fri, 20 Oct 2023 14:15:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4233,7 +3570,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7253f22f-d23d-4032-b796-6bc18f802e19
+      - e2fe4f9a-6ff4-4268-9a8b-6ddd29b58f55
     status: 200 OK
     code: 200
     duration: ""
@@ -4242,9 +3579,119 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:15:58.517299+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:15:18.863566+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3015"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:16:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 650eda48-bc35-47ed-b1fb-5e0824290af9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics
+    method: GET
+  response:
+    body: '{"private_nics":[{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:15:18.863566+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:16:02 GMT
+      Link:
+      - </servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics?page=1&per_page=50&>;
+        rel="last"
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6d35cfa6-c85a-4ff8-a906-498576cfee2e
+      X-Total-Count:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics/de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20
+    method: GET
+  response:
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:14:47.348863+00:00","id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","mac_address":"02:00:00:14:57:c8","modification_date":"2023-10-20T14:15:18.863566+00:00","private_network_id":"17818dee-ef3c-4c6a-b5a4-d701ee98d1e5","server_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","state":"available","tags":[],"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "378"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:16:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 879039d7-0304-4642-ba8a-db542c98ddc2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics/de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20
     method: DELETE
   response:
     body: ""
@@ -4252,7 +3699,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 28 Jul 2023 14:27:53 GMT
+      - Fri, 20 Oct 2023 14:16:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4262,7 +3709,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27ae012d-4241-42d0-b594-1b6bed6fa981
+      - eefbb63b-1329-44bb-8ee6-a46c371205d6
     status: 204 No Content
     code: 204
     duration: ""
@@ -4271,21 +3718,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f45be185-d322-46dc-883f-b995ede84e45
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79/private_nics/de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20
     method: GET
   response:
-    body: '{"message":"\"f45be185-d322-46dc-883f-b995ede84e45\" not found","type":"unknown_resource"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"de0ac0f5-5c1e-4896-80e6-63ad3e8f6a20","type":"not_found"}'
     headers:
       Content-Length:
-      - "93"
+      - "148"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:53 GMT
+      - Fri, 20 Oct 2023 14:16:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4295,7 +3742,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a93f6a32-9e40-4143-8c2a-0f4a109f5100
+      - e80815da-823a-49ad-b4b2-6c7df431492c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4304,17 +3751,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/41221beb-dc86-49ae-9e7f-b7a7ffa4a09c
-    method: DELETE
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
+    method: GET
   response:
-    body: ""
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:14:24.221137+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-friendly-jennings","id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b1:41","maintenances":[],"modification_date":"2023-10-20T14:15:58.517299+00:00","name":"tf-srv-friendly-jennings","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:14:24.221137+00:00","export_uri":null,"id":"57808eba-a9bf-4a38-b786-ac2cb062e5d6","modification_date":"2023-10-20T14:14:24.221137+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","name":"tf-srv-friendly-jennings"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
+      Content-Length:
+      - "2654"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:53 GMT
+      - Fri, 20 Oct 2023 14:16:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4324,7 +3781,36 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cc86b7c-4284-46e4-ad50-4aef6c9259f2
+      - 003b1255-4f19-4aec-9afd-54b4e18b596d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Fri, 20 Oct 2023 14:16:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 94394dd6-c3e0-4310-a74d-a13b72c5a0aa
     status: 204 No Content
     code: 204
     duration: ""
@@ -4333,9 +3819,71 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bb06b91c-d5e4-4f3f-a661-a322f90debc6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0cfb8a39-b2d6-44db-b247-e9f6ff901e79
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"0cfb8a39-b2d6-44db-b247-e9f6ff901e79","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:16:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0eba9ea6-d4a4-4bbd-bcf1-f6010f86124e
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/57808eba-a9bf-4a38-b786-ac2cb062e5d6
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Fri, 20 Oct 2023 14:16:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 62d8e53c-7968-4ba5-bc65-00855d5d5e66
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/17818dee-ef3c-4c6a-b5a4-d701ee98d1e5
     method: DELETE
   response:
     body: ""
@@ -4345,7 +3893,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:53 GMT
+      - Fri, 20 Oct 2023 14:16:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4355,7 +3903,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79c04a37-20d8-4432-8425-c6f99602f2a2
+      - 3b1ebd77-2fc1-46e7-8f29-bfa514269177
     status: 204 No Content
     code: 204
     duration: ""
@@ -4364,12 +3912,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/3465ffb2-22aa-4afb-8684-f08ec4302bc3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/ed17287e-2e94-4739-a493-5cfc6f7ad4dd
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"3465ffb2-22aa-4afb-8684-f08ec4302bc3","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"ed17287e-2e94-4739-a493-5cfc6f7ad4dd","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -4378,7 +3926,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 14:27:53 GMT
+      - Fri, 20 Oct 2023 14:16:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4388,7 +3936,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a66063bd-c71b-45fd-b8f5-4726bbacc4ec
+      - ec864f07-85fd-4e56-977e-870a05e1236f
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-vpc-public-gateway-dhcp-reservation-static.cassette.yaml
+++ b/scaleway/testdata/data-source-vpc-public-gateway-dhcp-reservation-static.cassette.yaml
@@ -2,27 +2,27 @@
 version: 1
 interactions:
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","subnet":"192.168.1.0/24","address":null,"pool_low":null,"pool_high":null,"enable_dynamic":null,"valid_lifetime":null,"renew_timer":null,"rebind_timer":null,"push_default_route":null,"push_dns_server":null,"dns_servers_override":null,"dns_search":null,"dns_local_name":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","address":null,"pool_low":null,"pool_high":null,"enable_dynamic":null,"valid_lifetime":null,"renew_timer":null,"rebind_timer":null,"push_default_route":null,"push_dns_server":null,"dns_servers_override":null,"dns_search":null,"dns_local_name":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
     method: POST
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:44 GMT
+      - Mon, 23 Oct 2023 06:49:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a18b02b-0d8f-492b-b3bf-d0c7e814ca2a
+      - 1ce646b4-959c-441c-bc66-fb328b3e88cb
     status: 200 OK
     code: 200
     duration: ""
@@ -41,21 +41,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/afc38af2-e533-44c1-8a2a-198ba31e273b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/060f8446-d73c-4c83-a8a1-a17a1d32bc17
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:44 GMT
+      - Mon, 23 Oct 2023 06:49:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,34 +65,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b44dcddd-4eca-41d8-b131-fc02c8083136
+      - 65e3099c-ab31-4063-81d5-b0e539a3ca80
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-sg-crazy-proskuriakova","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","stateful":true,"inbound_default_policy":"drop","outbound_default_policy":"accept","enable_default_security":true}'
+    body: '{"name":"tf-sg-nostalgic-jang","project":"105bdce1-64c0-48ab-899d-868455867ecf","stateful":true,"inbound_default_policy":"drop","outbound_default_policy":"accept","enable_default_security":true}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups
     method: POST
   response:
-    body: '{"security_group":{"creation_date":"2023-07-12T09:50:44.310237+00:00","description":null,"enable_default_security":true,"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","inbound_default_policy":"drop","modification_date":"2023-07-12T09:50:44.310237+00:00","name":"tf-sg-crazy-proskuriakova","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","organization_default":false,"outbound_default_policy":"accept","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_default":false,"servers":[],"state":"syncing","stateful":true,"tags":[],"zone":"fr-par-1"}}'
+    body: '{"security_group":{"creation_date":"2023-10-23T06:49:00.512612+00:00","description":null,"enable_default_security":true,"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","inbound_default_policy":"drop","modification_date":"2023-10-23T06:49:00.512612+00:00","name":"tf-sg-nostalgic-jang","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"syncing","stateful":true,"tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "587"
+      - "582"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:44 GMT
+      - Mon, 23 Oct 2023 06:49:00 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/c2db90cd-d287-4829-88fb-01dcadfa069a
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/fa78263d-512e-45c9-aba0-3e6aa6e527be
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,65 +102,30 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 715b1806-8ea9-43a0-a302-95c89c8cd7cd
+      - 081ccaf8-061d-4a42-a81d-fb8150491df4
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null,"subnets":null,"vpc_id":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
-    method: POST
-  response:
-    body: '{"created_at":"2023-07-12T09:50:44.321314Z","dhcp_enabled":false,"id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-07-12T09:50:44.321314Z","id":"3c8484b7-9e97-4ff9-a4f1-143551cf0d77","subnet":"172.16.8.0/22","updated_at":"2023-07-12T09:50:44.321314Z"},{"created_at":"2023-07-12T09:50:44.321314Z","id":"a8696ef3-6c67-494c-89fc-87907371e963","subnet":"fd46:78ab:30b8:91f6::/64","updated_at":"2023-07-12T09:50:44.321314Z"}],"tags":[],"updated_at":"2023-07-12T09:50:44.321314Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
-    headers:
-      Content-Length:
-      - "747"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:50:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - afcbc52b-dfdb-4533-887f-fffe8084b623
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
     body: ""
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/c2db90cd-d287-4829-88fb-01dcadfa069a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/fa78263d-512e-45c9-aba0-3e6aa6e527be
     method: GET
   response:
-    body: '{"security_group":{"creation_date":"2023-07-12T09:50:44.310237+00:00","description":null,"enable_default_security":true,"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","inbound_default_policy":"drop","modification_date":"2023-07-12T09:50:44.310237+00:00","name":"tf-sg-crazy-proskuriakova","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","organization_default":false,"outbound_default_policy":"accept","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_default":false,"servers":[],"state":"syncing","stateful":true,"tags":[],"zone":"fr-par-1"}}'
+    body: '{"security_group":{"creation_date":"2023-10-23T06:49:00.512612+00:00","description":null,"enable_default_security":true,"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","inbound_default_policy":"drop","modification_date":"2023-10-23T06:49:00.512612+00:00","name":"tf-sg-nostalgic-jang","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"syncing","stateful":true,"tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "587"
+      - "582"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:44 GMT
+      - Mon, 23 Oct 2023 06:49:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,65 +135,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef52260f-e0e8-431b-b41b-1515215d3605
+      - d9b103b6-f9cd-4a68-a628-6a62324dc53b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dafdd01e-9ac9-4392-86f3-0eea52ec4160
-    method: GET
-  response:
-    body: '{"created_at":"2023-07-12T09:50:44.321314Z","dhcp_enabled":false,"id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-07-12T09:50:44.321314Z","id":"3c8484b7-9e97-4ff9-a4f1-143551cf0d77","subnet":"172.16.8.0/22","updated_at":"2023-07-12T09:50:44.321314Z"},{"created_at":"2023-07-12T09:50:44.321314Z","id":"a8696ef3-6c67-494c-89fc-87907371e963","subnet":"fd46:78ab:30b8:91f6::/64","updated_at":"2023-07-12T09:50:44.321314Z"}],"tags":[],"updated_at":"2023-07-12T09:50:44.321314Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
-    headers:
-      Content-Length:
-      - "747"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:50:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6ba1a0dc-c043-4d55-af4a-c8c107e34802
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"tf-sg-crazy-proskuriakova","tags":[],"creation_date":"2023-07-12T09:50:44.310237Z","modification_date":"2023-07-12T09:50:44.310237Z","description":"","enable_default_security":true,"inbound_default_policy":"drop","outbound_default_policy":"accept","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","organization_default":false,"project_default":false,"servers":[],"stateful":true}'
+    body: '{"name":"tf-sg-nostalgic-jang","tags":[],"creation_date":"2023-10-23T06:49:00.512612Z","modification_date":"2023-10-23T06:49:00.512612Z","description":"","enable_default_security":true,"inbound_default_policy":"drop","outbound_default_policy":"accept","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"project_default":false,"servers":[],"stateful":true}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/c2db90cd-d287-4829-88fb-01dcadfa069a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/fa78263d-512e-45c9-aba0-3e6aa6e527be
     method: PUT
   response:
-    body: '{"security_group":{"creation_date":"2023-07-12T09:50:44.310237+00:00","description":"","enable_default_security":true,"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","inbound_default_policy":"drop","modification_date":"2023-07-12T09:50:44.455456+00:00","name":"tf-sg-crazy-proskuriakova","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","organization_default":false,"outbound_default_policy":"accept","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_default":false,"servers":[],"state":"syncing","stateful":true,"tags":[],"zone":"fr-par-1"}}'
+    body: '{"security_group":{"creation_date":"2023-10-23T06:49:00.512612+00:00","description":"","enable_default_security":true,"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","inbound_default_policy":"drop","modification_date":"2023-10-23T06:49:00.682907+00:00","name":"tf-sg-nostalgic-jang","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"syncing","stateful":true,"tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "585"
+      - "580"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:44 GMT
+      - Mon, 23 Oct 2023 06:49:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -238,32 +170,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a5f893a-ce3a-4025-9df5-673cf90b9103
+      - 23e40523-fa29-44b7-83ca-ed468bd8fbf7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
     method: POST
   response:
-    body: '{"address":"51.158.73.234","created_at":"2023-07-12T09:50:44.935513Z","gateway_id":null,"id":"512a1524-4038-4767-83b2-d3e9f1613898","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"234-73-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:50:44.935513Z","zone":"fr-par-1"}'
+    body: '{"address":"51.158.114.104","created_at":"2023-10-23T06:49:00.957190Z","gateway_id":null,"id":"a7332263-ec06-45f0-8553-608b5579a3e3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"104-114-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-23T06:49:00.957190Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "358"
+      - "369"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:44 GMT
+      - Mon, 23 Oct 2023 06:49:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -273,7 +205,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3df90c2-016b-49b9-97e9-f985fb0ce3d2
+      - e8dbce7a-4d38-40af-a375-e4b1d8e4d58d
     status: 200 OK
     code: 200
     duration: ""
@@ -282,21 +214,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/512a1524-4038-4767-83b2-d3e9f1613898
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/a7332263-ec06-45f0-8553-608b5579a3e3
     method: GET
   response:
-    body: '{"address":"51.158.73.234","created_at":"2023-07-12T09:50:44.935513Z","gateway_id":null,"id":"512a1524-4038-4767-83b2-d3e9f1613898","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"234-73-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:50:44.935513Z","zone":"fr-par-1"}'
+    body: '{"address":"51.158.114.104","created_at":"2023-10-23T06:49:00.957190Z","gateway_id":null,"id":"a7332263-ec06-45f0-8553-608b5579a3e3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"104-114-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-23T06:49:00.957190Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "358"
+      - "369"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:45 GMT
+      - Mon, 23 Oct 2023 06:49:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -306,7 +238,143 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2736378-0958-44da-8a41-bca185314e54
+      - 4e757a4e-d2e7-4006-9575-00d4195b2f76
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null,"vpc_id":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+    method: POST
+  response:
+    body: '{"created_at":"2023-10-23T06:49:00.430024Z","dhcp_enabled":true,"id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-23T06:49:00.430024Z","id":"867c0a14-8105-4a52-887b-0b1dd00b21a0","subnet":"172.16.152.0/22","updated_at":"2023-10-23T06:49:00.430024Z"},{"created_at":"2023-10-23T06:49:00.430024Z","id":"d008ebf0-c1a0-40c5-a489-4b108473f177","subnet":"fd5f:519c:6d46:a78a::/64","updated_at":"2023-10-23T06:49:00.430024Z"}],"tags":[],"updated_at":"2023-10-23T06:49:00.430024Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "765"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 23 Oct 2023 06:49:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 033b07c5-9e12-4558-a427-38d27be2fc84
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/41c8b3b2-3199-44a5-a72c-b542c635bf8f
+    method: GET
+  response:
+    body: '{"created_at":"2023-10-23T06:49:00.430024Z","dhcp_enabled":true,"id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-23T06:49:00.430024Z","id":"867c0a14-8105-4a52-887b-0b1dd00b21a0","subnet":"172.16.152.0/22","updated_at":"2023-10-23T06:49:00.430024Z"},{"created_at":"2023-10-23T06:49:00.430024Z","id":"d008ebf0-c1a0-40c5-a489-4b108473f177","subnet":"fd5f:519c:6d46:a78a::/64","updated_at":"2023-10-23T06:49:00.430024Z"}],"tags":[],"updated_at":"2023-10-23T06:49:00.430024Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "765"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 23 Oct 2023 06:49:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ee6e400d-2181-4659-8eef-44a6bf00ce2e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"a7332263-ec06-45f0-8553-608b5579a3e3","enable_smtp":false,"enable_bastion":false,"bastion_port":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
+    method: POST
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-23T06:49:01.203511Z","gateway_networks":[],"id":"2d37d34b-7e78-4592-b39f-6adb62147e09","ip":{"address":"51.158.114.104","created_at":"2023-10-23T06:49:00.957190Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"a7332263-ec06-45f0-8553-608b5579a3e3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"104-114-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-23T06:49:00.957190Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-23T06:49:01.203511Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "971"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 23 Oct 2023 06:49:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 97e25b02-b6ef-4ed2-9304-dfdae9ff9556
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/2d37d34b-7e78-4592-b39f-6adb62147e09
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-23T06:49:01.203511Z","gateway_networks":[],"id":"2d37d34b-7e78-4592-b39f-6adb62147e09","ip":{"address":"51.158.114.104","created_at":"2023-10-23T06:49:00.957190Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"a7332263-ec06-45f0-8553-608b5579a3e3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"104-114-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-23T06:49:00.957190Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-23T06:49:01.257097Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "974"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 23 Oct 2023 06:49:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7ba935dc-56c4-4e70-8d17-9b1de03024c7
     status: 200 OK
     code: 200
     duration: ""
@@ -317,21 +385,21 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/c2db90cd-d287-4829-88fb-01dcadfa069a/rules
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/fa78263d-512e-45c9-aba0-3e6aa6e527be/rules
     method: PUT
   response:
-    body: '{"rules":[{"action":"drop","dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"6dc48f49-c2ef-4ad4-85ca-b306f1b34a0f","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
+    body: '{"rules":[{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_ip_range":null,"dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"29c3f701-4721-40c7-91c4-9a9fbad22a75","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
     headers:
       Content-Length:
-      - "1631"
+      - "1792"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:45 GMT
+      - Mon, 23 Oct 2023 06:49:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -341,7 +409,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d9df49f-e0dd-41bd-a05b-38010a089dd7
+      - bc31ea95-0c10-490d-8c24-698cb306a770
     status: 200 OK
     code: 200
     duration: ""
@@ -350,21 +418,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/c2db90cd-d287-4829-88fb-01dcadfa069a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/fa78263d-512e-45c9-aba0-3e6aa6e527be
     method: GET
   response:
-    body: '{"security_group":{"creation_date":"2023-07-12T09:50:44.310237+00:00","description":"","enable_default_security":true,"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","inbound_default_policy":"drop","modification_date":"2023-07-12T09:50:45.511473+00:00","name":"tf-sg-crazy-proskuriakova","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","organization_default":false,"outbound_default_policy":"accept","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_default":false,"servers":[],"state":"available","stateful":true,"tags":[],"zone":"fr-par-1"}}'
+    body: '{"security_group":{"creation_date":"2023-10-23T06:49:00.512612+00:00","description":"","enable_default_security":true,"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","inbound_default_policy":"drop","modification_date":"2023-10-23T06:49:01.448209+00:00","name":"tf-sg-nostalgic-jang","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"available","stateful":true,"tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "587"
+      - "582"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:45 GMT
+      - Mon, 23 Oct 2023 06:49:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -374,42 +442,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6be7c5ff-b58e-4bac-88a5-507bbef46eef
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"512a1524-4038-4767-83b2-d3e9f1613898","enable_smtp":false,"enable_bastion":false,"bastion_port":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
-    method: POST
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:50:45.592092Z","gateway_networks":[],"id":"d3f71384-6fc6-44b7-acd4-224a746716f6","ip":{"address":"51.158.73.234","created_at":"2023-07-12T09:50:44.935513Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"512a1524-4038-4767-83b2-d3e9f1613898","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"234-73-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:50:44.935513Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:50:45.592092Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "922"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:50:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2766eb78-ef18-4e34-887b-abbb2397307c
+      - d426fa30-842c-4a76-8fe4-1459c5320955
     status: 200 OK
     code: 200
     duration: ""
@@ -418,21 +451,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/c2db90cd-d287-4829-88fb-01dcadfa069a/rules?page=1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/fa78263d-512e-45c9-aba0-3e6aa6e527be/rules?page=1
     method: GET
   response:
-    body: '{"rules":[{"action":"drop","dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"6dc48f49-c2ef-4ad4-85ca-b306f1b34a0f","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
+    body: '{"rules":[{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_ip_range":null,"dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"29c3f701-4721-40c7-91c4-9a9fbad22a75","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
     headers:
       Content-Length:
-      - "1631"
+      - "1792"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:45 GMT
+      - Mon, 23 Oct 2023 06:49:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -442,7 +475,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89ed8ce2-fb33-4575-9be4-779f5b2b6e55
+      - 62ca4baa-8fdc-415c-8c96-c0a0d1cea58e
     status: 200 OK
     code: 200
     duration: ""
@@ -451,54 +484,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d3f71384-6fc6-44b7-acd4-224a746716f6
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:50:45.592092Z","gateway_networks":[],"id":"d3f71384-6fc6-44b7-acd4-224a746716f6","ip":{"address":"51.158.73.234","created_at":"2023-07-12T09:50:44.935513Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"512a1524-4038-4767-83b2-d3e9f1613898","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"234-73-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:50:44.935513Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:50:45.650274Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "925"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:50:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 303f28c6-07dd-44cc-a1fe-969f69d0f204
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60"],"id":"5b51710c-e543-47b5-92d2-a68a83cefbe9","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"10b2d3c3-bfa7-42d4-910b-389e95f95ccb","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1092"
+      - "1256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:45 GMT
+      - Mon, 23 Oct 2023 06:49:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -508,7 +508,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa47591c-473e-47a3-a089-b107120ddf31
+      - af8b780d-c055-4407-8a3f-a66f8fa96221
     status: 200 OK
     code: 200
     duration: ""
@@ -517,21 +517,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
+    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
     headers:
       Content-Length:
-      - "37931"
+      - "38421"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:45 GMT
+      - Mon, 23 Oct 2023 06:49:01 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
@@ -544,7 +544,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f95d468-27fb-4437-82bd-fcbeaeb49697
+      - c9a5c3ef-6264-4eb0-a6db-2ce9820c8309
       X-Total-Count:
       - "56"
     status: 200 OK
@@ -555,21 +555,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
     headers:
       Content-Length:
-      - "4489"
+      - "4865"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:45 GMT
+      - Mon, 23 Oct 2023 06:49:01 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
@@ -582,41 +582,41 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bebbd4a6-b101-437d-99dc-0d020ba7e2e5
+      - 6db93c11-978d-4081-824e-297077fd8d7b
       X-Total-Count:
       - "56"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-srv-stoic-cannon","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","security_group":"c2db90cd-d287-4829-88fb-01dcadfa069a"}'
+    body: '{"name":"tf-srv-intelligent-wu","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","security_group":"fa78263d-512e-45c9-aba0-3e6aa6e527be"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:50:46.113408+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-23T06:49:02.173512+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-wu","id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:03:d7","maintenances":[],"modification_date":"2023-10-23T06:49:02.173512+00:00","name":"tf-srv-intelligent-wu","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","name":"tf-sg-nostalgic-jang"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-23T06:49:02.173512+00:00","export_uri":null,"id":"76b13f47-0510-4cf0-8f21-ca8a00e26062","modification_date":"2023-10-23T06:49:02.173512+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","name":"tf-srv-intelligent-wu"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2622"
+      - "2643"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:46 GMT
+      - Mon, 23 Oct 2023 06:49:02 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -626,7 +626,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0560aa5f-b4b3-4079-adb6-f71a554c6289
+      - fb5fa9fb-b31f-4840-8e16-6d32ea38ef7c
     status: 201 Created
     code: 201
     duration: ""
@@ -635,26 +635,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:50:46.113408+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-23T06:49:02.173512+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-wu","id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:03:d7","maintenances":[],"modification_date":"2023-10-23T06:49:02.173512+00:00","name":"tf-srv-intelligent-wu","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","name":"tf-sg-nostalgic-jang"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-23T06:49:02.173512+00:00","export_uri":null,"id":"76b13f47-0510-4cf0-8f21-ca8a00e26062","modification_date":"2023-10-23T06:49:02.173512+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","name":"tf-srv-intelligent-wu"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2622"
+      - "2643"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:46 GMT
+      - Mon, 23 Oct 2023 06:49:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -664,7 +664,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c442328c-8aca-45f9-b5a9-ca19a00fbe17
+      - c23e9ed4-36f1-420a-813f-6917b8873327
     status: 200 OK
     code: 200
     duration: ""
@@ -673,26 +673,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:50:46.113408+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-23T06:49:02.173512+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-wu","id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:03:d7","maintenances":[],"modification_date":"2023-10-23T06:49:02.173512+00:00","name":"tf-srv-intelligent-wu","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","name":"tf-sg-nostalgic-jang"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-23T06:49:02.173512+00:00","export_uri":null,"id":"76b13f47-0510-4cf0-8f21-ca8a00e26062","modification_date":"2023-10-23T06:49:02.173512+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","name":"tf-srv-intelligent-wu"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2622"
+      - "2643"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:46 GMT
+      - Mon, 23 Oct 2023 06:49:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -702,7 +702,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19b4b4d4-8c43-4409-b281-80ea0d7de0b9
+      - 568c2d01-175a-47ed-b561-fc135e7b1a91
     status: 200 OK
     code: 200
     duration: ""
@@ -713,12 +713,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89/action","href_result":"/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","id":"b3093e20-df8f-443f-b750-2693c6713d81","started_at":"2023-07-12T09:50:47.165609+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/action","href_result":"/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5","id":"c263f139-5b7e-442b-a70c-215f35a1366d","started_at":"2023-10-23T06:49:03.899526+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -727,9 +727,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:47 GMT
+      - Mon, 23 Oct 2023 06:49:03 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/b3093e20-df8f-443f-b750-2693c6713d81
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/c263f139-5b7e-442b-a70c-215f35a1366d
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -739,7 +739,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edc95767-7f34-4b3e-9a10-b963aedd79f5
+      - de322978-d095-431e-ace3-6760e6b16a59
     status: 202 Accepted
     code: 202
     duration: ""
@@ -748,27 +748,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:50:46.761968+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"starting","state_detail":"allocating
-      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-23T06:49:02.173512+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-wu","id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:03:d7","maintenances":[],"modification_date":"2023-10-23T06:49:03.399997+00:00","name":"tf-srv-intelligent-wu","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","name":"tf-sg-nostalgic-jang"},"state":"starting","state_detail":"allocating
+      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-23T06:49:02.173512+00:00","export_uri":null,"id":"76b13f47-0510-4cf0-8f21-ca8a00e26062","modification_date":"2023-10-23T06:49:02.173512+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","name":"tf-srv-intelligent-wu"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2644"
+      - "2665"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:47 GMT
+      - Mon, 23 Oct 2023 06:49:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -778,7 +778,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23e55305-fbd1-4779-9fe4-51b3090c6a17
+      - 37eb90b5-6ae5-45b7-805d-969400f245b0
     status: 200 OK
     code: 200
     duration: ""
@@ -787,21 +787,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d3f71384-6fc6-44b7-acd4-224a746716f6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/2d37d34b-7e78-4592-b39f-6adb62147e09
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:50:45.592092Z","gateway_networks":[],"id":"d3f71384-6fc6-44b7-acd4-224a746716f6","ip":{"address":"51.158.73.234","created_at":"2023-07-12T09:50:44.935513Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"512a1524-4038-4767-83b2-d3e9f1613898","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"234-73-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:50:44.935513Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:50:46.171455Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-23T06:49:01.203511Z","gateway_networks":[],"id":"2d37d34b-7e78-4592-b39f-6adb62147e09","ip":{"address":"51.158.114.104","created_at":"2023-10-23T06:49:00.957190Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"a7332263-ec06-45f0-8553-608b5579a3e3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"104-114-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-23T06:49:00.957190Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-23T06:49:01.913428Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "922"
+      - "971"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:50 GMT
+      - Mon, 23 Oct 2023 06:49:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -811,7 +811,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd87b9ec-ddfe-4ab2-aaf5-f799a201d9b0
+      - 7764dc6e-99b4-4ba1-b29a-ed8f74e7f402
     status: 200 OK
     code: 200
     duration: ""
@@ -820,21 +820,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d3f71384-6fc6-44b7-acd4-224a746716f6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/2d37d34b-7e78-4592-b39f-6adb62147e09
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:50:45.592092Z","gateway_networks":[],"id":"d3f71384-6fc6-44b7-acd4-224a746716f6","ip":{"address":"51.158.73.234","created_at":"2023-07-12T09:50:44.935513Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"512a1524-4038-4767-83b2-d3e9f1613898","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"234-73-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:50:44.935513Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:50:46.171455Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-23T06:49:01.203511Z","gateway_networks":[],"id":"2d37d34b-7e78-4592-b39f-6adb62147e09","ip":{"address":"51.158.114.104","created_at":"2023-10-23T06:49:00.957190Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"a7332263-ec06-45f0-8553-608b5579a3e3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"104-114-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-23T06:49:00.957190Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-23T06:49:01.913428Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "922"
+      - "971"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:50 GMT
+      - Mon, 23 Oct 2023 06:49:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -844,7 +844,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65638b9b-b8b1-40db-9164-33155953bd52
+      - df9e6751-0e9a-413b-83cf-7c43a023cbeb
     status: 200 OK
     code: 200
     duration: ""
@@ -853,21 +853,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d3f71384-6fc6-44b7-acd4-224a746716f6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/2d37d34b-7e78-4592-b39f-6adb62147e09
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:50:45.592092Z","gateway_networks":[],"id":"d3f71384-6fc6-44b7-acd4-224a746716f6","ip":{"address":"51.158.73.234","created_at":"2023-07-12T09:50:44.935513Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"512a1524-4038-4767-83b2-d3e9f1613898","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"234-73-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:50:44.935513Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:50:46.171455Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-23T06:49:01.203511Z","gateway_networks":[],"id":"2d37d34b-7e78-4592-b39f-6adb62147e09","ip":{"address":"51.158.114.104","created_at":"2023-10-23T06:49:00.957190Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"a7332263-ec06-45f0-8553-608b5579a3e3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"104-114-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-23T06:49:00.957190Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-23T06:49:01.913428Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "922"
+      - "971"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:50 GMT
+      - Mon, 23 Oct 2023 06:49:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -877,32 +877,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0191cb6-82f7-48a8-9d64-faa538734c7c
+      - f40406eb-fd2b-4a10-b0d0-86c21860e4af
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","enable_masquerade":true,"dhcp_id":"afc38af2-e533-44c1-8a2a-198ba31e273b","enable_dhcp":true}'
+    body: '{"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":null,"private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"created","updated_at":"2023-07-12T09:50:51.230484Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":null,"private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"created","updated_at":"2023-10-23T06:49:07.693022Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "934"
+      - "983"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:51 GMT
+      - Mon, 23 Oct 2023 06:49:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -912,7 +912,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 619e4c77-2d88-489d-bb2d-1727dd1a6eca
+      - 0c9b6a4e-32ae-41ff-85dd-013fc2d684b8
     status: 200 OK
     code: 200
     duration: ""
@@ -921,21 +921,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d3f71384-6fc6-44b7-acd4-224a746716f6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/2d37d34b-7e78-4592-b39f-6adb62147e09
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:50:45.592092Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":null,"private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"created","updated_at":"2023-07-12T09:50:51.230484Z","zone":"fr-par-1"}],"id":"d3f71384-6fc6-44b7-acd4-224a746716f6","ip":{"address":"51.158.73.234","created_at":"2023-07-12T09:50:44.935513Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"512a1524-4038-4767-83b2-d3e9f1613898","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"234-73-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:50:44.935513Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:50:51.330084Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-23T06:49:01.203511Z","gateway_networks":[{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":null,"private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"created","updated_at":"2023-10-23T06:49:07.693022Z","zone":"fr-par-1"}],"id":"2d37d34b-7e78-4592-b39f-6adb62147e09","ip":{"address":"51.158.114.104","created_at":"2023-10-23T06:49:00.957190Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"a7332263-ec06-45f0-8553-608b5579a3e3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"104-114-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-23T06:49:00.957190Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-23T06:49:07.912605Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1860"
+      - "1957"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:51 GMT
+      - Mon, 23 Oct 2023 06:49:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -945,7 +945,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9eab2ff8-fabb-48bd-a9a8-372039dfdfe1
+      - 0dfc2a5c-f2b1-43a9-8e66-cdfa32df77b4
     status: 200 OK
     code: 200
     duration: ""
@@ -954,27 +954,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:50:46.761968+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.226.55","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"starting","state_detail":"provisioning
-      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-23T06:49:02.173512+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-wu","id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1402","node_id":"25","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:03:d7","maintenances":[],"modification_date":"2023-10-23T06:49:03.399997+00:00","name":"tf-srv-intelligent-wu","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.54.49","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","name":"tf-sg-nostalgic-jang"},"state":"starting","state_detail":"provisioning
+      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-23T06:49:02.173512+00:00","export_uri":null,"id":"76b13f47-0510-4cf0-8f21-ca8a00e26062","modification_date":"2023-10-23T06:49:02.173512+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","name":"tf-srv-intelligent-wu"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2754"
+      - "2774"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:52 GMT
+      - Mon, 23 Oct 2023 06:49:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -984,7 +984,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e1efb4c-21d5-4ea7-865a-e592fd69d69d
+      - ba697219-e33f-4dfe-b8cf-b55023f44794
     status: 200 OK
     code: 200
     duration: ""
@@ -993,21 +993,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d3f71384-6fc6-44b7-acd4-224a746716f6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/2d37d34b-7e78-4592-b39f-6adb62147e09
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:50:45.592092Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":"02:00:00:13:5D:C5","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"ready","updated_at":"2023-07-12T09:50:52.969791Z","zone":"fr-par-1"}],"id":"d3f71384-6fc6-44b7-acd4-224a746716f6","ip":{"address":"51.158.73.234","created_at":"2023-07-12T09:50:44.935513Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"512a1524-4038-4767-83b2-d3e9f1613898","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"234-73-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:50:44.935513Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:50:53.068180Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-23T06:49:01.203511Z","gateway_networks":[{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":null,"private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"created","updated_at":"2023-10-23T06:49:07.693022Z","zone":"fr-par-1"}],"id":"2d37d34b-7e78-4592-b39f-6adb62147e09","ip":{"address":"51.158.114.104","created_at":"2023-10-23T06:49:00.957190Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"a7332263-ec06-45f0-8553-608b5579a3e3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"104-114-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-23T06:49:00.957190Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-23T06:49:07.912605Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1869"
+      - "1957"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:56 GMT
+      - Mon, 23 Oct 2023 06:49:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1017,7 +1017,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0063f974-c5d5-45a0-bf93-c810f3d5a2df
+      - 3402ebb9-b3f6-478f-a5f4-562790d6971d
     status: 200 OK
     code: 200
     duration: ""
@@ -1026,159 +1026,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/11abc7fb-3d2c-482d-9b81-10bfd069b264
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":"02:00:00:13:5D:C5","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"ready","updated_at":"2023-07-12T09:50:52.969791Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "947"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:50:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c8d8b02c-fa51-467f-944f-bf0a0df8a0f8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/11abc7fb-3d2c-482d-9b81-10bfd069b264
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":"02:00:00:13:5D:C5","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"ready","updated_at":"2023-07-12T09:50:52.969791Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "947"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:50:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e61d51c5-4e31-437d-a3dc-5aea263d611c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d3f71384-6fc6-44b7-acd4-224a746716f6
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:50:45.592092Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":"02:00:00:13:5D:C5","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"ready","updated_at":"2023-07-12T09:50:52.969791Z","zone":"fr-par-1"}],"id":"d3f71384-6fc6-44b7-acd4-224a746716f6","ip":{"address":"51.158.73.234","created_at":"2023-07-12T09:50:44.935513Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"512a1524-4038-4767-83b2-d3e9f1613898","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"234-73-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:50:44.935513Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:50:53.068180Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1869"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:50:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6c98d184-2afb-4c80-944f-b87daa86f48f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/11abc7fb-3d2c-482d-9b81-10bfd069b264
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":"02:00:00:13:5D:C5","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"ready","updated_at":"2023-07-12T09:50:52.969791Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "947"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:50:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9c339e41-bb8e-4a1e-8bd4-5467236b31ad
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:50:46.761968+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.226.55","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"starting","state_detail":"provisioning
-      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-23T06:49:02.173512+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-wu","id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1402","node_id":"25","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:03:d7","maintenances":[],"modification_date":"2023-10-23T06:49:03.399997+00:00","name":"tf-srv-intelligent-wu","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.54.49","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","name":"tf-sg-nostalgic-jang"},"state":"starting","state_detail":"provisioning
+      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-23T06:49:02.173512+00:00","export_uri":null,"id":"76b13f47-0510-4cf0-8f21-ca8a00e26062","modification_date":"2023-10-23T06:49:02.173512+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","name":"tf-srv-intelligent-wu"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2754"
+      - "2774"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:50:57 GMT
+      - Mon, 23 Oct 2023 06:49:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1188,7 +1056,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bad07728-44cf-4d20-8a48-3d9a59d2fd33
+      - 16921602-f8ca-40cf-97e8-751f1f98b668
     status: 200 OK
     code: 200
     duration: ""
@@ -1197,27 +1065,192 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/2d37d34b-7e78-4592-b39f-6adb62147e09
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-23T06:49:01.203511Z","gateway_networks":[{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":"02:00:00:14:5E:C0","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"ready","updated_at":"2023-10-23T06:49:14.785590Z","zone":"fr-par-1"}],"id":"2d37d34b-7e78-4592-b39f-6adb62147e09","ip":{"address":"51.158.114.104","created_at":"2023-10-23T06:49:00.957190Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"a7332263-ec06-45f0-8553-608b5579a3e3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"104-114-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-23T06:49:00.957190Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-23T06:49:14.933740Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1966"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 23 Oct 2023 06:49:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1bd76b10-a018-417f-a524-7a1d32831a95
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/5eeb3b25-340f-4e06-b10d-1098a45470d8
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":"02:00:00:14:5E:C0","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"ready","updated_at":"2023-10-23T06:49:14.785590Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 23 Oct 2023 06:49:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5204f3d7-6329-4eff-b08b-68c52992113c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/5eeb3b25-340f-4e06-b10d-1098a45470d8
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":"02:00:00:14:5E:C0","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"ready","updated_at":"2023-10-23T06:49:14.785590Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 23 Oct 2023 06:49:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e8f401bc-f66e-4c8b-9220-6e20b4319d59
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/2d37d34b-7e78-4592-b39f-6adb62147e09
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-23T06:49:01.203511Z","gateway_networks":[{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":"02:00:00:14:5E:C0","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"ready","updated_at":"2023-10-23T06:49:14.785590Z","zone":"fr-par-1"}],"id":"2d37d34b-7e78-4592-b39f-6adb62147e09","ip":{"address":"51.158.114.104","created_at":"2023-10-23T06:49:00.957190Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"a7332263-ec06-45f0-8553-608b5579a3e3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"104-114-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-23T06:49:00.957190Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-23T06:49:14.933740Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1966"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 23 Oct 2023 06:49:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0dfbea4d-d0e7-43a4-a3b0-1158a660322b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/5eeb3b25-340f-4e06-b10d-1098a45470d8
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":"02:00:00:14:5E:C0","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"ready","updated_at":"2023-10-23T06:49:14.785590Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 23 Oct 2023 06:49:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 61505ae9-9066-4ff2-83ad-5cebff3ae77d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:50:59.931708+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.226.55","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"running","state_detail":"booting
-      kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-23T06:49:02.173512+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-wu","id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1402","node_id":"25","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:03:d7","maintenances":[],"modification_date":"2023-10-23T06:49:15.994601+00:00","name":"tf-srv-intelligent-wu","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.54.49","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","name":"tf-sg-nostalgic-jang"},"state":"running","state_detail":"booting
+      kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-23T06:49:02.173512+00:00","export_uri":null,"id":"76b13f47-0510-4cf0-8f21-ca8a00e26062","modification_date":"2023-10-23T06:49:02.173512+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","name":"tf-srv-intelligent-wu"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2785"
+      - "2805"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:02 GMT
+      - Mon, 23 Oct 2023 06:49:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1227,7 +1260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc2244cb-9a08-4685-bafc-c3f50dbc1f43
+      - 61a6092c-6f90-41fe-8d97-c41b1b3ccb21
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,21 +1269,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/dafdd01e-9ac9-4392-86f3-0eea52ec4160
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/41c8b3b2-3199-44a5-a72c-b542c635bf8f
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:50:44.321314Z","id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","subnets":["192.168.1.0/24","fd46:78ab:30b8:91f6::/64"],"tags":[],"updated_at":"2023-07-12T09:50:52.632827Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-23T06:49:00.430024Z","id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnets":["192.168.1.0/24","fd5f:519c:6d46:a78a::/64"],"tags":[],"updated_at":"2023-10-23T06:49:14.337043Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "397"
+      - "406"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:02 GMT
+      - Mon, 23 Oct 2023 06:49:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1260,7 +1293,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d81e28a-b34c-447c-b2f2-bf7cc8b6879c
+      - 7b5510ec-a083-478a-be5b-8566f89ad347
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,27 +1302,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:50:59.931708+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.226.55","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"running","state_detail":"booting
-      kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-23T06:49:02.173512+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-wu","id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1402","node_id":"25","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:03:d7","maintenances":[],"modification_date":"2023-10-23T06:49:15.994601+00:00","name":"tf-srv-intelligent-wu","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.54.49","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","name":"tf-sg-nostalgic-jang"},"state":"running","state_detail":"booting
+      kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-23T06:49:02.173512+00:00","export_uri":null,"id":"76b13f47-0510-4cf0-8f21-ca8a00e26062","modification_date":"2023-10-23T06:49:02.173512+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","name":"tf-srv-intelligent-wu"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2785"
+      - "2805"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:03 GMT
+      - Mon, 23 Oct 2023 06:49:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1299,23 +1332,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08d191d7-f698-4a30-ae0f-94e61240a82d
+      - 0cecea42-dd29-4c4b-b908-ae88100480a4
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160"}'
+    body: '{"private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:03.162990+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:20.076461+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1324,7 +1357,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:03 GMT
+      - Mon, 23 Oct 2023 06:49:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1334,7 +1367,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21182be9-ab20-4623-b497-6f34e4c5555e
+      - 74d810f5-c95b-426e-9978-0cade4e27fb0
     status: 201 Created
     code: 201
     duration: ""
@@ -1343,12 +1376,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89/private_nics/f8655da0-7f20-44f8-b0e2-62cba3f12203
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/private_nics/c20a2ee0-5a33-4dca-8c27-99737557de8b
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:03.162990+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:20.076461+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1357,7 +1390,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:04 GMT
+      - Mon, 23 Oct 2023 06:49:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1367,7 +1400,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b455156a-ffa8-40ac-873a-e25902053ab6
+      - 55b8a854-798b-44d3-82f3-1d1634370eed
     status: 200 OK
     code: 200
     duration: ""
@@ -1376,12 +1409,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89/private_nics/f8655da0-7f20-44f8-b0e2-62cba3f12203
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/private_nics/c20a2ee0-5a33-4dca-8c27-99737557de8b
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:04.180023+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:21.137205+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1390,7 +1423,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:09 GMT
+      - Mon, 23 Oct 2023 06:49:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1400,7 +1433,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6e21ce4-dbb7-4f13-9499-711a1967482b
+      - de8784aa-cd6a-431f-bb7e-d481be26b85e
     status: 200 OK
     code: 200
     duration: ""
@@ -1409,12 +1442,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89/private_nics/f8655da0-7f20-44f8-b0e2-62cba3f12203
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/private_nics/c20a2ee0-5a33-4dca-8c27-99737557de8b
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:04.180023+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:21.137205+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1423,7 +1456,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:14 GMT
+      - Mon, 23 Oct 2023 06:49:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1433,7 +1466,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30a5501e-34bd-4ea3-a518-1872a5f3f3e2
+      - 96d35263-5042-4341-9b30-4dc13ef8f0f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1442,12 +1475,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89/private_nics/f8655da0-7f20-44f8-b0e2-62cba3f12203
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/private_nics/c20a2ee0-5a33-4dca-8c27-99737557de8b
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:04.180023+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:21.137205+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1456,7 +1489,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:19 GMT
+      - Mon, 23 Oct 2023 06:49:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1466,7 +1499,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5cd00db5-a739-4f5c-bb9d-9711b62acc82
+      - 2d8ca852-c274-4aa5-abf3-3e42c31c0a05
     status: 200 OK
     code: 200
     duration: ""
@@ -1475,12 +1508,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89/private_nics/f8655da0-7f20-44f8-b0e2-62cba3f12203
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/private_nics/c20a2ee0-5a33-4dca-8c27-99737557de8b
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:04.180023+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:21.137205+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1489,7 +1522,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:24 GMT
+      - Mon, 23 Oct 2023 06:49:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1499,7 +1532,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b71cc9c-631b-4f20-975b-e2368128be8d
+      - 68d31643-8be1-4017-a802-eaa53aa27086
     status: 200 OK
     code: 200
     duration: ""
@@ -1508,12 +1541,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89/private_nics/f8655da0-7f20-44f8-b0e2-62cba3f12203
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/private_nics/c20a2ee0-5a33-4dca-8c27-99737557de8b
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:04.180023+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:21.137205+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1522,7 +1555,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:29 GMT
+      - Mon, 23 Oct 2023 06:49:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1532,7 +1565,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c004a3a-5111-4b69-ad82-0c27f02ab4a4
+      - 2dfc3fdf-d239-40ef-b8e9-039dffc689e6
     status: 200 OK
     code: 200
     duration: ""
@@ -1541,12 +1574,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89/private_nics/f8655da0-7f20-44f8-b0e2-62cba3f12203
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/private_nics/c20a2ee0-5a33-4dca-8c27-99737557de8b
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:04.180023+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:21.137205+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1555,7 +1588,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:34 GMT
+      - Mon, 23 Oct 2023 06:49:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1565,7 +1598,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81a6c0c7-5816-46ed-9adb-845643bd477e
+      - 6e61372f-f77f-4730-b4cd-085d440d2c6b
     status: 200 OK
     code: 200
     duration: ""
@@ -1574,12 +1607,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89/private_nics/f8655da0-7f20-44f8-b0e2-62cba3f12203
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/private_nics/c20a2ee0-5a33-4dca-8c27-99737557de8b
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:34.591525+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:51.552219+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1588,7 +1621,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:39 GMT
+      - Mon, 23 Oct 2023 06:49:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1598,7 +1631,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c76c0d9-88f9-414e-ba77-0709a39f7198
+      - 757d031c-0f67-4240-97ae-369912e7870c
     status: 200 OK
     code: 200
     duration: ""
@@ -1607,12 +1640,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89/private_nics/f8655da0-7f20-44f8-b0e2-62cba3f12203
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/private_nics/c20a2ee0-5a33-4dca-8c27-99737557de8b
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:34.591525+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:51.552219+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1621,7 +1654,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:39 GMT
+      - Mon, 23 Oct 2023 06:49:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1631,7 +1664,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca609423-9fec-47f4-bf76-2a571f59ed76
+      - 697bf96d-3cf3-43b5-9332-1b53306710ca
     status: 200 OK
     code: 200
     duration: ""
@@ -1640,26 +1673,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:50:59.931708+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.226.55","private_nics":[{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:34.591525+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-23T06:49:02.173512+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-wu","id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1402","node_id":"25","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:03:d7","maintenances":[],"modification_date":"2023-10-23T06:49:15.994601+00:00","name":"tf-srv-intelligent-wu","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.54.49","private_nics":[{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:51.552219+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","name":"tf-sg-nostalgic-jang"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-23T06:49:02.173512+00:00","export_uri":null,"id":"76b13f47-0510-4cf0-8f21-ca8a00e26062","modification_date":"2023-10-23T06:49:02.173512+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","name":"tf-srv-intelligent-wu"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3138"
+      - "3158"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:39 GMT
+      - Mon, 23 Oct 2023 06:49:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1669,7 +1702,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2375074e-c8f8-4302-aafb-545a57b724a0
+      - ac1df0c2-e847-44bc-aad2-dc0faac89dd9
     status: 200 OK
     code: 200
     duration: ""
@@ -1678,9 +1711,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1692,7 +1725,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:39 GMT
+      - Mon, 23 Oct 2023 06:49:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1702,7 +1735,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0508cc78-00d2-4639-acf5-39f3714a878f
+      - 00fe39b4-24c5-419a-8246-01bb58ac386e
     status: 200 OK
     code: 200
     duration: ""
@@ -1711,12 +1744,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:34.591525+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:51.552219+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -1725,9 +1758,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:39 GMT
+      - Mon, 23 Oct 2023 06:49:57 GMT
       Link:
-      - </servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89/private_nics?page=1&per_page=50&>;
+      - </servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -1738,7 +1771,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46993cd9-f606-48d1-b472-575a2c8e07b9
+      - ac706f1d-a1e6-4522-8c91-83dad9ee26d2
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -1749,21 +1782,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/11abc7fb-3d2c-482d-9b81-10bfd069b264
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/5eeb3b25-340f-4e06-b10d-1098a45470d8
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":"02:00:00:13:5D:C5","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"ready","updated_at":"2023-07-12T09:50:52.969791Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":"02:00:00:14:5E:C0","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"ready","updated_at":"2023-10-23T06:49:14.785590Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:39 GMT
+      - Mon, 23 Oct 2023 06:49:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1773,32 +1806,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8315343a-9719-49b2-8f69-6e18a73d5244
+      - 807473fd-3383-4849-b031-86219aaa15a6
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_network_id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":"02:00:00:13:5d:c6","ip_address":"192.168.1.4"}'
+    body: '{"gateway_network_id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","mac_address":"02:00:00:14:5e:c1","ip_address":"192.168.1.4"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries
     method: POST
   response:
-    body: '{"created_at":"2023-07-12T09:51:39.900841Z","gateway_network_id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","hostname":"","id":"7893118c-bf64-40dc-a447-f89797d3ded3","ip_address":"192.168.1.4","mac_address":"02:00:00:13:5d:c6","type":"reservation","updated_at":"2023-07-12T09:51:39.900841Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-23T06:49:21.045171Z","gateway_network_id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","hostname":"tf-srv-intelligent-wu","id":"c298ea6d-288f-4c91-8fbf-7660fb9ca998","ip_address":"192.168.1.4","mac_address":"02:00:00:14:5e:c1","type":"reservation","updated_at":"2023-10-23T06:49:58.949441Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "305"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:39 GMT
+      - Mon, 23 Oct 2023 06:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1808,7 +1841,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f99904a6-8432-48cf-9a52-745a148814a4
+      - e8ab4bf1-484b-49af-b5bc-ba453618bd60
     status: 200 OK
     code: 200
     duration: ""
@@ -1817,21 +1850,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/11abc7fb-3d2c-482d-9b81-10bfd069b264
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/5eeb3b25-340f-4e06-b10d-1098a45470d8
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":"02:00:00:13:5D:C5","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"ready","updated_at":"2023-07-12T09:50:52.969791Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":"02:00:00:14:5E:C0","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"ready","updated_at":"2023-10-23T06:49:14.785590Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:40 GMT
+      - Mon, 23 Oct 2023 06:49:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1841,7 +1874,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ddf0ea9-f836-4854-9797-e965a6de343b
+      - a2be5b7d-ff50-48df-b0e5-82ed18ec043c
     status: 200 OK
     code: 200
     duration: ""
@@ -1850,21 +1883,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/7893118c-bf64-40dc-a447-f89797d3ded3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/c298ea6d-288f-4c91-8fbf-7660fb9ca998
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:51:39.900841Z","gateway_network_id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","hostname":"","id":"7893118c-bf64-40dc-a447-f89797d3ded3","ip_address":"192.168.1.4","mac_address":"02:00:00:13:5d:c6","type":"reservation","updated_at":"2023-07-12T09:51:39.900841Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-23T06:49:21.045171Z","gateway_network_id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","hostname":"tf-srv-intelligent-wu","id":"c298ea6d-288f-4c91-8fbf-7660fb9ca998","ip_address":"192.168.1.4","mac_address":"02:00:00:14:5e:c1","type":"reservation","updated_at":"2023-10-23T06:49:58.949441Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "305"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:40 GMT
+      - Mon, 23 Oct 2023 06:49:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1874,7 +1907,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28b4ebe6-5f8d-4826-b66d-02febfb0a9a5
+      - 0354e21a-c42f-460d-8e07-063418255f2b
     status: 200 OK
     code: 200
     duration: ""
@@ -1883,21 +1916,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d3f71384-6fc6-44b7-acd4-224a746716f6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/2d37d34b-7e78-4592-b39f-6adb62147e09
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:50:45.592092Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":"02:00:00:13:5D:C5","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"ready","updated_at":"2023-07-12T09:51:40.164705Z","zone":"fr-par-1"}],"id":"d3f71384-6fc6-44b7-acd4-224a746716f6","ip":{"address":"51.158.73.234","created_at":"2023-07-12T09:50:44.935513Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"512a1524-4038-4767-83b2-d3e9f1613898","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"234-73-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:50:44.935513Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:50:53.068180Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-23T06:49:01.203511Z","gateway_networks":[{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":"02:00:00:14:5E:C0","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"ready","updated_at":"2023-10-23T06:49:14.785590Z","zone":"fr-par-1"}],"id":"2d37d34b-7e78-4592-b39f-6adb62147e09","ip":{"address":"51.158.114.104","created_at":"2023-10-23T06:49:00.957190Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"a7332263-ec06-45f0-8553-608b5579a3e3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"104-114-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-23T06:49:00.957190Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-23T06:49:14.933740Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1869"
+      - "1966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:40 GMT
+      - Mon, 23 Oct 2023 06:49:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1907,7 +1940,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29cabc3a-6e4a-46f8-9df2-d2a2d51234bc
+      - 3050a3b8-d74e-4956-a5f8-6ebffc7bb19c
     status: 200 OK
     code: 200
     duration: ""
@@ -1916,21 +1949,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/7893118c-bf64-40dc-a447-f89797d3ded3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/c298ea6d-288f-4c91-8fbf-7660fb9ca998
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:51:39.900841Z","gateway_network_id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","hostname":"","id":"7893118c-bf64-40dc-a447-f89797d3ded3","ip_address":"192.168.1.4","mac_address":"02:00:00:13:5d:c6","type":"reservation","updated_at":"2023-07-12T09:51:39.900841Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-23T06:49:21.045171Z","gateway_network_id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","hostname":"tf-srv-intelligent-wu","id":"c298ea6d-288f-4c91-8fbf-7660fb9ca998","ip_address":"192.168.1.4","mac_address":"02:00:00:14:5e:c1","type":"reservation","updated_at":"2023-10-23T06:49:58.949441Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "305"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:40 GMT
+      - Mon, 23 Oct 2023 06:49:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1940,7 +1973,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca2fcf3c-a5fc-465f-aca0-44038d445ab5
+      - 2e945c6d-2081-4305-af2e-0be54cb6b03e
     status: 200 OK
     code: 200
     duration: ""
@@ -1949,21 +1982,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d3f71384-6fc6-44b7-acd4-224a746716f6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/2d37d34b-7e78-4592-b39f-6adb62147e09
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:50:45.592092Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":"02:00:00:13:5D:C5","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"ready","updated_at":"2023-07-12T09:51:40.164705Z","zone":"fr-par-1"}],"id":"d3f71384-6fc6-44b7-acd4-224a746716f6","ip":{"address":"51.158.73.234","created_at":"2023-07-12T09:50:44.935513Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"512a1524-4038-4767-83b2-d3e9f1613898","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"234-73-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:50:44.935513Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:50:53.068180Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-23T06:49:01.203511Z","gateway_networks":[{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":"02:00:00:14:5E:C0","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"ready","updated_at":"2023-10-23T06:49:14.785590Z","zone":"fr-par-1"}],"id":"2d37d34b-7e78-4592-b39f-6adb62147e09","ip":{"address":"51.158.114.104","created_at":"2023-10-23T06:49:00.957190Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"a7332263-ec06-45f0-8553-608b5579a3e3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"104-114-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-23T06:49:00.957190Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-23T06:49:14.933740Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1869"
+      - "1966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:40 GMT
+      - Mon, 23 Oct 2023 06:49:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1973,32 +2006,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a03a2c3-d22e-4983-ae38-07596f5853b4
+      - 561b83cb-6824-48e0-a594-4d18a86630df
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","public_port":2222,"private_ip":"192.168.1.4","private_port":22,"protocol":"tcp"}'
+    body: '{"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","public_port":2222,"private_ip":"192.168.1.4","private_port":22,"protocol":"tcp"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules
     method: POST
   response:
-    body: '{"created_at":"2023-07-12T09:51:40.276087Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"7dfef787-8901-4d2a-be61-d7cf0181b2f7","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2023-07-12T09:51:40.276087Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-23T06:49:59.392783Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"38d069a3-39bb-4451-bdd9-d7e88976dec9","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2023-10-23T06:49:59.392783Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "282"
+      - "290"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:40 GMT
+      - Mon, 23 Oct 2023 06:49:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2008,7 +2041,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 072e485a-be22-4c6b-8a66-bd126c9d478d
+      - c641d2e1-72ff-4ad3-8d27-7c52ebca94ce
     status: 200 OK
     code: 200
     duration: ""
@@ -2017,21 +2050,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d3f71384-6fc6-44b7-acd4-224a746716f6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/2d37d34b-7e78-4592-b39f-6adb62147e09
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:50:45.592092Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":"02:00:00:13:5D:C5","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"ready","updated_at":"2023-07-12T09:51:40.164705Z","zone":"fr-par-1"}],"id":"d3f71384-6fc6-44b7-acd4-224a746716f6","ip":{"address":"51.158.73.234","created_at":"2023-07-12T09:50:44.935513Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"512a1524-4038-4767-83b2-d3e9f1613898","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"234-73-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:50:44.935513Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:50:53.068180Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-23T06:49:01.203511Z","gateway_networks":[{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":"02:00:00:14:5E:C0","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"ready","updated_at":"2023-10-23T06:49:14.785590Z","zone":"fr-par-1"}],"id":"2d37d34b-7e78-4592-b39f-6adb62147e09","ip":{"address":"51.158.114.104","created_at":"2023-10-23T06:49:00.957190Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"a7332263-ec06-45f0-8553-608b5579a3e3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"104-114-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-23T06:49:00.957190Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-23T06:49:14.933740Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1869"
+      - "1966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:40 GMT
+      - Mon, 23 Oct 2023 06:49:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2041,7 +2074,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0892c789-0dc4-47ce-80c7-5a0804fe621f
+      - dfe7dce5-1e2a-4e48-bcab-108b93284c09
     status: 200 OK
     code: 200
     duration: ""
@@ -2050,21 +2083,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/7dfef787-8901-4d2a-be61-d7cf0181b2f7
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/38d069a3-39bb-4451-bdd9-d7e88976dec9
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:51:40.276087Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"7dfef787-8901-4d2a-be61-d7cf0181b2f7","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2023-07-12T09:51:40.276087Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-23T06:49:59.392783Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"38d069a3-39bb-4451-bdd9-d7e88976dec9","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2023-10-23T06:49:59.392783Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "282"
+      - "290"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:40 GMT
+      - Mon, 23 Oct 2023 06:49:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2074,7 +2107,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e8b397a-286f-4436-8b85-1834d316b2c3
+      - 74f1a812-c259-4a0c-902e-cc67bcec47b6
     status: 200 OK
     code: 200
     duration: ""
@@ -2083,21 +2116,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/7893118c-bf64-40dc-a447-f89797d3ded3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/c298ea6d-288f-4c91-8fbf-7660fb9ca998
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:51:39.900841Z","gateway_network_id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","hostname":"","id":"7893118c-bf64-40dc-a447-f89797d3ded3","ip_address":"192.168.1.4","mac_address":"02:00:00:13:5d:c6","type":"reservation","updated_at":"2023-07-12T09:51:39.900841Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-23T06:49:21.045171Z","gateway_network_id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","hostname":"tf-srv-intelligent-wu","id":"c298ea6d-288f-4c91-8fbf-7660fb9ca998","ip_address":"192.168.1.4","mac_address":"02:00:00:14:5e:c1","type":"reservation","updated_at":"2023-10-23T06:49:58.949441Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "305"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:40 GMT
+      - Mon, 23 Oct 2023 06:49:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2107,7 +2140,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72d4d65e-e8a7-433b-97c5-6de081ec4836
+      - d8aede02-edd4-4269-9c96-b1a4eb74445a
     status: 200 OK
     code: 200
     duration: ""
@@ -2116,21 +2149,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/afc38af2-e533-44c1-8a2a-198ba31e273b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/060f8446-d73c-4c83-a8a1-a17a1d32bc17
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:40 GMT
+      - Mon, 23 Oct 2023 06:50:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2140,7 +2173,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90e9ff73-0c88-4afc-a1b1-9573fbef3a89
+      - 60ecb236-fee0-46fc-8abc-4b1215aeba36
     status: 200 OK
     code: 200
     duration: ""
@@ -2149,21 +2182,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/512a1524-4038-4767-83b2-d3e9f1613898
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/a7332263-ec06-45f0-8553-608b5579a3e3
     method: GET
   response:
-    body: '{"address":"51.158.73.234","created_at":"2023-07-12T09:50:44.935513Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"512a1524-4038-4767-83b2-d3e9f1613898","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"234-73-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:50:44.935513Z","zone":"fr-par-1"}'
+    body: '{"address":"51.158.114.104","created_at":"2023-10-23T06:49:00.957190Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"a7332263-ec06-45f0-8553-608b5579a3e3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"104-114-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-23T06:49:00.957190Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "392"
+      - "403"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:40 GMT
+      - Mon, 23 Oct 2023 06:50:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2173,7 +2206,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d675d24-c2f3-4eb9-9246-e56ee5afa5a2
+      - 9172b2cd-69e0-4be6-a563-49ec871d1b6e
     status: 200 OK
     code: 200
     duration: ""
@@ -2182,21 +2215,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dafdd01e-9ac9-4392-86f3-0eea52ec4160
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/41c8b3b2-3199-44a5-a72c-b542c635bf8f
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:50:44.321314Z","dhcp_enabled":false,"id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-07-12T09:50:44.321314Z","id":"3c8484b7-9e97-4ff9-a4f1-143551cf0d77","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:51.057679Z"},{"created_at":"2023-07-12T09:50:44.321314Z","id":"a8696ef3-6c67-494c-89fc-87907371e963","subnet":"fd46:78ab:30b8:91f6::/64","updated_at":"2023-07-12T09:50:51.057679Z"}],"tags":[],"updated_at":"2023-07-12T09:51:40.026403Z","vpc_id":"de180274-5c5d-4eb4-b6e7-f658470a3409"}'
+    body: '{"created_at":"2023-10-23T06:49:00.430024Z","dhcp_enabled":true,"id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-23T06:49:00.430024Z","id":"867c0a14-8105-4a52-887b-0b1dd00b21a0","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:06.741060Z"},{"created_at":"2023-10-23T06:49:00.430024Z","id":"d008ebf0-c1a0-40c5-a489-4b108473f177","subnet":"fd5f:519c:6d46:a78a::/64","updated_at":"2023-10-23T06:49:06.744956Z"}],"tags":[],"updated_at":"2023-10-23T06:49:14.337043Z","vpc_id":"0520a26c-84b0-49e9-bfbb-74ff3c383261"}'
     headers:
       Content-Length:
-      - "748"
+      - "764"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:40 GMT
+      - Mon, 23 Oct 2023 06:50:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2206,7 +2239,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e13d2a97-601e-4d81-95a1-e2dd5be1c602
+      - 55992956-d9e6-42cd-848b-68eaec60781c
     status: 200 OK
     code: 200
     duration: ""
@@ -2215,21 +2248,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d3f71384-6fc6-44b7-acd4-224a746716f6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/2d37d34b-7e78-4592-b39f-6adb62147e09
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:50:45.592092Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":"02:00:00:13:5D:C5","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"ready","updated_at":"2023-07-12T09:51:40.164705Z","zone":"fr-par-1"}],"id":"d3f71384-6fc6-44b7-acd4-224a746716f6","ip":{"address":"51.158.73.234","created_at":"2023-07-12T09:50:44.935513Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"512a1524-4038-4767-83b2-d3e9f1613898","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"234-73-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:50:44.935513Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:50:53.068180Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-23T06:49:01.203511Z","gateway_networks":[{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":"02:00:00:14:5E:C0","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"ready","updated_at":"2023-10-23T06:49:14.785590Z","zone":"fr-par-1"}],"id":"2d37d34b-7e78-4592-b39f-6adb62147e09","ip":{"address":"51.158.114.104","created_at":"2023-10-23T06:49:00.957190Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"a7332263-ec06-45f0-8553-608b5579a3e3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"104-114-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-23T06:49:00.957190Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-23T06:49:14.933740Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1869"
+      - "1966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:41 GMT
+      - Mon, 23 Oct 2023 06:50:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2239,7 +2272,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 770263be-02b4-478e-9058-b0657d7681ec
+      - 0f872915-605f-4e3a-a5b1-37158efe7a29
     status: 200 OK
     code: 200
     duration: ""
@@ -2248,21 +2281,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/c2db90cd-d287-4829-88fb-01dcadfa069a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/fa78263d-512e-45c9-aba0-3e6aa6e527be
     method: GET
   response:
-    body: '{"security_group":{"creation_date":"2023-07-12T09:50:44.310237+00:00","description":"","enable_default_security":true,"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","inbound_default_policy":"drop","modification_date":"2023-07-12T09:50:45.511473+00:00","name":"tf-sg-crazy-proskuriakova","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","organization_default":false,"outbound_default_policy":"accept","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_default":false,"servers":[{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"}],"state":"available","stateful":true,"tags":[],"zone":"fr-par-1"}}'
+    body: '{"security_group":{"creation_date":"2023-10-23T06:49:00.512612+00:00","description":"","enable_default_security":true,"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","inbound_default_policy":"drop","modification_date":"2023-10-23T06:49:01.448209+00:00","name":"tf-sg-nostalgic-jang","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[{"id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","name":"tf-srv-intelligent-wu"}],"state":"available","stateful":true,"tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "664"
+      - "661"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:41 GMT
+      - Mon, 23 Oct 2023 06:50:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2272,7 +2305,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a098968-b8da-47ab-85cd-2b94b10faa5e
+      - ddfa3527-de72-4103-be96-d44fd23ed4d2
     status: 200 OK
     code: 200
     duration: ""
@@ -2281,21 +2314,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/c2db90cd-d287-4829-88fb-01dcadfa069a/rules?page=1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/5eeb3b25-340f-4e06-b10d-1098a45470d8
     method: GET
   response:
-    body: '{"rules":[{"action":"drop","dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"6dc48f49-c2ef-4ad4-85ca-b306f1b34a0f","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
+    body: '{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":"02:00:00:14:5E:C0","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"ready","updated_at":"2023-10-23T06:49:14.785590Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1631"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:41 GMT
+      - Mon, 23 Oct 2023 06:50:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2305,7 +2338,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 488eeefa-a5eb-4802-a398-cb5a83f77099
+      - 754fabc2-c74f-4fd9-b4f0-a3e071b573cd
     status: 200 OK
     code: 200
     duration: ""
@@ -2314,21 +2347,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/11abc7fb-3d2c-482d-9b81-10bfd069b264
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/2d37d34b-7e78-4592-b39f-6adb62147e09
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":"02:00:00:13:5D:C5","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"ready","updated_at":"2023-07-12T09:51:40.164705Z","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-23T06:49:01.203511Z","gateway_networks":[{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":"02:00:00:14:5E:C0","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"ready","updated_at":"2023-10-23T06:49:14.785590Z","zone":"fr-par-1"}],"id":"2d37d34b-7e78-4592-b39f-6adb62147e09","ip":{"address":"51.158.114.104","created_at":"2023-10-23T06:49:00.957190Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"a7332263-ec06-45f0-8553-608b5579a3e3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"104-114-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-23T06:49:00.957190Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-23T06:49:14.933740Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "1966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:41 GMT
+      - Mon, 23 Oct 2023 06:50:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2338,7 +2371,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5cd9f45-2daa-418b-8a3e-8dfb577e23cf
+      - be1f5fff-5242-49db-b371-67b3c6ce0745
     status: 200 OK
     code: 200
     duration: ""
@@ -2347,21 +2380,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d3f71384-6fc6-44b7-acd4-224a746716f6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/fa78263d-512e-45c9-aba0-3e6aa6e527be/rules?page=1
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:50:45.592092Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":"02:00:00:13:5D:C5","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"ready","updated_at":"2023-07-12T09:51:40.164705Z","zone":"fr-par-1"}],"id":"d3f71384-6fc6-44b7-acd4-224a746716f6","ip":{"address":"51.158.73.234","created_at":"2023-07-12T09:50:44.935513Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"512a1524-4038-4767-83b2-d3e9f1613898","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"234-73-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:50:44.935513Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:50:53.068180Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"rules":[{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_ip_range":null,"dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"29c3f701-4721-40c7-91c4-9a9fbad22a75","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
     headers:
       Content-Length:
-      - "1869"
+      - "1792"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:41 GMT
+      - Mon, 23 Oct 2023 06:50:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2371,7 +2404,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 633ce8b4-3b96-4373-b34d-86b56966ff20
+      - d79fc52d-8094-49ad-afe7-5be1a800cdf2
     status: 200 OK
     code: 200
     duration: ""
@@ -2380,26 +2413,59 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/5eeb3b25-340f-4e06-b10d-1098a45470d8
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":"02:00:00:14:5E:C0","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"ready","updated_at":"2023-10-23T06:49:14.785590Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 23 Oct 2023 06:50:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8d6b9c36-cd96-4d04-9951-62bb0044e6dc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:50:59.931708+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.226.55","private_nics":[{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:34.591525+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-23T06:49:02.173512+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-wu","id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1402","node_id":"25","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:03:d7","maintenances":[],"modification_date":"2023-10-23T06:49:15.994601+00:00","name":"tf-srv-intelligent-wu","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.54.49","private_nics":[{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:51.552219+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","name":"tf-sg-nostalgic-jang"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-23T06:49:02.173512+00:00","export_uri":null,"id":"76b13f47-0510-4cf0-8f21-ca8a00e26062","modification_date":"2023-10-23T06:49:02.173512+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","name":"tf-srv-intelligent-wu"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3138"
+      - "3158"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:41 GMT
+      - Mon, 23 Oct 2023 06:50:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2409,7 +2475,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f407a2a6-78e9-4f1c-8c7f-7bca85add2a3
+      - 48ac0368-6380-4ae0-a3f7-32782fd38a6e
     status: 200 OK
     code: 200
     duration: ""
@@ -2418,42 +2484,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/11abc7fb-3d2c-482d-9b81-10bfd069b264
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":"02:00:00:13:5D:C5","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"ready","updated_at":"2023-07-12T09:51:40.164705Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "947"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:51:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7b1e25ba-63ee-4b46-8752-69a42b5cc7b1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2465,7 +2498,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:41 GMT
+      - Mon, 23 Oct 2023 06:50:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2475,7 +2508,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b53e2fc-d631-4359-8dc4-20e34aa34f6c
+      - ec031ec8-6964-4d17-8aee-ff1b4dc14534
     status: 200 OK
     code: 200
     duration: ""
@@ -2484,12 +2517,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:34.591525+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:51.552219+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -2498,9 +2531,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:41 GMT
+      - Mon, 23 Oct 2023 06:50:00 GMT
       Link:
-      - </servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89/private_nics?page=1&per_page=50&>;
+      - </servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -2511,7 +2544,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 383463ae-d6e2-49cc-b1ba-c3d76d223384
+      - c3857b9f-8862-4dfa-93f7-ad8714bb82e9
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -2522,21 +2555,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/7893118c-bf64-40dc-a447-f89797d3ded3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/c298ea6d-288f-4c91-8fbf-7660fb9ca998
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:51:39.900841Z","gateway_network_id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","hostname":"","id":"7893118c-bf64-40dc-a447-f89797d3ded3","ip_address":"192.168.1.4","mac_address":"02:00:00:13:5d:c6","type":"reservation","updated_at":"2023-07-12T09:51:39.900841Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-23T06:49:21.045171Z","gateway_network_id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","hostname":"tf-srv-intelligent-wu","id":"c298ea6d-288f-4c91-8fbf-7660fb9ca998","ip_address":"192.168.1.4","mac_address":"02:00:00:14:5e:c1","type":"reservation","updated_at":"2023-10-23T06:49:58.949441Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "305"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:41 GMT
+      - Mon, 23 Oct 2023 06:50:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2546,7 +2579,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ae6ccff-dc24-473d-b594-496f8cc27553
+      - 55e9f8b7-b9fd-40ba-a198-55c64e2948cb
     status: 200 OK
     code: 200
     duration: ""
@@ -2555,21 +2588,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/7dfef787-8901-4d2a-be61-d7cf0181b2f7
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/38d069a3-39bb-4451-bdd9-d7e88976dec9
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:51:40.276087Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"7dfef787-8901-4d2a-be61-d7cf0181b2f7","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2023-07-12T09:51:40.276087Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-23T06:49:59.392783Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"38d069a3-39bb-4451-bdd9-d7e88976dec9","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2023-10-23T06:49:59.392783Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "282"
+      - "290"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:41 GMT
+      - Mon, 23 Oct 2023 06:50:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2579,7 +2612,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8de6ace-784a-41d0-abd8-af11088f93a1
+      - 34cdb683-0d33-4755-b81d-8c7493b5f489
     status: 200 OK
     code: 200
     duration: ""
@@ -2588,21 +2621,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/7893118c-bf64-40dc-a447-f89797d3ded3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/c298ea6d-288f-4c91-8fbf-7660fb9ca998
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:51:39.900841Z","gateway_network_id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","hostname":"","id":"7893118c-bf64-40dc-a447-f89797d3ded3","ip_address":"192.168.1.4","mac_address":"02:00:00:13:5d:c6","type":"reservation","updated_at":"2023-07-12T09:51:39.900841Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-23T06:49:21.045171Z","gateway_network_id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","hostname":"tf-srv-intelligent-wu","id":"c298ea6d-288f-4c91-8fbf-7660fb9ca998","ip_address":"192.168.1.4","mac_address":"02:00:00:14:5e:c1","type":"reservation","updated_at":"2023-10-23T06:49:58.949441Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "305"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:41 GMT
+      - Mon, 23 Oct 2023 06:50:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2612,7 +2645,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d977a2ea-5738-4a5a-9818-de625ff9fd93
+      - 69efb57c-a93c-4fff-bf92-d5565f795aa0
     status: 200 OK
     code: 200
     duration: ""
@@ -2621,21 +2654,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/7893118c-bf64-40dc-a447-f89797d3ded3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/c298ea6d-288f-4c91-8fbf-7660fb9ca998
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:51:39.900841Z","gateway_network_id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","hostname":"","id":"7893118c-bf64-40dc-a447-f89797d3ded3","ip_address":"192.168.1.4","mac_address":"02:00:00:13:5d:c6","type":"reservation","updated_at":"2023-07-12T09:51:39.900841Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-23T06:49:21.045171Z","gateway_network_id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","hostname":"tf-srv-intelligent-wu","id":"c298ea6d-288f-4c91-8fbf-7660fb9ca998","ip_address":"192.168.1.4","mac_address":"02:00:00:14:5e:c1","type":"reservation","updated_at":"2023-10-23T06:49:58.949441Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "305"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:41 GMT
+      - Mon, 23 Oct 2023 06:50:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2645,7 +2678,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb57ca25-f638-4abf-95bc-e033dd453a56
+      - e365a6e0-5a07-415a-ac17-09f929f067fa
     status: 200 OK
     code: 200
     duration: ""
@@ -2654,21 +2687,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/7dfef787-8901-4d2a-be61-d7cf0181b2f7
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/38d069a3-39bb-4451-bdd9-d7e88976dec9
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:51:40.276087Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"7dfef787-8901-4d2a-be61-d7cf0181b2f7","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2023-07-12T09:51:40.276087Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-23T06:49:59.392783Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"38d069a3-39bb-4451-bdd9-d7e88976dec9","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2023-10-23T06:49:59.392783Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "282"
+      - "290"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:42 GMT
+      - Mon, 23 Oct 2023 06:50:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2678,7 +2711,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1249e61-d1c0-47a1-a811-56cf358c9345
+      - 0528315a-e58b-4fcc-97dc-b6852198c2f1
     status: 200 OK
     code: 200
     duration: ""
@@ -2687,21 +2720,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d3f71384-6fc6-44b7-acd4-224a746716f6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/2d37d34b-7e78-4592-b39f-6adb62147e09
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:50:45.592092Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":"02:00:00:13:5D:C5","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"ready","updated_at":"2023-07-12T09:51:40.164705Z","zone":"fr-par-1"}],"id":"d3f71384-6fc6-44b7-acd4-224a746716f6","ip":{"address":"51.158.73.234","created_at":"2023-07-12T09:50:44.935513Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"512a1524-4038-4767-83b2-d3e9f1613898","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"234-73-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:50:44.935513Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:50:53.068180Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-23T06:49:01.203511Z","gateway_networks":[{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":"02:00:00:14:5E:C0","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"ready","updated_at":"2023-10-23T06:49:14.785590Z","zone":"fr-par-1"}],"id":"2d37d34b-7e78-4592-b39f-6adb62147e09","ip":{"address":"51.158.114.104","created_at":"2023-10-23T06:49:00.957190Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"a7332263-ec06-45f0-8553-608b5579a3e3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"104-114-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-23T06:49:00.957190Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-23T06:49:14.933740Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1869"
+      - "1966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:42 GMT
+      - Mon, 23 Oct 2023 06:50:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2711,7 +2744,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1c9c2da-0b13-4172-92e0-06a0828227c6
+      - a03d9002-8387-449d-b385-8bbc36a26b66
     status: 200 OK
     code: 200
     duration: ""
@@ -2720,9 +2753,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/7dfef787-8901-4d2a-be61-d7cf0181b2f7
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/38d069a3-39bb-4451-bdd9-d7e88976dec9
     method: DELETE
   response:
     body: ""
@@ -2732,7 +2765,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:42 GMT
+      - Mon, 23 Oct 2023 06:50:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2742,7 +2775,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd253de0-952a-495a-bb9e-9578861baf14
+      - 59f267af-5fa7-4b84-83c8-f0d233875107
     status: 204 No Content
     code: 204
     duration: ""
@@ -2751,21 +2784,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d3f71384-6fc6-44b7-acd4-224a746716f6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/2d37d34b-7e78-4592-b39f-6adb62147e09
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:50:45.592092Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":"02:00:00:13:5D:C5","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"ready","updated_at":"2023-07-12T09:51:40.164705Z","zone":"fr-par-1"}],"id":"d3f71384-6fc6-44b7-acd4-224a746716f6","ip":{"address":"51.158.73.234","created_at":"2023-07-12T09:50:44.935513Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"512a1524-4038-4767-83b2-d3e9f1613898","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"234-73-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:50:44.935513Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:50:53.068180Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-23T06:49:01.203511Z","gateway_networks":[{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":"02:00:00:14:5E:C0","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"ready","updated_at":"2023-10-23T06:49:14.785590Z","zone":"fr-par-1"}],"id":"2d37d34b-7e78-4592-b39f-6adb62147e09","ip":{"address":"51.158.114.104","created_at":"2023-10-23T06:49:00.957190Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"a7332263-ec06-45f0-8553-608b5579a3e3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"104-114-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-23T06:49:00.957190Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-23T06:49:14.933740Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1869"
+      - "1966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:42 GMT
+      - Mon, 23 Oct 2023 06:50:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2775,7 +2808,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2c13f7f-e33d-48f8-b485-24bf1d7000cc
+      - 4942ea14-4a0e-4b43-8b49-bc55297a8cbf
     status: 200 OK
     code: 200
     duration: ""
@@ -2784,21 +2817,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/11abc7fb-3d2c-482d-9b81-10bfd069b264
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/5eeb3b25-340f-4e06-b10d-1098a45470d8
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":"02:00:00:13:5D:C5","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"ready","updated_at":"2023-07-12T09:51:40.164705Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":"02:00:00:14:5E:C0","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"ready","updated_at":"2023-10-23T06:49:14.785590Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:42 GMT
+      - Mon, 23 Oct 2023 06:50:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2808,7 +2841,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 813e49da-7ca6-4016-8326-c2d9469aca10
+      - 72574bd1-a56e-452a-bf7e-31c326de731b
     status: 200 OK
     code: 200
     duration: ""
@@ -2817,9 +2850,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/7893118c-bf64-40dc-a447-f89797d3ded3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/c298ea6d-288f-4c91-8fbf-7660fb9ca998
     method: DELETE
   response:
     body: ""
@@ -2829,7 +2862,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:42 GMT
+      - Mon, 23 Oct 2023 06:50:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2839,7 +2872,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82585af5-49cc-434d-9df9-f955f1f3f170
+      - 5c1ba544-7fa0-48dc-8e87-3c471b443c6c
     status: 204 No Content
     code: 204
     duration: ""
@@ -2848,21 +2881,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/11abc7fb-3d2c-482d-9b81-10bfd069b264
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/5eeb3b25-340f-4e06-b10d-1098a45470d8
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":"02:00:00:13:5D:C5","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"ready","updated_at":"2023-07-12T09:51:40.164705Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":"02:00:00:14:5E:C0","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"ready","updated_at":"2023-10-23T06:49:14.785590Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:42 GMT
+      - Mon, 23 Oct 2023 06:50:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2872,7 +2905,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2ff8adf-77eb-468c-8cbe-2c6fe5c58ce8
+      - 5d82f913-a0a2-4c36-9968-6c2aacfa1e48
     status: 200 OK
     code: 200
     duration: ""
@@ -2881,21 +2914,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/11abc7fb-3d2c-482d-9b81-10bfd069b264
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/5eeb3b25-340f-4e06-b10d-1098a45470d8
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":"02:00:00:13:5D:C5","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"ready","updated_at":"2023-07-12T09:51:42.753383Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":"02:00:00:14:5E:C0","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"ready","updated_at":"2023-10-23T06:49:14.785590Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:42 GMT
+      - Mon, 23 Oct 2023 06:50:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2905,7 +2938,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 203c0067-1ab5-489d-82f4-4fb26bec1b4a
+      - b7cf62c3-9d23-4ede-a479-c11c195e7310
     status: 200 OK
     code: 200
     duration: ""
@@ -2914,26 +2947,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:50:59.931708+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.226.55","private_nics":[{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:34.591525+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-23T06:49:02.173512+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-wu","id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1402","node_id":"25","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:03:d7","maintenances":[],"modification_date":"2023-10-23T06:49:15.994601+00:00","name":"tf-srv-intelligent-wu","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.54.49","private_nics":[{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:51.552219+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","name":"tf-sg-nostalgic-jang"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-23T06:49:02.173512+00:00","export_uri":null,"id":"76b13f47-0510-4cf0-8f21-ca8a00e26062","modification_date":"2023-10-23T06:49:02.173512+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","name":"tf-srv-intelligent-wu"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3138"
+      - "3158"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:42 GMT
+      - Mon, 23 Oct 2023 06:50:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2943,7 +2976,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e53776fc-c1c3-465b-ab51-b5dfed43c923
+      - 4c2372a2-3d46-4892-b3fa-b4bff7cb5517
     status: 200 OK
     code: 200
     duration: ""
@@ -2952,9 +2985,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/11abc7fb-3d2c-482d-9b81-10bfd069b264?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/5eeb3b25-340f-4e06-b10d-1098a45470d8?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -2964,7 +2997,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:42 GMT
+      - Mon, 23 Oct 2023 06:50:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2974,7 +3007,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba073295-8665-41ca-853e-bc2abb0c6f28
+      - 61b84df5-57eb-4651-b89f-149f6cdb6a01
     status: 204 No Content
     code: 204
     duration: ""
@@ -2983,21 +3016,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/11abc7fb-3d2c-482d-9b81-10bfd069b264
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/5eeb3b25-340f-4e06-b10d-1098a45470d8
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:50:51.230484Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:50:44.263952Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"afc38af2-e533-44c1-8a2a-198ba31e273b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:50:44.263952Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","mac_address":"02:00:00:13:5D:C5","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","status":"detaching","updated_at":"2023-07-12T09:51:42.870128Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-23T06:49:07.693022Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-23T06:49:00.416583Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-23T06:49:00.416583Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","ipam_config":null,"mac_address":"02:00:00:14:5E:C0","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","status":"detaching","updated_at":"2023-10-23T06:50:02.042192Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "951"
+      - "1000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:43 GMT
+      - Mon, 23 Oct 2023 06:50:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3007,7 +3040,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18cb8c64-7d1d-4aba-b28c-732d3c6ecfe3
+      - 82395623-4da9-420b-96ac-c73b64f2ba2e
     status: 200 OK
     code: 200
     duration: ""
@@ -3018,12 +3051,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89/action","href_result":"/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","id":"fce91e7f-1228-4159-ad5c-3b9630d68670","started_at":"2023-07-12T09:51:43.247990+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/action","href_result":"/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5","id":"d1ab1c54-2ee4-42b0-8e08-c6416198e80f","started_at":"2023-10-23T06:50:02.793199+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -3032,9 +3065,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:43 GMT
+      - Mon, 23 Oct 2023 06:50:02 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/fce91e7f-1228-4159-ad5c-3b9630d68670
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/d1ab1c54-2ee4-42b0-8e08-c6416198e80f
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3044,7 +3077,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9e24dd6-62a6-49d1-ae93-7d8676668ddf
+      - 74ee54e8-a040-4274-a95a-31a1f7d7f41a
     status: 202 Accepted
     code: 202
     duration: ""
@@ -3053,26 +3086,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:51:42.870968+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.226.55","private_nics":[{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:34.591525+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-23T06:49:02.173512+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-wu","id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1402","node_id":"25","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:03:d7","maintenances":[],"modification_date":"2023-10-23T06:50:02.079666+00:00","name":"tf-srv-intelligent-wu","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.54.49","private_nics":[{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:51.552219+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","name":"tf-sg-nostalgic-jang"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-23T06:49:02.173512+00:00","export_uri":null,"id":"76b13f47-0510-4cf0-8f21-ca8a00e26062","modification_date":"2023-10-23T06:49:02.173512+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","name":"tf-srv-intelligent-wu"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3106"
+      - "3126"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:43 GMT
+      - Mon, 23 Oct 2023 06:50:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3082,7 +3115,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4dd72a81-ebe1-47a9-9a99-dac10ae5ee33
+      - f6f086e2-2c3e-4040-8e13-a3873ac467e3
     status: 200 OK
     code: 200
     duration: ""
@@ -3091,12 +3124,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/11abc7fb-3d2c-482d-9b81-10bfd069b264
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/5eeb3b25-340f-4e06-b10d-1098a45470d8
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"11abc7fb-3d2c-482d-9b81-10bfd069b264","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"5eeb3b25-340f-4e06-b10d-1098a45470d8","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3105,7 +3138,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:48 GMT
+      - Mon, 23 Oct 2023 06:50:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3115,7 +3148,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ea07f33-02f4-4b5a-a6fd-fd16ec4ec8e6
+      - 11f06432-33fb-49e7-9a79-9a2c0623dfe8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3124,21 +3157,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d3f71384-6fc6-44b7-acd4-224a746716f6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/2d37d34b-7e78-4592-b39f-6adb62147e09
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:50:45.592092Z","gateway_networks":[],"id":"d3f71384-6fc6-44b7-acd4-224a746716f6","ip":{"address":"51.158.73.234","created_at":"2023-07-12T09:50:44.935513Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"512a1524-4038-4767-83b2-d3e9f1613898","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"234-73-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:50:44.935513Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:50:53.068180Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-23T06:49:01.203511Z","gateway_networks":[],"id":"2d37d34b-7e78-4592-b39f-6adb62147e09","ip":{"address":"51.158.114.104","created_at":"2023-10-23T06:49:00.957190Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"a7332263-ec06-45f0-8553-608b5579a3e3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"104-114-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-23T06:49:00.957190Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-23T06:49:14.933740Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "922"
+      - "970"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:48 GMT
+      - Mon, 23 Oct 2023 06:50:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3148,7 +3181,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83c3ddc0-f275-40c1-9dcd-a8d1043cd562
+      - 23362894-2e17-4224-881f-a8debafc927e
     status: 200 OK
     code: 200
     duration: ""
@@ -3157,12 +3190,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/afc38af2-e533-44c1-8a2a-198ba31e273b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/060f8446-d73c-4c83-a8a1-a17a1d32bc17
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"afc38af2-e533-44c1-8a2a-198ba31e273b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3171,7 +3204,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:48 GMT
+      - Mon, 23 Oct 2023 06:50:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3181,7 +3214,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52fca57c-97eb-4b99-8319-36b67ad7579b
+      - 494c8e96-991b-4d38-830c-c92bde95772a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3190,21 +3223,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d3f71384-6fc6-44b7-acd4-224a746716f6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/2d37d34b-7e78-4592-b39f-6adb62147e09
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:50:45.592092Z","gateway_networks":[],"id":"d3f71384-6fc6-44b7-acd4-224a746716f6","ip":{"address":"51.158.73.234","created_at":"2023-07-12T09:50:44.935513Z","gateway_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","id":"512a1524-4038-4767-83b2-d3e9f1613898","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"234-73-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:50:44.935513Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:50:53.068180Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-23T06:49:01.203511Z","gateway_networks":[],"id":"2d37d34b-7e78-4592-b39f-6adb62147e09","ip":{"address":"51.158.114.104","created_at":"2023-10-23T06:49:00.957190Z","gateway_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","id":"a7332263-ec06-45f0-8553-608b5579a3e3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"104-114-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-23T06:49:00.957190Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-23T06:49:14.933740Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "922"
+      - "970"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:48 GMT
+      - Mon, 23 Oct 2023 06:50:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3214,7 +3247,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2af3779-8d42-4d9c-a639-7f097f5709cd
+      - 0fd06948-486c-4ec8-855d-cc67b37c5eba
     status: 200 OK
     code: 200
     duration: ""
@@ -3223,9 +3256,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d3f71384-6fc6-44b7-acd4-224a746716f6?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/2d37d34b-7e78-4592-b39f-6adb62147e09?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -3235,7 +3268,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:48 GMT
+      - Mon, 23 Oct 2023 06:50:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3245,7 +3278,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef9ad42f-8540-4fbe-b50a-94340e2967df
+      - fb8aa760-32fb-403a-a8fa-639e3c9d9549
     status: 204 No Content
     code: 204
     duration: ""
@@ -3254,12 +3287,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d3f71384-6fc6-44b7-acd4-224a746716f6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/2d37d34b-7e78-4592-b39f-6adb62147e09
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"d3f71384-6fc6-44b7-acd4-224a746716f6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"2d37d34b-7e78-4592-b39f-6adb62147e09","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3268,7 +3301,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:48 GMT
+      - Mon, 23 Oct 2023 06:50:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3278,7 +3311,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c98d3525-f63a-47f5-b844-3695e8f6460f
+      - 33865642-47f8-4e21-91cb-7b67121928c1
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3287,47 +3320,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:51:42.870968+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.226.55","private_nics":[{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:34.591525+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3106"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:51:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f049df34-72e3-4fdd-a76a-0446cdfe60a6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/512a1524-4038-4767-83b2-d3e9f1613898
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/a7332263-ec06-45f0-8553-608b5579a3e3
     method: DELETE
   response:
     body: ""
@@ -3337,7 +3332,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:48 GMT
+      - Mon, 23 Oct 2023 06:50:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3347,7 +3342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34e74056-a67a-4350-8d05-8f03ee487946
+      - 4ccf79a2-4f1b-493a-95bd-1e72d853fef1
     status: 204 No Content
     code: 204
     duration: ""
@@ -3356,26 +3351,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:51:42.870968+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.226.55","private_nics":[{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:34.591525+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-23T06:49:02.173512+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-wu","id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1402","node_id":"25","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:03:d7","maintenances":[],"modification_date":"2023-10-23T06:50:02.079666+00:00","name":"tf-srv-intelligent-wu","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.54.49","private_nics":[{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:51.552219+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","name":"tf-sg-nostalgic-jang"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-23T06:49:02.173512+00:00","export_uri":null,"id":"76b13f47-0510-4cf0-8f21-ca8a00e26062","modification_date":"2023-10-23T06:49:02.173512+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","name":"tf-srv-intelligent-wu"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3106"
+      - "3126"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:53 GMT
+      - Mon, 23 Oct 2023 06:50:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3385,7 +3380,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25859363-f75a-40e0-b2c7-a9305908af2f
+      - 79e2897b-fac3-45ed-87c5-5e9cb9b19515
     status: 200 OK
     code: 200
     duration: ""
@@ -3394,26 +3389,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:51:42.870968+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.226.55","private_nics":[{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:34.591525+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-23T06:49:02.173512+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-wu","id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1402","node_id":"25","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:03:d7","maintenances":[],"modification_date":"2023-10-23T06:50:02.079666+00:00","name":"tf-srv-intelligent-wu","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.54.49","private_nics":[{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:51.552219+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","name":"tf-sg-nostalgic-jang"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-23T06:49:02.173512+00:00","export_uri":null,"id":"76b13f47-0510-4cf0-8f21-ca8a00e26062","modification_date":"2023-10-23T06:49:02.173512+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","name":"tf-srv-intelligent-wu"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3106"
+      - "3126"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:51:58 GMT
+      - Mon, 23 Oct 2023 06:50:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3423,7 +3418,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09d2d1be-d7da-4da4-a362-cef12a45ff64
+      - a279a341-3fe3-4aaa-9864-9409dfd5efc2
     status: 200 OK
     code: 200
     duration: ""
@@ -3432,26 +3427,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:51:42.870968+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.226.55","private_nics":[{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:34.591525+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-23T06:49:02.173512+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-wu","id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1402","node_id":"25","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:03:d7","maintenances":[],"modification_date":"2023-10-23T06:50:02.079666+00:00","name":"tf-srv-intelligent-wu","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.54.49","private_nics":[{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:51.552219+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","name":"tf-sg-nostalgic-jang"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-23T06:49:02.173512+00:00","export_uri":null,"id":"76b13f47-0510-4cf0-8f21-ca8a00e26062","modification_date":"2023-10-23T06:49:02.173512+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","name":"tf-srv-intelligent-wu"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3106"
+      - "3126"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:52:03 GMT
+      - Mon, 23 Oct 2023 06:50:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3461,7 +3456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a376ec8-f968-43f4-ba49-3fa19a52144d
+      - 03f9d1d5-fdd7-42e1-bedf-f77324109d7e
     status: 200 OK
     code: 200
     duration: ""
@@ -3470,26 +3465,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:51:42.870968+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.226.55","private_nics":[{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:34.591525+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-23T06:49:02.173512+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-wu","id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1402","node_id":"25","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:03:d7","maintenances":[],"modification_date":"2023-10-23T06:50:02.079666+00:00","name":"tf-srv-intelligent-wu","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.54.49","private_nics":[{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:51.552219+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","name":"tf-sg-nostalgic-jang"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-23T06:49:02.173512+00:00","export_uri":null,"id":"76b13f47-0510-4cf0-8f21-ca8a00e26062","modification_date":"2023-10-23T06:49:02.173512+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","name":"tf-srv-intelligent-wu"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3106"
+      - "3126"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:52:09 GMT
+      - Mon, 23 Oct 2023 06:50:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3499,7 +3494,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb59f7f3-d197-4adc-84fc-e4735773efac
+      - 8281a629-4ce0-4ebd-86d2-06af64b6b5bc
     status: 200 OK
     code: 200
     duration: ""
@@ -3508,26 +3503,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:51:42.870968+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.226.55","private_nics":[{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:34.591525+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-23T06:49:02.173512+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-wu","id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1402","node_id":"25","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:03:d7","maintenances":[],"modification_date":"2023-10-23T06:50:02.079666+00:00","name":"tf-srv-intelligent-wu","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.54.49","private_nics":[{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:51.552219+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","name":"tf-sg-nostalgic-jang"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-23T06:49:02.173512+00:00","export_uri":null,"id":"76b13f47-0510-4cf0-8f21-ca8a00e26062","modification_date":"2023-10-23T06:49:02.173512+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","name":"tf-srv-intelligent-wu"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3106"
+      - "3126"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:52:14 GMT
+      - Mon, 23 Oct 2023 06:50:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3537,7 +3532,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea55afaa-5cc3-43ea-9d9b-cfd91a6e3186
+      - 8a7bdfab-6273-4f84-8535-3c6a7d3be7e5
     status: 200 OK
     code: 200
     duration: ""
@@ -3546,26 +3541,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:51:42.870968+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.226.55","private_nics":[{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:34.591525+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-23T06:49:02.173512+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-wu","id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:03:d7","maintenances":[],"modification_date":"2023-10-23T06:50:32.452682+00:00","name":"tf-srv-intelligent-wu","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:51.552219+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","name":"tf-sg-nostalgic-jang"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-23T06:49:02.173512+00:00","export_uri":null,"id":"76b13f47-0510-4cf0-8f21-ca8a00e26062","modification_date":"2023-10-23T06:49:02.173512+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","name":"tf-srv-intelligent-wu"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3106"
+      - "3004"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:52:19 GMT
+      - Mon, 23 Oct 2023 06:50:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3575,7 +3570,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 802978f7-2bc8-4caf-ba6a-25d649c9decf
+      - 4a129a87-a7bd-4e45-9455-4d34c2c1763b
     status: 200 OK
     code: 200
     duration: ""
@@ -3584,26 +3579,24 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/private_nics
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:51:42.870968+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.226.55","private_nics":[{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:34.591525+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    body: '{"private_nics":[{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:51.552219+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
-      - "3106"
+      - "381"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:52:24 GMT
+      - Mon, 23 Oct 2023 06:50:34 GMT
+      Link:
+      - </servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/private_nics?page=1&per_page=50&>;
+        rel="last"
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3613,7 +3606,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ffb49a21-2514-48cc-8548-25efbcf32842
+      - 9f75c79b-99a3-441c-8629-7bf490dbd76b
+      X-Total-Count:
+      - "1"
     status: 200 OK
     code: 200
     duration: ""
@@ -3622,26 +3617,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/private_nics/c20a2ee0-5a33-4dca-8c27-99737557de8b
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:52:27.654782+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:34.591525+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-23T06:49:20.076461+00:00","id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","mac_address":"02:00:00:14:5e:c1","modification_date":"2023-10-23T06:49:51.552219+00:00","private_network_id":"41c8b3b2-3199-44a5-a72c-b542c635bf8f","server_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2983"
+      - "378"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:52:29 GMT
+      - Mon, 23 Oct 2023 06:50:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3651,7 +3641,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd1a8691-77d1-4f09-a68f-713c705b3598
+      - cd8b4f46-5bc9-414c-8874-3d2adff0b212
     status: 200 OK
     code: 200
     duration: ""
@@ -3660,47 +3650,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:50:46.113408+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-stoic-cannon","id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:57","maintenances":[],"modification_date":"2023-07-12T09:52:27.654782+00:00","name":"tf-srv-stoic-cannon","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-07-12T09:51:03.162990+00:00","id":"f8655da0-7f20-44f8-b0e2-62cba3f12203","mac_address":"02:00:00:13:5d:c6","modification_date":"2023-07-12T09:51:34.591525+00:00","private_network_id":"dafdd01e-9ac9-4392-86f3-0eea52ec4160","server_id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"c2db90cd-d287-4829-88fb-01dcadfa069a","name":"tf-sg-crazy-proskuriakova"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:50:46.113408+00:00","export_uri":null,"id":"b0957a27-6da1-487d-a9ca-639ea037d153","modification_date":"2023-07-12T09:50:46.113408+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89","name":"tf-srv-stoic-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2983"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:52:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c9f711ce-39ca-423f-bc2c-27e319918a8b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/private_nics/c20a2ee0-5a33-4dca-8c27-99737557de8b
     method: DELETE
   response:
     body: ""
@@ -3708,7 +3660,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Wed, 12 Jul 2023 09:52:30 GMT
+      - Mon, 23 Oct 2023 06:50:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3718,7 +3670,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5119da43-9b0f-44c5-8a4e-d8de46c5dbb7
+      - 68d549ec-abd0-4fd0-b79e-0fd12a696b8d
     status: 204 No Content
     code: 204
     duration: ""
@@ -3727,21 +3679,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5/private_nics/c20a2ee0-5a33-4dca-8c27-99737557de8b
     method: GET
   response:
-    body: '{"message":"\"c0e5b3e7-6fe4-4a10-8d22-8d30091a9b89\" not found","type":"unknown_resource"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"c20a2ee0-5a33-4dca-8c27-99737557de8b","type":"not_found"}'
     headers:
       Content-Length:
-      - "93"
+      - "148"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:52:30 GMT
+      - Mon, 23 Oct 2023 06:50:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3751,7 +3703,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0cfd7fc4-8c00-4719-9ffe-53d52de2f47f
+      - 83cb6dc6-57c2-4545-a809-1bd891ae961c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3760,17 +3712,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b0957a27-6da1-487d-a9ca-639ea037d153
-    method: DELETE
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5
+    method: GET
   response:
-    body: ""
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-23T06:49:02.173512+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-wu","id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:03:d7","maintenances":[],"modification_date":"2023-10-23T06:50:32.452682+00:00","name":"tf-srv-intelligent-wu","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"fa78263d-512e-45c9-aba0-3e6aa6e527be","name":"tf-sg-nostalgic-jang"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-23T06:49:02.173512+00:00","export_uri":null,"id":"76b13f47-0510-4cf0-8f21-ca8a00e26062","modification_date":"2023-10-23T06:49:02.173512+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","name":"tf-srv-intelligent-wu"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
+      Content-Length:
+      - "2643"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
       Date:
-      - Wed, 12 Jul 2023 09:52:30 GMT
+      - Mon, 23 Oct 2023 06:50:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3780,18 +3741,18 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e4a4f71-be59-4644-8ccd-ffba61508a1d
-    status: 204 No Content
-    code: 204
+      - 76f18427-1625-43c8-bb25-b1f22f616885
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/c2db90cd-d287-4829-88fb-01dcadfa069a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5
     method: DELETE
   response:
     body: ""
@@ -3799,7 +3760,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Wed, 12 Jul 2023 09:52:30 GMT
+      - Mon, 23 Oct 2023 06:50:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3809,7 +3770,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 888d49eb-0445-4649-a3c1-6d2b12a1fe2d
+      - 4d99a392-b24f-4777-9703-6ab2e2e26d53
     status: 204 No Content
     code: 204
     duration: ""
@@ -3818,9 +3779,100 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dafdd01e-9ac9-4392-86f3-0eea52ec4160
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7c290b6b-39e7-4be4-b311-4ff4a19de4c5
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"7c290b6b-39e7-4be4-b311-4ff4a19de4c5","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 23 Oct 2023 06:50:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a37928d9-1373-4cbb-8a66-39a657f017ac
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/76b13f47-0510-4cf0-8f21-ca8a00e26062
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Mon, 23 Oct 2023 06:50:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fb0a8b2f-eb53-4b4b-99b2-3f36ec227100
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/fa78263d-512e-45c9-aba0-3e6aa6e527be
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Mon, 23 Oct 2023 06:50:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dadf4771-8dbc-4c5f-bd54-b4674e90fec0
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/41c8b3b2-3199-44a5-a72c-b542c635bf8f
     method: DELETE
   response:
     body: ""
@@ -3830,7 +3882,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:52:30 GMT
+      - Mon, 23 Oct 2023 06:50:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3840,7 +3892,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0529cf57-2646-4c7e-a8b8-5a57b252fb07
+      - d5a3da83-18ba-4006-8c61-fa91511dab53
     status: 204 No Content
     code: 204
     duration: ""
@@ -3849,12 +3901,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/afc38af2-e533-44c1-8a2a-198ba31e273b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/060f8446-d73c-4c83-a8a1-a17a1d32bc17
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"afc38af2-e533-44c1-8a2a-198ba31e273b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"060f8446-d73c-4c83-a8a1-a17a1d32bc17","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3863,7 +3915,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:52:30 GMT
+      - Mon, 23 Oct 2023 06:50:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3873,7 +3925,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3824bab-2610-4001-83e6-6c744b3b69fb
+      - 4f1f52ac-de67-4e79-b399-1cef492f26e8
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/instance-server-private-network.cassette.yaml
+++ b/scaleway/testdata/instance-server-private-network.cassette.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"private_network_instance","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"private_network_instance","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null,"vpc_id":null}'
     form: {}
     headers:
       Content-Type:
@@ -13,7 +13,7 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-18T08:55:55.577432Z","dhcp_enabled":true,"id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","name":"private_network_instance","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","subnets":[{"created_at":"2023-10-18T08:55:55.577432Z","id":"10ec72c6-a185-4541-9453-700ea6026b82","subnet":"172.16.24.0/22","updated_at":"2023-10-18T08:55:55.577432Z"},{"created_at":"2023-10-18T08:55:55.577432Z","id":"39ec4216-9858-4945-838d-36e63d0e5049","subnet":"fd4a:c18e:554d:d253::/64","updated_at":"2023-10-18T08:55:55.577432Z"}],"tags":[],"updated_at":"2023-10-18T08:55:55.577432Z","vpc_id":"53e50f63-f6c0-44f7-8576-d6edcb965d9c"}'
+    body: '{"created_at":"2023-10-20T13:46:54.037849Z","dhcp_enabled":true,"id":"53b3457b-4f5f-440a-ac83-2659edfd0347","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:46:54.037849Z","id":"6b296a55-4d4e-4b62-be14-60b113a92ffd","subnet":"172.16.92.0/22","updated_at":"2023-10-20T13:46:54.037849Z"},{"created_at":"2023-10-20T13:46:54.037849Z","id":"21b82cbf-0071-490f-9f5c-b19ecbc45038","subnet":"fd5f:519c:6d46:8a45::/64","updated_at":"2023-10-20T13:46:54.037849Z"}],"tags":[],"updated_at":"2023-10-20T13:46:54.037849Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "725"
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:55:56 GMT
+      - Fri, 20 Oct 2023 13:46:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ae47f7a-f0c5-4728-8650-097aea10a57b
+      - fa9c1941-fdd1-47f6-80d6-6f18bb42d69b
     status: 200 OK
     code: 200
     duration: ""
@@ -43,10 +43,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4f08b9a2-5513-44d7-a56b-4a471cdb85e9
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/53b3457b-4f5f-440a-ac83-2659edfd0347
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T08:55:55.577432Z","dhcp_enabled":true,"id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","name":"private_network_instance","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","subnets":[{"created_at":"2023-10-18T08:55:55.577432Z","id":"10ec72c6-a185-4541-9453-700ea6026b82","subnet":"172.16.24.0/22","updated_at":"2023-10-18T08:55:55.577432Z"},{"created_at":"2023-10-18T08:55:55.577432Z","id":"39ec4216-9858-4945-838d-36e63d0e5049","subnet":"fd4a:c18e:554d:d253::/64","updated_at":"2023-10-18T08:55:55.577432Z"}],"tags":[],"updated_at":"2023-10-18T08:55:55.577432Z","vpc_id":"53e50f63-f6c0-44f7-8576-d6edcb965d9c"}'
+    body: '{"created_at":"2023-10-20T13:46:54.037849Z","dhcp_enabled":true,"id":"53b3457b-4f5f-440a-ac83-2659edfd0347","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:46:54.037849Z","id":"6b296a55-4d4e-4b62-be14-60b113a92ffd","subnet":"172.16.92.0/22","updated_at":"2023-10-20T13:46:54.037849Z"},{"created_at":"2023-10-20T13:46:54.037849Z","id":"21b82cbf-0071-490f-9f5c-b19ecbc45038","subnet":"fd5f:519c:6d46:8a45::/64","updated_at":"2023-10-20T13:46:54.037849Z"}],"tags":[],"updated_at":"2023-10-20T13:46:54.037849Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "725"
@@ -55,7 +55,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:55:56 GMT
+      - Fri, 20 Oct 2023 13:46:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62eae9eb-b031-4739-9b58-09c6529628a5
+      - 393e7fe0-6436-4138-bba2-28e8b62b4409
     status: 200 OK
     code: 200
     duration: ""
@@ -88,7 +88,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:55:56 GMT
+      - Fri, 20 Oct 2023 13:46:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b160571f-43c8-4a19-a220-7035b9081807
+      - 4672d032-2d1f-476b-ac37-0f94d588f02b
     status: 200 OK
     code: 200
     duration: ""
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:55:56 GMT
+      - Fri, 20 Oct 2023 13:46:54 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
@@ -134,7 +134,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1737a4f4-e94b-4a9b-90ad-0be76397a414
+      - 7cdc4f5c-c2da-46af-84ac-0283531b15c5
       X-Total-Count:
       - "54"
     status: 200 OK
@@ -159,7 +159,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:55:56 GMT
+      - Fri, 20 Oct 2023 13:46:55 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
@@ -172,14 +172,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c3fd202-c229-4403-b794-8b1f78fb0aa7
+      - bc3057ea-c2e1-418b-9813-05b4fd3ec229
       X-Total-Count:
       - "54"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-srv-clever-feistel","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b"}'
+    body: '{"name":"tf-srv-great-newton","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
@@ -192,22 +192,22 @@ interactions:
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:55:56.881606+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":null,"private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:46:55.449727+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "2645"
+      - "2639"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:55:57 GMT
+      - Fri, 20 Oct 2023 13:46:55 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+      - https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -217,7 +217,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22a68f37-be68-440f-9f67-4dea685a187f
+      - 2e1fb0c4-869d-4222-8047-25b1d6d8bb24
     status: 201 Created
     code: 201
     duration: ""
@@ -228,25 +228,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:55:56.881606+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":null,"private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:46:55.449727+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "2645"
+      - "2639"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:55:57 GMT
+      - Fri, 20 Oct 2023 13:46:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -256,7 +256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fe40ac9-91db-45c3-a5ef-b6ddda0c39d2
+      - 5bd735ac-2037-47cb-ad17-7bdcbf688ad4
     status: 200 OK
     code: 200
     duration: ""
@@ -267,25 +267,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:55:56.881606+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":null,"private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:46:55.449727+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "2645"
+      - "2639"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:55:57 GMT
+      - Fri, 20 Oct 2023 13:46:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -295,7 +295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1b5699f-eef2-448c-8cbf-70fb02b76955
+      - 956918ad-436d-49ce-a267-1997e20db69c
     status: 200 OK
     code: 200
     duration: ""
@@ -308,10 +308,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/action","href_result":"/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb","id":"ff9a57cf-ba27-4efb-a953-a6243c018db1","started_at":"2023-10-18T08:55:58.328792+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/action","href_result":"/servers/beef1307-ffb4-454e-9911-1b9a4a827e97","id":"7c6f3346-1ef5-45f7-b1a5-4d8c57cfac8d","started_at":"2023-10-20T13:46:56.915203+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -320,9 +320,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:55:58 GMT
+      - Fri, 20 Oct 2023 13:46:56 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-2/tasks/ff9a57cf-ba27-4efb-a953-a6243c018db1
+      - https://api.scaleway.com/instance/v1/zones/fr-par-2/tasks/7c6f3346-1ef5-45f7-b1a5-4d8c57cfac8d
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -332,7 +332,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2bfcef94-8e45-48b4-be29-fac28a29c002
+      - 4ced567c-a53a-4f8a-8968-c8f7e77cd669
     status: 202 Accepted
     code: 202
     duration: ""
@@ -343,25 +343,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:55:57.749705+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":null,"private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:46:56.285452+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "2667"
+      - "2661"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:55:58 GMT
+      - Fri, 20 Oct 2023 13:46:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -371,7 +371,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f24815e-dca2-4e29-b093-2f39678ce689
+      - 543a6ccc-453c-446a-a02c-8aeef8c3738e
     status: 200 OK
     code: 200
     duration: ""
@@ -382,25 +382,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"49","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:55:57.749705+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.200.164.97","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"19","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:46:56.285452+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.200.0.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "2781"
+      - "2772"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:03 GMT
+      - Fri, 20 Oct 2023 13:47:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -410,7 +410,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b49263cb-dcc3-4ba2-afcb-7a502f06a5dc
+      - 52c474cc-08de-4b8c-ac12-ffe8e82476c1
     status: 200 OK
     code: 200
     duration: ""
@@ -421,25 +421,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"49","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:55:57.749705+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.200.164.97","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"19","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:46:56.285452+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.200.0.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "2781"
+      - "2772"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:09 GMT
+      - Fri, 20 Oct 2023 13:47:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -449,7 +449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb13503f-0fbc-4a1f-af4d-1690042a4f8f
+      - 6310ba89-fa7c-4f42-b84a-d3fa8e4018e4
     status: 200 OK
     code: 200
     duration: ""
@@ -460,25 +460,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"49","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:56:11.156892+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.200.164.97","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"19","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:47:07.812594+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.200.0.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "2812"
+      - "2803"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:14 GMT
+      - Fri, 20 Oct 2023 13:47:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -488,7 +488,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78d26b6b-7688-4a26-96b4-5a99e00d716e
+      - d8b3153c-1525-4938-aace-c63bb40cc3a5
     status: 200 OK
     code: 200
     duration: ""
@@ -499,10 +499,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/fr-par-2/private-networks/4f08b9a2-5513-44d7-a56b-4a471cdb85e9
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-2/private-networks/53b3457b-4f5f-440a-ac83-2659edfd0347
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T08:55:55.577432Z","id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","name":"private_network_instance","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":["172.16.24.0/22","fd4a:c18e:554d:d253::/64"],"tags":[],"updated_at":"2023-10-18T08:55:55.577432Z","zone":"fr-par-2"}'
+    body: '{"created_at":"2023-10-20T13:46:54.037849Z","id":"53b3457b-4f5f-440a-ac83-2659edfd0347","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnets":["172.16.92.0/22","fd5f:519c:6d46:8a45::/64"],"tags":[],"updated_at":"2023-10-20T13:46:54.037849Z","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "367"
@@ -511,7 +511,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:14 GMT
+      - Fri, 20 Oct 2023 13:47:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -521,7 +521,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91ad51ed-63af-4de9-a3b1-f49d8b921a55
+      - 1f8bf1e4-3184-4c44-ac63-cb0ff1d77d96
     status: 200 OK
     code: 200
     duration: ""
@@ -532,25 +532,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"49","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:56:11.156892+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.200.164.97","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"19","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:47:07.812594+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.200.0.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "2812"
+      - "2803"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:14 GMT
+      - Fri, 20 Oct 2023 13:47:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -560,12 +560,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d131c10-cb2b-4177-baff-07986e2c40e4
+      - 41ef9add-99d1-44a2-bde3-122c59a8921d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9"}'
+    body: '{"private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347"}'
     form: {}
     headers:
       Content-Type:
@@ -573,10 +573,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:14.531206+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:13.166510+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"syncing","tags":[],"zone":"fr-par-2"}}'
     headers:
       Content-Length:
       - "376"
@@ -585,7 +585,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:15 GMT
+      - Fri, 20 Oct 2023 13:47:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -595,7 +595,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2718b580-8674-4ffc-8598-e7bb5d61175e
+      - 371e21b5-ae0e-4bd3-8030-6c0a82e826ff
     status: 201 Created
     code: 201
     duration: ""
@@ -606,10 +606,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/private_nics/8abf0d74-02d8-42e3-9baf-2557987a1739
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics/a9c3927d-9675-46ad-a002-6e82eaf30708
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:14.531206+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:13.166510+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"syncing","tags":[],"zone":"fr-par-2"}}'
     headers:
       Content-Length:
       - "376"
@@ -618,7 +618,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:15 GMT
+      - Fri, 20 Oct 2023 13:47:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -628,7 +628,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06d8acab-581c-4e01-adad-67fb4fef4e89
+      - a139cc81-ec1b-472a-bad8-5490e0fe5ab7
     status: 200 OK
     code: 200
     duration: ""
@@ -639,10 +639,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/private_nics/8abf0d74-02d8-42e3-9baf-2557987a1739
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics/a9c3927d-9675-46ad-a002-6e82eaf30708
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:15.739996+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:14.210822+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"syncing","tags":[],"zone":"fr-par-2"}}'
     headers:
       Content-Length:
       - "376"
@@ -651,7 +651,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:20 GMT
+      - Fri, 20 Oct 2023 13:47:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -661,7 +661,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc196e43-556c-4e02-835e-d7ee7bacd6a2
+      - 8f2d639e-2321-4503-89d8-bffec133a697
     status: 200 OK
     code: 200
     duration: ""
@@ -672,10 +672,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/private_nics/8abf0d74-02d8-42e3-9baf-2557987a1739
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics/a9c3927d-9675-46ad-a002-6e82eaf30708
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:15.739996+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:14.210822+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"syncing","tags":[],"zone":"fr-par-2"}}'
     headers:
       Content-Length:
       - "376"
@@ -684,7 +684,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:25 GMT
+      - Fri, 20 Oct 2023 13:47:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -694,7 +694,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57c4d532-77ab-49f6-bdf7-f20dcee9d81f
+      - 1a57b798-6d28-4266-81c2-97b1147899af
     status: 200 OK
     code: 200
     duration: ""
@@ -705,10 +705,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/private_nics/8abf0d74-02d8-42e3-9baf-2557987a1739
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics/a9c3927d-9675-46ad-a002-6e82eaf30708
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:15.739996+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:14.210822+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"syncing","tags":[],"zone":"fr-par-2"}}'
     headers:
       Content-Length:
       - "376"
@@ -717,7 +717,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:30 GMT
+      - Fri, 20 Oct 2023 13:47:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -727,7 +727,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d910c08-abe9-4b42-b0aa-04ac6d1d4aa7
+      - 922a2462-6b29-4431-a0af-4b68e5c25ef4
     status: 200 OK
     code: 200
     duration: ""
@@ -738,10 +738,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/private_nics/8abf0d74-02d8-42e3-9baf-2557987a1739
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics/a9c3927d-9675-46ad-a002-6e82eaf30708
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:15.739996+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:14.210822+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"syncing","tags":[],"zone":"fr-par-2"}}'
     headers:
       Content-Length:
       - "376"
@@ -750,7 +750,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:35 GMT
+      - Fri, 20 Oct 2023 13:47:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -760,7 +760,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a55b702e-ff7e-4671-8e41-11fd47da8322
+      - e73f9eff-904c-428f-92a1-eceb09d26c8d
     status: 200 OK
     code: 200
     duration: ""
@@ -771,10 +771,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/private_nics/8abf0d74-02d8-42e3-9baf-2557987a1739
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics/a9c3927d-9675-46ad-a002-6e82eaf30708
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:15.739996+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:14.210822+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"syncing","tags":[],"zone":"fr-par-2"}}'
     headers:
       Content-Length:
       - "376"
@@ -783,7 +783,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:41 GMT
+      - Fri, 20 Oct 2023 13:47:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -793,7 +793,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5694fef-08a2-431b-8c3f-2323d59c153b
+      - e677ee39-3730-40c5-8dfb-760f47b22a31
     status: 200 OK
     code: 200
     duration: ""
@@ -804,10 +804,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/private_nics/8abf0d74-02d8-42e3-9baf-2557987a1739
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics/a9c3927d-9675-46ad-a002-6e82eaf30708
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:46.086489+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"available","tags":[],"zone":"fr-par-2"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:44.382091+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"available","tags":[],"zone":"fr-par-2"}}'
     headers:
       Content-Length:
       - "378"
@@ -816,7 +816,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:46 GMT
+      - Fri, 20 Oct 2023 13:47:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -826,7 +826,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae914464-c3e7-4c46-a8dd-7ba28d3bd229
+      - d8917fea-d48d-4f9b-91d3-1304b0667f72
     status: 200 OK
     code: 200
     duration: ""
@@ -837,10 +837,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/private_nics/8abf0d74-02d8-42e3-9baf-2557987a1739
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics/a9c3927d-9675-46ad-a002-6e82eaf30708
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:46.086489+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"available","tags":[],"zone":"fr-par-2"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:44.382091+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"available","tags":[],"zone":"fr-par-2"}}'
     headers:
       Content-Length:
       - "378"
@@ -849,7 +849,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:46 GMT
+      - Fri, 20 Oct 2023 13:47:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -859,7 +859,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4c1d022-61ea-4f0f-8ce0-6bbe2bcb5077
+      - 46ac78ca-7192-4f5c-95c4-c1a3ae3d680e
     status: 200 OK
     code: 200
     duration: ""
@@ -870,25 +870,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"49","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:56:11.156892+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.200.164.97","private_nics":[{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:46.086489+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"available","tags":[],"zone":"fr-par-2"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"19","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:47:07.812594+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.200.0.37","private_nics":[{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:44.382091+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "3165"
+      - "3156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:46 GMT
+      - Fri, 20 Oct 2023 13:47:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d270338-2ef4-49b3-94c5-f506e5859dfe
+      - 09f07e15-a79a-41e2-b1b5-0cdebc9997d5
     status: 200 OK
     code: 200
     duration: ""
@@ -909,7 +909,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -921,7 +921,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:46 GMT
+      - Fri, 20 Oct 2023 13:47:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 028e5aee-9a4f-4bc5-b073-ca5d451e577d
+      - 30ed8eaa-e785-497d-ac05-c2e03fb1d308
     status: 200 OK
     code: 200
     duration: ""
@@ -942,10 +942,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:46.086489+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"available","tags":[],"zone":"fr-par-2"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:44.382091+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"available","tags":[],"zone":"fr-par-2"}]}'
     headers:
       Content-Length:
       - "381"
@@ -954,9 +954,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:46 GMT
+      - Fri, 20 Oct 2023 13:47:44 GMT
       Link:
-      - </servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/private_nics?page=1&per_page=50&>;
+      - </servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -967,7 +967,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 390a1d5c-d249-4263-a42b-b86131ff8858
+      - 30677a3c-09f4-403d-ac93-f68320248e46
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -980,10 +980,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:46.086489+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"available","tags":[],"zone":"fr-par-2"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:44.382091+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"available","tags":[],"zone":"fr-par-2"}]}'
     headers:
       Content-Length:
       - "381"
@@ -992,9 +992,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:46 GMT
+      - Fri, 20 Oct 2023 13:47:45 GMT
       Link:
-      - </servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/private_nics?page=1&per_page=50&>;
+      - </servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -1005,7 +1005,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8bd1651-84e3-4118-aa5d-ce89bab63e9b
+      - ce191148-4bc7-45cd-a411-29f03d3102e9
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -1018,10 +1018,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4f08b9a2-5513-44d7-a56b-4a471cdb85e9
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/53b3457b-4f5f-440a-ac83-2659edfd0347
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T08:55:55.577432Z","dhcp_enabled":true,"id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","name":"private_network_instance","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","subnets":[{"created_at":"2023-10-18T08:55:55.577432Z","id":"10ec72c6-a185-4541-9453-700ea6026b82","subnet":"172.16.24.0/22","updated_at":"2023-10-18T08:55:55.577432Z"},{"created_at":"2023-10-18T08:55:55.577432Z","id":"39ec4216-9858-4945-838d-36e63d0e5049","subnet":"fd4a:c18e:554d:d253::/64","updated_at":"2023-10-18T08:55:55.577432Z"}],"tags":[],"updated_at":"2023-10-18T08:55:55.577432Z","vpc_id":"53e50f63-f6c0-44f7-8576-d6edcb965d9c"}'
+    body: '{"created_at":"2023-10-20T13:46:54.037849Z","dhcp_enabled":true,"id":"53b3457b-4f5f-440a-ac83-2659edfd0347","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:46:54.037849Z","id":"6b296a55-4d4e-4b62-be14-60b113a92ffd","subnet":"172.16.92.0/22","updated_at":"2023-10-20T13:46:54.037849Z"},{"created_at":"2023-10-20T13:46:54.037849Z","id":"21b82cbf-0071-490f-9f5c-b19ecbc45038","subnet":"fd5f:519c:6d46:8a45::/64","updated_at":"2023-10-20T13:46:54.037849Z"}],"tags":[],"updated_at":"2023-10-20T13:46:54.037849Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "725"
@@ -1030,7 +1030,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:47 GMT
+      - Fri, 20 Oct 2023 13:47:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1040,7 +1040,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ad356b6-cba8-4f60-8e47-08036a2d482c
+      - 2aa0865e-7a13-40d8-b288-faf79c0572ba
     status: 200 OK
     code: 200
     duration: ""
@@ -1051,25 +1051,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"49","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:56:11.156892+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.200.164.97","private_nics":[{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:46.086489+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"available","tags":[],"zone":"fr-par-2"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"19","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:47:07.812594+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.200.0.37","private_nics":[{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:44.382091+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "3165"
+      - "3156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:47 GMT
+      - Fri, 20 Oct 2023 13:47:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1079,7 +1079,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2522f6ea-c990-49a8-bc55-50dc7347106f
+      - 3b1a22ed-087e-49a5-8f3d-b969ddf215df
     status: 200 OK
     code: 200
     duration: ""
@@ -1090,7 +1090,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1102,7 +1102,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:47 GMT
+      - Fri, 20 Oct 2023 13:47:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1112,7 +1112,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01d7b9ef-787a-48b3-b1c1-831287bdd05a
+      - 40ea7248-0657-4336-8eed-8c407e0876d7
     status: 200 OK
     code: 200
     duration: ""
@@ -1123,10 +1123,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:46.086489+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"available","tags":[],"zone":"fr-par-2"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:44.382091+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"available","tags":[],"zone":"fr-par-2"}]}'
     headers:
       Content-Length:
       - "381"
@@ -1135,9 +1135,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:47 GMT
+      - Fri, 20 Oct 2023 13:47:45 GMT
       Link:
-      - </servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/private_nics?page=1&per_page=50&>;
+      - </servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -1148,7 +1148,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 464012e5-a0de-48db-9432-663dee5bc30c
+      - 74c52d30-5eb6-464c-a9ca-b645e5873d16
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -1161,10 +1161,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4f08b9a2-5513-44d7-a56b-4a471cdb85e9
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/53b3457b-4f5f-440a-ac83-2659edfd0347
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T08:55:55.577432Z","dhcp_enabled":true,"id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","name":"private_network_instance","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","subnets":[{"created_at":"2023-10-18T08:55:55.577432Z","id":"10ec72c6-a185-4541-9453-700ea6026b82","subnet":"172.16.24.0/22","updated_at":"2023-10-18T08:55:55.577432Z"},{"created_at":"2023-10-18T08:55:55.577432Z","id":"39ec4216-9858-4945-838d-36e63d0e5049","subnet":"fd4a:c18e:554d:d253::/64","updated_at":"2023-10-18T08:55:55.577432Z"}],"tags":[],"updated_at":"2023-10-18T08:55:55.577432Z","vpc_id":"53e50f63-f6c0-44f7-8576-d6edcb965d9c"}'
+    body: '{"created_at":"2023-10-20T13:46:54.037849Z","dhcp_enabled":true,"id":"53b3457b-4f5f-440a-ac83-2659edfd0347","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:46:54.037849Z","id":"6b296a55-4d4e-4b62-be14-60b113a92ffd","subnet":"172.16.92.0/22","updated_at":"2023-10-20T13:46:54.037849Z"},{"created_at":"2023-10-20T13:46:54.037849Z","id":"21b82cbf-0071-490f-9f5c-b19ecbc45038","subnet":"fd5f:519c:6d46:8a45::/64","updated_at":"2023-10-20T13:46:54.037849Z"}],"tags":[],"updated_at":"2023-10-20T13:46:54.037849Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "725"
@@ -1173,7 +1173,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:48 GMT
+      - Fri, 20 Oct 2023 13:47:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1183,7 +1183,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9986fa44-3484-439d-bb98-651db7ffc01a
+      - b24a3c7d-6246-4a81-817d-f625c6540b49
     status: 200 OK
     code: 200
     duration: ""
@@ -1194,25 +1194,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"49","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:56:11.156892+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.200.164.97","private_nics":[{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:46.086489+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"available","tags":[],"zone":"fr-par-2"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"19","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:47:07.812594+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.200.0.37","private_nics":[{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:44.382091+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "3165"
+      - "3156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:48 GMT
+      - Fri, 20 Oct 2023 13:47:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1222,7 +1222,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4980b9e1-ae18-412f-854d-b652abe0a50d
+      - ee688201-3402-45e2-adfd-95f820da2b99
     status: 200 OK
     code: 200
     duration: ""
@@ -1233,7 +1233,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1245,7 +1245,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:48 GMT
+      - Fri, 20 Oct 2023 13:47:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1255,7 +1255,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2afdff0-b81c-48d1-b03d-531f4653c084
+      - f255daed-0456-47a5-b1c5-f1eba24b309f
     status: 200 OK
     code: 200
     duration: ""
@@ -1266,10 +1266,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:46.086489+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"available","tags":[],"zone":"fr-par-2"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:44.382091+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"available","tags":[],"zone":"fr-par-2"}]}'
     headers:
       Content-Length:
       - "381"
@@ -1278,9 +1278,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:48 GMT
+      - Fri, 20 Oct 2023 13:47:46 GMT
       Link:
-      - </servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/private_nics?page=1&per_page=50&>;
+      - </servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -1291,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 019fe5f5-372e-4862-9bb2-dae08ea35c1a
+      - cf9c0776-ab18-4928-a526-e3564b5a3555
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -1304,25 +1304,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"49","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:56:11.156892+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.200.164.97","private_nics":[{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:46.086489+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"available","tags":[],"zone":"fr-par-2"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"19","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:47:07.812594+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.200.0.37","private_nics":[{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:44.382091+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "3165"
+      - "3156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:48 GMT
+      - Fri, 20 Oct 2023 13:47:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1332,7 +1332,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0afcb448-45d4-47d3-bdda-ccf6c9cd5a32
+      - ba09ca73-2b8e-4893-80e9-a850e6c43068
     status: 200 OK
     code: 200
     duration: ""
@@ -1345,10 +1345,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb/action","href_result":"/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb","id":"55c69374-9ab9-4f78-8598-a23939fc0a7f","started_at":"2023-10-18T08:56:49.482111+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/action","href_result":"/servers/beef1307-ffb4-454e-9911-1b9a4a827e97","id":"fed53e9d-edf1-4983-b546-0b2cdfdbf48e","started_at":"2023-10-20T13:47:47.614579+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -1357,9 +1357,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:49 GMT
+      - Fri, 20 Oct 2023 13:47:47 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-2/tasks/55c69374-9ab9-4f78-8598-a23939fc0a7f
+      - https://api.scaleway.com/instance/v1/zones/fr-par-2/tasks/fed53e9d-edf1-4983-b546-0b2cdfdbf48e
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1369,7 +1369,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 220e9db8-f70b-4e7b-9ba8-024beb615c22
+      - bbb79090-ecf1-4c68-a784-509774458cb6
     status: 202 Accepted
     code: 202
     duration: ""
@@ -1380,25 +1380,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"49","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:56:48.966543+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.200.164.97","private_nics":[{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:46.086489+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"available","tags":[],"zone":"fr-par-2"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"19","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:47:47.275769+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.200.0.37","private_nics":[{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:44.382091+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "3133"
+      - "3124"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:49 GMT
+      - Fri, 20 Oct 2023 13:47:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1408,7 +1408,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3fadb0b-860e-49de-909a-7bd8a9908480
+      - be4885e1-0ed7-4c42-aa96-9d7022ca2645
     status: 200 OK
     code: 200
     duration: ""
@@ -1419,25 +1419,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"49","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:56:48.966543+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.200.164.97","private_nics":[{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:46.086489+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"available","tags":[],"zone":"fr-par-2"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"19","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:47:47.275769+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.200.0.37","private_nics":[{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:44.382091+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "3133"
+      - "3124"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:56:55 GMT
+      - Fri, 20 Oct 2023 13:47:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1447,7 +1447,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c71c3bcf-da98-4445-adac-ed628db6e1c4
+      - e983b376-976d-4e76-88ce-3538e248d07e
     status: 200 OK
     code: 200
     duration: ""
@@ -1458,25 +1458,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"49","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:56:48.966543+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.200.164.97","private_nics":[{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:46.086489+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"available","tags":[],"zone":"fr-par-2"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"19","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:47:47.275769+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.200.0.37","private_nics":[{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:44.382091+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "3133"
+      - "3124"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:00 GMT
+      - Fri, 20 Oct 2023 13:47:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1486,7 +1486,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d4ddb04-73b9-48ee-9a5e-7e7183f649d6
+      - 7a36c40b-6e84-4d2b-bec6-0e2045c4f661
     status: 200 OK
     code: 200
     duration: ""
@@ -1497,25 +1497,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"49","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:56:48.966543+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.200.164.97","private_nics":[{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:46.086489+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"available","tags":[],"zone":"fr-par-2"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"19","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:47:47.275769+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.200.0.37","private_nics":[{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:44.382091+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "3133"
+      - "3124"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:05 GMT
+      - Fri, 20 Oct 2023 13:48:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bd9ff75-122a-4e18-87a7-e9902890876f
+      - bd4b1ac1-b6b6-4006-b3a3-033e3da3ae31
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,25 +1536,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"49","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:56:48.966543+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.200.164.97","private_nics":[{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:46.086489+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"available","tags":[],"zone":"fr-par-2"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"19","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:47:47.275769+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.200.0.37","private_nics":[{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:44.382091+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "3133"
+      - "3124"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:10 GMT
+      - Fri, 20 Oct 2023 13:48:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1564,7 +1564,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d265faac-61f0-41ec-b0e5-c829d7207701
+      - fb58e5a4-f03e-4bb4-967c-0eac334ab118
     status: 200 OK
     code: 200
     duration: ""
@@ -1575,25 +1575,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"49","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:56:48.966543+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.200.164.97","private_nics":[{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:46.086489+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"available","tags":[],"zone":"fr-par-2"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"19","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:47:47.275769+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.200.0.37","private_nics":[{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:44.382091+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "3133"
+      - "3124"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:16 GMT
+      - Fri, 20 Oct 2023 13:48:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1603,7 +1603,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac13def7-e01e-486e-b3d6-927e962a1f54
+      - 71f3471e-2465-4b94-ae6b-ca283edb06a2
     status: 200 OK
     code: 200
     duration: ""
@@ -1614,25 +1614,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"49","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:56:48.966543+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.200.164.97","private_nics":[{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:46.086489+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"available","tags":[],"zone":"fr-par-2"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"19","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:47:47.275769+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.200.0.37","private_nics":[{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:44.382091+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "3133"
+      - "3124"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:21 GMT
+      - Fri, 20 Oct 2023 13:48:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1642,7 +1642,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95b035bd-21dd-4d0f-adc7-64c58e89ed86
+      - 340efe87-02c7-4bb8-bd27-4cef3ecd3261
     status: 200 OK
     code: 200
     duration: ""
@@ -1653,25 +1653,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"49","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:56:48.966543+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.200.164.97","private_nics":[{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:46.086489+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"available","tags":[],"zone":"fr-par-2"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"19","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:47:47.275769+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.200.0.37","private_nics":[{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:44.382091+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "3133"
+      - "3124"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:26 GMT
+      - Fri, 20 Oct 2023 13:48:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1681,7 +1681,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbb3661b-bf66-43f0-987a-b04bfacfeeeb
+      - 24c88037-befa-4901-8ded-052ba1db41e6
     status: 200 OK
     code: 200
     duration: ""
@@ -1692,64 +1692,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"49","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:56:48.966543+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.200.164.97","private_nics":[{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:46.086489+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"available","tags":[],"zone":"fr-par-2"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "3133"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 08:57:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3a40c123-0645-474e-b4e8-0bce47f71f13
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:57:34.044076+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:46.086489+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"available","tags":[],"zone":"fr-par-2"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:48:24.756309+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:44.382091+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "3006"
+      - "3000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:36 GMT
+      - Fri, 20 Oct 2023 13:48:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1759,7 +1720,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3718ed3e-d1bf-40de-adcb-e0931603bea3
+      - 8c2dd6d7-5d1c-4b89-8689-ad01b4b50510
     status: 200 OK
     code: 200
     duration: ""
@@ -1770,25 +1731,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:55:56.881606+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-feistel","id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:20:3c:37","maintenances":[],"modification_date":"2023-10-18T08:57:34.044076+00:00","name":"tf-srv-clever-feistel","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-10-18T08:56:14.531206+00:00","id":"8abf0d74-02d8-42e3-9baf-2557987a1739","mac_address":"02:00:00:22:dc:d1","modification_date":"2023-10-18T08:56:46.086489+00:00","private_network_id":"4f08b9a2-5513-44d7-a56b-4a471cdb85e9","server_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","state":"available","tags":[],"zone":"fr-par-2"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"07a1e012-3e68-44ec-9b41-cbe87504b716","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:55:56.881606+00:00","export_uri":null,"id":"576120ae-7546-453d-81fd-9e7654ec4ba3","modification_date":"2023-10-18T08:55:56.881606+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","name":"tf-srv-clever-feistel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:44.382091+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"available","tags":[],"zone":"fr-par-2"}]}'
     headers:
       Content-Length:
-      - "3006"
+      - "381"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:37 GMT
+      - Fri, 20 Oct 2023 13:48:29 GMT
+      Link:
+      - </servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics?page=1&per_page=50&>;
+        rel="last"
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1798,7 +1756,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c817450-7efa-4cf0-b7fb-e0effc825cbe
+      - 55c7adcb-4784-41fd-80c2-7beff6e54a7e
+      X-Total-Count:
+      - "1"
     status: 200 OK
     code: 200
     duration: ""
@@ -1809,7 +1769,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics/a9c3927d-9675-46ad-a002-6e82eaf30708
+    method: GET
+  response:
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:47:13.166510+00:00","id":"a9c3927d-9675-46ad-a002-6e82eaf30708","mac_address":"02:00:00:22:e5:18","modification_date":"2023-10-20T13:47:44.382091+00:00","private_network_id":"53b3457b-4f5f-440a-ac83-2659edfd0347","server_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","state":"available","tags":[],"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "378"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 13:48:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ff67e8cf-2a49-4d2f-91e1-c67a30956176
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics/a9c3927d-9675-46ad-a002-6e82eaf30708
     method: DELETE
   response:
     body: ""
@@ -1817,7 +1810,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Wed, 18 Oct 2023 08:57:37 GMT
+      - Fri, 20 Oct 2023 13:48:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1827,7 +1820,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9fdcbfeb-6409-4cc7-91fc-53927238cc7b
+      - 8e273677-30b4-4e9f-8801-42ab94f62428
     status: 204 No Content
     code: 204
     duration: ""
@@ -1838,19 +1831,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/d0c3c720-0b5b-4192-beff-caaa270af2bb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97/private_nics/a9c3927d-9675-46ad-a002-6e82eaf30708
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"d0c3c720-0b5b-4192-beff-caaa270af2bb","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"a9c3927d-9675-46ad-a002-6e82eaf30708","type":"not_found"}'
     headers:
       Content-Length:
-      - "143"
+      - "148"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:37 GMT
+      - Fri, 20 Oct 2023 13:48:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1860,7 +1853,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bcf2f1b-1a69-4d82-a3c5-05f038c0272b
+      - 52177177-c045-469b-8e0a-cb00a0118700
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1871,81 +1864,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/576120ae-7546-453d-81fd-9e7654ec4ba3
-    method: DELETE
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
+    method: GET
   response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Date:
-      - Wed, 18 Oct 2023 08:57:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6b275e3c-ad4b-4128-9810-35267e973ccb
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4f08b9a2-5513-44d7-a56b-4a471cdb85e9
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 08:57:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 84e3a2c9-2435-461b-8ab1-4181488d1576
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: '{"name":"private_network_instance","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","tags":null,"subnets":null,"vpc_id":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
-    method: POST
-  response:
-    body: '{"created_at":"2023-10-18T08:57:38.125186Z","dhcp_enabled":true,"id":"1fdff68c-4feb-4634-be51-e8c3fd767556","name":"private_network_instance","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","subnets":[{"created_at":"2023-10-18T08:57:38.125186Z","id":"49f398fd-5f2b-4ffb-9709-acba45e37bc2","subnet":"172.16.60.0/22","updated_at":"2023-10-18T08:57:38.125186Z"},{"created_at":"2023-10-18T08:57:38.125186Z","id":"dacd056b-0d3b-44e5-ad71-393caad4402f","subnet":"fd4a:c18e:554d:825e::/64","updated_at":"2023-10-18T08:57:38.125186Z"}],"tags":[],"updated_at":"2023-10-18T08:57:38.125186Z","vpc_id":"53e50f63-f6c0-44f7-8576-d6edcb965d9c"}'
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:46:55.449727+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-newton","id":"beef1307-ffb4-454e-9911-1b9a4a827e97","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:20:88:cd","maintenances":[],"modification_date":"2023-10-20T13:48:24.756309+00:00","name":"tf-srv-great-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:46:55.449727+00:00","export_uri":null,"id":"699f8828-1e31-4f6b-b0dc-85ca82b464cc","modification_date":"2023-10-20T13:46:55.449727+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"beef1307-ffb4-454e-9911-1b9a4a827e97","name":"tf-srv-great-newton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "725"
+      - "2639"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:39 GMT
+      - Fri, 20 Oct 2023 13:48:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1955,7 +1892,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d56f7b62-ee81-41ee-8c50-773a6a3e2779
+      - 92e88ac6-d490-44e7-9607-ef3759248f79
     status: 200 OK
     code: 200
     duration: ""
@@ -1966,19 +1903,15 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1fdff68c-4feb-4634-be51-e8c3fd767556
-    method: GET
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
+    method: DELETE
   response:
-    body: '{"created_at":"2023-10-18T08:57:38.125186Z","dhcp_enabled":true,"id":"1fdff68c-4feb-4634-be51-e8c3fd767556","name":"private_network_instance","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","subnets":[{"created_at":"2023-10-18T08:57:38.125186Z","id":"49f398fd-5f2b-4ffb-9709-acba45e37bc2","subnet":"172.16.60.0/22","updated_at":"2023-10-18T08:57:38.125186Z"},{"created_at":"2023-10-18T08:57:38.125186Z","id":"dacd056b-0d3b-44e5-ad71-393caad4402f","subnet":"fd4a:c18e:554d:825e::/64","updated_at":"2023-10-18T08:57:38.125186Z"}],"tags":[],"updated_at":"2023-10-18T08:57:38.125186Z","vpc_id":"53e50f63-f6c0-44f7-8576-d6edcb965d9c"}'
+    body: ""
     headers:
-      Content-Length:
-      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:39 GMT
+      - Fri, 20 Oct 2023 13:48:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1988,7 +1921,168 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0c011b1-b42f-474d-9962-f3e567d99ea4
+      - 772c7ad7-f5ca-4e7f-8e32-7a260d6079f4
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/beef1307-ffb4-454e-9911-1b9a4a827e97
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"beef1307-ffb4-454e-9911-1b9a4a827e97","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 13:48:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - eb6812f6-aa5c-4b27-8662-6adc216cb7dc
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/699f8828-1e31-4f6b-b0dc-85ca82b464cc
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Fri, 20 Oct 2023 13:48:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fff4892c-63b3-493b-bd9d-28a3a3c9fe36
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/53b3457b-4f5f-440a-ac83-2659edfd0347
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 13:48:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 194f3cb5-3062-4888-b876-97da3690f003
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"name":"private_network_instance","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null,"vpc_id":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+    method: POST
+  response:
+    body: '{"created_at":"2023-10-20T13:48:31.136221Z","dhcp_enabled":true,"id":"6144b80b-8a12-4993-aa65-073e23fd774c","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:48:31.136221Z","id":"68d333ba-17fb-442e-bada-c92078d27a6d","subnet":"172.16.80.0/22","updated_at":"2023-10-20T13:48:31.136221Z"},{"created_at":"2023-10-20T13:48:31.136221Z","id":"70ec41bb-524c-48f3-b031-5d9b088ba7bd","subnet":"fd5f:519c:6d46:d64d::/64","updated_at":"2023-10-20T13:48:31.136221Z"}],"tags":[],"updated_at":"2023-10-20T13:48:31.136221Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "725"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 13:48:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e33e6f74-0f20-4c62-b294-ae38084121e7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6144b80b-8a12-4993-aa65-073e23fd774c
+    method: GET
+  response:
+    body: '{"created_at":"2023-10-20T13:48:31.136221Z","dhcp_enabled":true,"id":"6144b80b-8a12-4993-aa65-073e23fd774c","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:48:31.136221Z","id":"68d333ba-17fb-442e-bada-c92078d27a6d","subnet":"172.16.80.0/22","updated_at":"2023-10-20T13:48:31.136221Z"},{"created_at":"2023-10-20T13:48:31.136221Z","id":"70ec41bb-524c-48f3-b031-5d9b088ba7bd","subnet":"fd5f:519c:6d46:d64d::/64","updated_at":"2023-10-20T13:48:31.136221Z"}],"tags":[],"updated_at":"2023-10-20T13:48:31.136221Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "725"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 13:48:32 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1c6622b3-29e1-43d2-ab35-c09e93a60e39
     status: 200 OK
     code: 200
     duration: ""
@@ -2011,7 +2105,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:39 GMT
+      - Fri, 20 Oct 2023 13:48:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2021,7 +2115,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79c6a77f-9e5e-434e-9942-b5e7455d963c
+      - d8cb442f-244b-469c-a351-054e0ced17d7
     status: 200 OK
     code: 200
     duration: ""
@@ -2035,16 +2129,16 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
+    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
     headers:
       Content-Length:
-      - "39631"
+      - "38421"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:39 GMT
+      - Fri, 20 Oct 2023 13:48:32 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
@@ -2057,7 +2151,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21169a36-6652-48d0-a0ec-2e8135dede72
+      - 9061d05b-3568-431a-9a2c-7502131d002b
       X-Total-Count:
       - "56"
     status: 200 OK
@@ -2073,16 +2167,16 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
     headers:
       Content-Length:
-      - "4693"
+      - "4865"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:39 GMT
+      - Fri, 20 Oct 2023 13:48:32 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
@@ -2095,14 +2189,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e97b3201-e1b0-420d-b2a1-f8d4a5e986d1
+      - 667da8a6-cc79-4254-a41b-1a60acc23233
       X-Total-Count:
       - "56"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-srv-focused-mendeleev","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b"}'
+    body: '{"name":"tf-srv-peaceful-hamilton","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
@@ -2115,11 +2209,11 @@ interactions:
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:40.186570+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":null,"private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:32.530862+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "2654"
@@ -2128,9 +2222,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:40 GMT
+      - Fri, 20 Oct 2023 13:48:32 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2140,7 +2234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fde3a0b6-ccaf-45e2-9a96-d4b1cc343660
+      - 4d55f222-5c4d-4a5d-9394-86839890ea0d
     status: 201 Created
     code: 201
     duration: ""
@@ -2151,16 +2245,16 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:40.186570+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":null,"private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:32.530862+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "2654"
@@ -2169,7 +2263,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:40 GMT
+      - Fri, 20 Oct 2023 13:48:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2179,7 +2273,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eafbe5f6-6d12-461e-8369-b0f44836344e
+      - d7e171b2-1e83-4c10-a0e3-63b5510aaabe
     status: 200 OK
     code: 200
     duration: ""
@@ -2190,16 +2284,16 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:40.186570+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":null,"private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:32.530862+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "2654"
@@ -2208,7 +2302,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:40 GMT
+      - Fri, 20 Oct 2023 13:48:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2312,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4808d66e-1b16-47fb-8ea8-8892bc33e5c9
+      - ccee4720-1ca9-4c4f-8d12-d6d76c3c4436
     status: 200 OK
     code: 200
     duration: ""
@@ -2231,10 +2325,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/action","href_result":"/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd","id":"bd1b4ca6-e304-41e6-a3b3-c55bd57380ac","started_at":"2023-10-18T08:57:41.159059+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/action","href_result":"/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409","id":"ea5596b6-3937-40c9-b814-67ff809b0581","started_at":"2023-10-20T13:48:34.330622+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -2243,9 +2337,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:41 GMT
+      - Fri, 20 Oct 2023 13:48:34 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/bd1b4ca6-e304-41e6-a3b3-c55bd57380ac
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/ea5596b6-3937-40c9-b814-67ff809b0581
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2255,7 +2349,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01c73e68-84f3-48d2-9364-558bae674ff4
+      - 02f439d1-1878-45bc-ad1e-03d661c621d7
     status: 202 Accepted
     code: 202
     duration: ""
@@ -2266,16 +2360,16 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:40.861922+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":null,"private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:33.881346+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "2676"
@@ -2284,7 +2378,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:41 GMT
+      - Fri, 20 Oct 2023 13:48:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2294,7 +2388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9ecb809-6e11-416b-b890-4ad9ba324736
+      - 4f0832b7-9839-4ba4-ad1c-b729db601ab8
     status: 200 OK
     code: 200
     duration: ""
@@ -2305,25 +2399,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:40.861922+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:33.881346+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2785"
+      - "2782"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:46 GMT
+      - Fri, 20 Oct 2023 13:48:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2333,7 +2427,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f951600a-d973-46c3-9b4f-228bc1b33fa8
+      - 015d0fa4-c2ea-4ab0-bd09-2ab49c683f7f
     status: 200 OK
     code: 200
     duration: ""
@@ -2344,25 +2438,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:40.861922+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:33.881346+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2785"
+      - "2782"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:51 GMT
+      - Fri, 20 Oct 2023 13:48:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2372,7 +2466,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99dc6a71-118c-46ae-bc5b-19db1834417f
+      - 773eaccd-cda2-4cad-ad72-47c5c2091a4f
     status: 200 OK
     code: 200
     duration: ""
@@ -2383,25 +2477,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2816"
+      - "2813"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:57 GMT
+      - Fri, 20 Oct 2023 13:48:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2411,7 +2505,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b98b2e18-bf02-4a80-8550-a04cada2e902
+      - 742b78bb-ee41-4882-8eb4-d680777751ae
     status: 200 OK
     code: 200
     duration: ""
@@ -2422,10 +2516,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/1fdff68c-4feb-4634-be51-e8c3fd767556
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/6144b80b-8a12-4993-aa65-073e23fd774c
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T08:57:38.125186Z","id":"1fdff68c-4feb-4634-be51-e8c3fd767556","name":"private_network_instance","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":["172.16.60.0/22","fd4a:c18e:554d:825e::/64"],"tags":[],"updated_at":"2023-10-18T08:57:38.125186Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T13:48:31.136221Z","id":"6144b80b-8a12-4993-aa65-073e23fd774c","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnets":["172.16.80.0/22","fd5f:519c:6d46:d64d::/64"],"tags":[],"updated_at":"2023-10-20T13:48:31.136221Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "367"
@@ -2434,7 +2528,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:57 GMT
+      - Fri, 20 Oct 2023 13:48:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2444,7 +2538,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5aa791d8-25d3-4df5-9823-7c19c4d91bb1
+      - cd884a68-37bd-413f-97aa-e27ec7666ffb
     status: 200 OK
     code: 200
     duration: ""
@@ -2455,25 +2549,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2816"
+      - "2813"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:57 GMT
+      - Fri, 20 Oct 2023 13:48:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2483,12 +2577,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88b2968e-44d5-4dda-a30a-1f3a73d40184
+      - 2509b912-fc1f-4a51-a755-939975196cbe
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556"}'
+    body: '{"private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c"}'
     form: {}
     headers:
       Content-Type:
@@ -2496,10 +2590,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:57:57.648825+00:00","id":"6d1efb9b-5583-4a45-b707-317f72355a8d","mac_address":"02:00:00:14:49:86","modification_date":"2023-10-18T08:57:57.648825+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:48:50.392896+00:00","id":"44dfb4ad-f027-4412-b2d8-38e96d9ba904","mac_address":"02:00:00:14:57:aa","modification_date":"2023-10-20T13:48:50.392896+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -2508,7 +2602,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:58 GMT
+      - Fri, 20 Oct 2023 13:48:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2518,7 +2612,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fba5344a-ceeb-46ba-88be-5743b8c9437f
+      - 39ecaedb-8c58-457e-b7bc-539eeddf678b
     status: 201 Created
     code: 201
     duration: ""
@@ -2529,10 +2623,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/6d1efb9b-5583-4a45-b707-317f72355a8d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/44dfb4ad-f027-4412-b2d8-38e96d9ba904
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:57:57.648825+00:00","id":"6d1efb9b-5583-4a45-b707-317f72355a8d","mac_address":"02:00:00:14:49:86","modification_date":"2023-10-18T08:57:57.648825+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:48:50.392896+00:00","id":"44dfb4ad-f027-4412-b2d8-38e96d9ba904","mac_address":"02:00:00:14:57:aa","modification_date":"2023-10-20T13:48:50.392896+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -2541,7 +2635,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:57:58 GMT
+      - Fri, 20 Oct 2023 13:48:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2551,7 +2645,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a6dd588-4565-41d2-b70c-f192f3bf70f7
+      - 0e2008c6-1e70-493c-a739-6566e77815e5
     status: 200 OK
     code: 200
     duration: ""
@@ -2562,10 +2656,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/6d1efb9b-5583-4a45-b707-317f72355a8d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/44dfb4ad-f027-4412-b2d8-38e96d9ba904
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:57:57.648825+00:00","id":"6d1efb9b-5583-4a45-b707-317f72355a8d","mac_address":"02:00:00:14:49:86","modification_date":"2023-10-18T08:58:00.646860+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:48:50.392896+00:00","id":"44dfb4ad-f027-4412-b2d8-38e96d9ba904","mac_address":"02:00:00:14:57:aa","modification_date":"2023-10-20T13:48:51.263198+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -2574,7 +2668,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:03 GMT
+      - Fri, 20 Oct 2023 13:48:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2584,7 +2678,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad646594-db78-4a24-945b-fa7047102c54
+      - c229bb77-a548-4c27-9340-81bd846880ab
     status: 200 OK
     code: 200
     duration: ""
@@ -2595,10 +2689,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/6d1efb9b-5583-4a45-b707-317f72355a8d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/44dfb4ad-f027-4412-b2d8-38e96d9ba904
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:57:57.648825+00:00","id":"6d1efb9b-5583-4a45-b707-317f72355a8d","mac_address":"02:00:00:14:49:86","modification_date":"2023-10-18T08:58:00.646860+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:48:50.392896+00:00","id":"44dfb4ad-f027-4412-b2d8-38e96d9ba904","mac_address":"02:00:00:14:57:aa","modification_date":"2023-10-20T13:48:51.263198+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -2607,7 +2701,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:08 GMT
+      - Fri, 20 Oct 2023 13:49:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2617,7 +2711,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3216e74c-d00a-422a-a406-e8c701df880b
+      - 568c1390-9fd4-4bcb-80a6-5a7a9e8fd5d0
     status: 200 OK
     code: 200
     duration: ""
@@ -2628,10 +2722,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/6d1efb9b-5583-4a45-b707-317f72355a8d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/44dfb4ad-f027-4412-b2d8-38e96d9ba904
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:57:57.648825+00:00","id":"6d1efb9b-5583-4a45-b707-317f72355a8d","mac_address":"02:00:00:14:49:86","modification_date":"2023-10-18T08:58:00.646860+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:48:50.392896+00:00","id":"44dfb4ad-f027-4412-b2d8-38e96d9ba904","mac_address":"02:00:00:14:57:aa","modification_date":"2023-10-20T13:48:51.263198+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -2640,7 +2734,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:13 GMT
+      - Fri, 20 Oct 2023 13:49:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2650,7 +2744,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b57041fe-7f12-4cba-99c1-0a03fbc285e2
+      - 8bd2b29b-d750-4dcd-b0d1-465bad183afd
     status: 200 OK
     code: 200
     duration: ""
@@ -2661,10 +2755,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/6d1efb9b-5583-4a45-b707-317f72355a8d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/44dfb4ad-f027-4412-b2d8-38e96d9ba904
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:57:57.648825+00:00","id":"6d1efb9b-5583-4a45-b707-317f72355a8d","mac_address":"02:00:00:14:49:86","modification_date":"2023-10-18T08:58:00.646860+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:48:50.392896+00:00","id":"44dfb4ad-f027-4412-b2d8-38e96d9ba904","mac_address":"02:00:00:14:57:aa","modification_date":"2023-10-20T13:48:51.263198+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -2673,7 +2767,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:18 GMT
+      - Fri, 20 Oct 2023 13:49:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2683,7 +2777,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03631a3a-ce1c-4ab0-a55b-ef9a6a76ebc5
+      - e8543b6b-6c9a-45d4-ac52-aae8908806d1
     status: 200 OK
     code: 200
     duration: ""
@@ -2694,10 +2788,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/6d1efb9b-5583-4a45-b707-317f72355a8d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/44dfb4ad-f027-4412-b2d8-38e96d9ba904
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:57:57.648825+00:00","id":"6d1efb9b-5583-4a45-b707-317f72355a8d","mac_address":"02:00:00:14:49:86","modification_date":"2023-10-18T08:58:00.646860+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:48:50.392896+00:00","id":"44dfb4ad-f027-4412-b2d8-38e96d9ba904","mac_address":"02:00:00:14:57:aa","modification_date":"2023-10-20T13:48:51.263198+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -2706,7 +2800,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:23 GMT
+      - Fri, 20 Oct 2023 13:49:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2716,7 +2810,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5af89881-a9d4-4303-aee0-885a12c0d02f
+      - 2c4d5f9d-1242-40f8-aff2-8e1bd2052527
     status: 200 OK
     code: 200
     duration: ""
@@ -2727,10 +2821,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/6d1efb9b-5583-4a45-b707-317f72355a8d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/44dfb4ad-f027-4412-b2d8-38e96d9ba904
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:57:57.648825+00:00","id":"6d1efb9b-5583-4a45-b707-317f72355a8d","mac_address":"02:00:00:14:49:86","modification_date":"2023-10-18T08:58:28.873938+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:48:50.392896+00:00","id":"44dfb4ad-f027-4412-b2d8-38e96d9ba904","mac_address":"02:00:00:14:57:aa","modification_date":"2023-10-20T13:49:21.629727+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -2739,7 +2833,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:29 GMT
+      - Fri, 20 Oct 2023 13:49:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2749,7 +2843,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae77476b-4811-4d2a-a25c-4210dded207b
+      - 2fac434f-b681-433b-bd18-80c921024eb7
     status: 200 OK
     code: 200
     duration: ""
@@ -2760,10 +2854,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/6d1efb9b-5583-4a45-b707-317f72355a8d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/44dfb4ad-f027-4412-b2d8-38e96d9ba904
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:57:57.648825+00:00","id":"6d1efb9b-5583-4a45-b707-317f72355a8d","mac_address":"02:00:00:14:49:86","modification_date":"2023-10-18T08:58:28.873938+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:48:50.392896+00:00","id":"44dfb4ad-f027-4412-b2d8-38e96d9ba904","mac_address":"02:00:00:14:57:aa","modification_date":"2023-10-20T13:49:21.629727+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -2772,7 +2866,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:29 GMT
+      - Fri, 20 Oct 2023 13:49:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2782,7 +2876,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8843dd52-5191-4b70-9905-0fcc99b42ddb
+      - 48d9f695-8f08-4464-8c4c-2dc20be3af0b
     status: 200 OK
     code: 200
     duration: ""
@@ -2793,25 +2887,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[{"creation_date":"2023-10-18T08:57:57.648825+00:00","id":"6d1efb9b-5583-4a45-b707-317f72355a8d","mac_address":"02:00:00:14:49:86","modification_date":"2023-10-18T08:58:28.873938+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[{"creation_date":"2023-10-20T13:48:50.392896+00:00","id":"44dfb4ad-f027-4412-b2d8-38e96d9ba904","mac_address":"02:00:00:14:57:aa","modification_date":"2023-10-20T13:49:21.629727+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3169"
+      - "3166"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:29 GMT
+      - Fri, 20 Oct 2023 13:49:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2821,7 +2915,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e340b1e-342b-4af7-92c2-8358c8ca4b2c
+      - 9f259795-e192-4ed7-a416-21ae26fc4070
     status: 200 OK
     code: 200
     duration: ""
@@ -2832,7 +2926,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2844,7 +2938,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:29 GMT
+      - Fri, 20 Oct 2023 13:49:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2854,7 +2948,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b269914-44d7-4868-aa58-4faa5e56174f
+      - 1f26d62d-ceb6-45e6-809d-29ae011222cd
     status: 200 OK
     code: 200
     duration: ""
@@ -2865,10 +2959,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-18T08:57:57.648825+00:00","id":"6d1efb9b-5583-4a45-b707-317f72355a8d","mac_address":"02:00:00:14:49:86","modification_date":"2023-10-18T08:58:28.873938+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T13:48:50.392896+00:00","id":"44dfb4ad-f027-4412-b2d8-38e96d9ba904","mac_address":"02:00:00:14:57:aa","modification_date":"2023-10-20T13:49:21.629727+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -2877,9 +2971,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:29 GMT
+      - Fri, 20 Oct 2023 13:49:22 GMT
       Link:
-      - </servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics?page=1&per_page=50&>;
+      - </servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -2890,7 +2984,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26ba357c-0d3b-4ee6-a0b8-ceecb1811e0c
+      - 1835b56a-b4f6-42b0-901e-0d0b181f5f40
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -2903,10 +2997,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-18T08:57:57.648825+00:00","id":"6d1efb9b-5583-4a45-b707-317f72355a8d","mac_address":"02:00:00:14:49:86","modification_date":"2023-10-18T08:58:28.873938+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T13:48:50.392896+00:00","id":"44dfb4ad-f027-4412-b2d8-38e96d9ba904","mac_address":"02:00:00:14:57:aa","modification_date":"2023-10-20T13:49:21.629727+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -2915,9 +3009,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:29 GMT
+      - Fri, 20 Oct 2023 13:49:22 GMT
       Link:
-      - </servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics?page=1&per_page=50&>;
+      - </servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -2928,7 +3022,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0855950c-1c73-44b1-b925-5a321952b17d
+      - 29360720-34be-44ee-b1c0-84dfcbcef4b9
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -2941,10 +3035,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1fdff68c-4feb-4634-be51-e8c3fd767556
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6144b80b-8a12-4993-aa65-073e23fd774c
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T08:57:38.125186Z","dhcp_enabled":true,"id":"1fdff68c-4feb-4634-be51-e8c3fd767556","name":"private_network_instance","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","subnets":[{"created_at":"2023-10-18T08:57:38.125186Z","id":"49f398fd-5f2b-4ffb-9709-acba45e37bc2","subnet":"172.16.60.0/22","updated_at":"2023-10-18T08:57:38.125186Z"},{"created_at":"2023-10-18T08:57:38.125186Z","id":"dacd056b-0d3b-44e5-ad71-393caad4402f","subnet":"fd4a:c18e:554d:825e::/64","updated_at":"2023-10-18T08:57:38.125186Z"}],"tags":[],"updated_at":"2023-10-18T08:57:38.125186Z","vpc_id":"53e50f63-f6c0-44f7-8576-d6edcb965d9c"}'
+    body: '{"created_at":"2023-10-20T13:48:31.136221Z","dhcp_enabled":true,"id":"6144b80b-8a12-4993-aa65-073e23fd774c","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:48:31.136221Z","id":"68d333ba-17fb-442e-bada-c92078d27a6d","subnet":"172.16.80.0/22","updated_at":"2023-10-20T13:48:31.136221Z"},{"created_at":"2023-10-20T13:48:31.136221Z","id":"70ec41bb-524c-48f3-b031-5d9b088ba7bd","subnet":"fd5f:519c:6d46:d64d::/64","updated_at":"2023-10-20T13:48:31.136221Z"}],"tags":[],"updated_at":"2023-10-20T13:48:31.136221Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "725"
@@ -2953,7 +3047,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:30 GMT
+      - Fri, 20 Oct 2023 13:49:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2963,7 +3057,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5b97ba9-e323-4970-8232-51745541cc7d
+      - 4f6c9174-6c20-4830-a0bd-63f794413f09
     status: 200 OK
     code: 200
     duration: ""
@@ -2974,25 +3068,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[{"creation_date":"2023-10-18T08:57:57.648825+00:00","id":"6d1efb9b-5583-4a45-b707-317f72355a8d","mac_address":"02:00:00:14:49:86","modification_date":"2023-10-18T08:58:28.873938+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[{"creation_date":"2023-10-20T13:48:50.392896+00:00","id":"44dfb4ad-f027-4412-b2d8-38e96d9ba904","mac_address":"02:00:00:14:57:aa","modification_date":"2023-10-20T13:49:21.629727+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3169"
+      - "3166"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:30 GMT
+      - Fri, 20 Oct 2023 13:49:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3002,7 +3096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e736555f-55af-479e-a19e-56a93b070fce
+      - 200875b7-ac39-47e0-9cc7-7940ded9f456
     status: 200 OK
     code: 200
     duration: ""
@@ -3013,7 +3107,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -3025,7 +3119,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:30 GMT
+      - Fri, 20 Oct 2023 13:49:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3035,7 +3129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d5a274d-0678-423e-a627-7918840bfbf9
+      - a4de9202-c9e5-46d2-aa9e-12eda15830fd
     status: 200 OK
     code: 200
     duration: ""
@@ -3046,10 +3140,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-18T08:57:57.648825+00:00","id":"6d1efb9b-5583-4a45-b707-317f72355a8d","mac_address":"02:00:00:14:49:86","modification_date":"2023-10-18T08:58:28.873938+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T13:48:50.392896+00:00","id":"44dfb4ad-f027-4412-b2d8-38e96d9ba904","mac_address":"02:00:00:14:57:aa","modification_date":"2023-10-20T13:49:21.629727+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -3058,9 +3152,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:30 GMT
+      - Fri, 20 Oct 2023 13:49:23 GMT
       Link:
-      - </servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics?page=1&per_page=50&>;
+      - </servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -3071,7 +3165,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a8fcc26-7b95-43eb-b022-f65c1c87b5d6
+      - 9af642f6-9936-4335-8980-0888dd4009b3
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -3084,10 +3178,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1fdff68c-4feb-4634-be51-e8c3fd767556
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6144b80b-8a12-4993-aa65-073e23fd774c
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T08:57:38.125186Z","dhcp_enabled":true,"id":"1fdff68c-4feb-4634-be51-e8c3fd767556","name":"private_network_instance","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","subnets":[{"created_at":"2023-10-18T08:57:38.125186Z","id":"49f398fd-5f2b-4ffb-9709-acba45e37bc2","subnet":"172.16.60.0/22","updated_at":"2023-10-18T08:57:38.125186Z"},{"created_at":"2023-10-18T08:57:38.125186Z","id":"dacd056b-0d3b-44e5-ad71-393caad4402f","subnet":"fd4a:c18e:554d:825e::/64","updated_at":"2023-10-18T08:57:38.125186Z"}],"tags":[],"updated_at":"2023-10-18T08:57:38.125186Z","vpc_id":"53e50f63-f6c0-44f7-8576-d6edcb965d9c"}'
+    body: '{"created_at":"2023-10-20T13:48:31.136221Z","dhcp_enabled":true,"id":"6144b80b-8a12-4993-aa65-073e23fd774c","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:48:31.136221Z","id":"68d333ba-17fb-442e-bada-c92078d27a6d","subnet":"172.16.80.0/22","updated_at":"2023-10-20T13:48:31.136221Z"},{"created_at":"2023-10-20T13:48:31.136221Z","id":"70ec41bb-524c-48f3-b031-5d9b088ba7bd","subnet":"fd5f:519c:6d46:d64d::/64","updated_at":"2023-10-20T13:48:31.136221Z"}],"tags":[],"updated_at":"2023-10-20T13:48:31.136221Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "725"
@@ -3096,7 +3190,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:31 GMT
+      - Fri, 20 Oct 2023 13:49:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3106,7 +3200,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8857bde-8f60-4373-ad17-fbf8e3408d8f
+      - a15cf626-806b-4747-b14c-98c4b9368fed
     status: 200 OK
     code: 200
     duration: ""
@@ -3117,25 +3211,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[{"creation_date":"2023-10-18T08:57:57.648825+00:00","id":"6d1efb9b-5583-4a45-b707-317f72355a8d","mac_address":"02:00:00:14:49:86","modification_date":"2023-10-18T08:58:28.873938+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[{"creation_date":"2023-10-20T13:48:50.392896+00:00","id":"44dfb4ad-f027-4412-b2d8-38e96d9ba904","mac_address":"02:00:00:14:57:aa","modification_date":"2023-10-20T13:49:21.629727+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3169"
+      - "3166"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:31 GMT
+      - Fri, 20 Oct 2023 13:49:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3145,7 +3239,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd0941c8-df45-43f3-bdfb-b76e90c6f757
+      - 640a2ca9-7364-4e1b-9f3a-ac36ce2ca29d
     status: 200 OK
     code: 200
     duration: ""
@@ -3156,7 +3250,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -3168,7 +3262,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:31 GMT
+      - Fri, 20 Oct 2023 13:49:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3178,7 +3272,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 672491c6-8d86-4b64-8ca5-c4e5af134884
+      - 674d7a17-3126-41d5-8fc6-08af873f2ca8
     status: 200 OK
     code: 200
     duration: ""
@@ -3189,10 +3283,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-18T08:57:57.648825+00:00","id":"6d1efb9b-5583-4a45-b707-317f72355a8d","mac_address":"02:00:00:14:49:86","modification_date":"2023-10-18T08:58:28.873938+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T13:48:50.392896+00:00","id":"44dfb4ad-f027-4412-b2d8-38e96d9ba904","mac_address":"02:00:00:14:57:aa","modification_date":"2023-10-20T13:49:21.629727+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -3201,9 +3295,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:31 GMT
+      - Fri, 20 Oct 2023 13:49:25 GMT
       Link:
-      - </servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics?page=1&per_page=50&>;
+      - </servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -3214,14 +3308,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a894ea4-8a3b-4ba2-aff3-beb658fc055e
+      - 4bcbfb31-6b9a-45fd-b8b8-9989d9cabc60
       X-Total-Count:
       - "1"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"private_network_instance_02","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"private_network_instance_02","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null,"vpc_id":null}'
     form: {}
     headers:
       Content-Type:
@@ -3232,16 +3326,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-18T08:58:31.837558Z","dhcp_enabled":true,"id":"b4297f49-9804-45eb-a83b-40de42f4384b","name":"private_network_instance_02","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","subnets":[{"created_at":"2023-10-18T08:58:31.837558Z","id":"1bded4a4-b339-4c73-9aa9-66186737568a","subnet":"172.16.76.0/22","updated_at":"2023-10-18T08:58:31.837558Z"},{"created_at":"2023-10-18T08:58:31.837558Z","id":"665f118c-6b37-460e-8b9b-55286dcfaa34","subnet":"fd4a:c18e:554d:fe68::/64","updated_at":"2023-10-18T08:58:31.837558Z"}],"tags":[],"updated_at":"2023-10-18T08:58:31.837558Z","vpc_id":"53e50f63-f6c0-44f7-8576-d6edcb965d9c"}'
+    body: '{"created_at":"2023-10-20T13:49:25.601184Z","dhcp_enabled":true,"id":"fe18faa7-6634-4132-b109-07403444845f","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:49:25.601184Z","id":"2f505869-a87d-4ef1-9c50-26a0bf30354e","subnet":"172.16.136.0/22","updated_at":"2023-10-20T13:49:25.601184Z"},{"created_at":"2023-10-20T13:49:25.601184Z","id":"f5e76938-9011-4fbc-8ebf-6828c040f65f","subnet":"fd5f:519c:6d46:cb90::/64","updated_at":"2023-10-20T13:49:25.601184Z"}],"tags":[],"updated_at":"2023-10-20T13:49:25.601184Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "728"
+      - "729"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:32 GMT
+      - Fri, 20 Oct 2023 13:49:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3251,7 +3345,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2dc7e4c-d22a-4a38-9f38-0e2f877f52f7
+      - 0c5f9952-5254-44b1-aa5d-b97d75f2f088
     status: 200 OK
     code: 200
     duration: ""
@@ -3262,19 +3356,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b4297f49-9804-45eb-a83b-40de42f4384b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fe18faa7-6634-4132-b109-07403444845f
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T08:58:31.837558Z","dhcp_enabled":true,"id":"b4297f49-9804-45eb-a83b-40de42f4384b","name":"private_network_instance_02","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","subnets":[{"created_at":"2023-10-18T08:58:31.837558Z","id":"1bded4a4-b339-4c73-9aa9-66186737568a","subnet":"172.16.76.0/22","updated_at":"2023-10-18T08:58:31.837558Z"},{"created_at":"2023-10-18T08:58:31.837558Z","id":"665f118c-6b37-460e-8b9b-55286dcfaa34","subnet":"fd4a:c18e:554d:fe68::/64","updated_at":"2023-10-18T08:58:31.837558Z"}],"tags":[],"updated_at":"2023-10-18T08:58:31.837558Z","vpc_id":"53e50f63-f6c0-44f7-8576-d6edcb965d9c"}'
+    body: '{"created_at":"2023-10-20T13:49:25.601184Z","dhcp_enabled":true,"id":"fe18faa7-6634-4132-b109-07403444845f","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:49:25.601184Z","id":"2f505869-a87d-4ef1-9c50-26a0bf30354e","subnet":"172.16.136.0/22","updated_at":"2023-10-20T13:49:25.601184Z"},{"created_at":"2023-10-20T13:49:25.601184Z","id":"f5e76938-9011-4fbc-8ebf-6828c040f65f","subnet":"fd5f:519c:6d46:cb90::/64","updated_at":"2023-10-20T13:49:25.601184Z"}],"tags":[],"updated_at":"2023-10-20T13:49:25.601184Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "728"
+      - "729"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:32 GMT
+      - Fri, 20 Oct 2023 13:49:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3284,7 +3378,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 854ed520-8347-4d0a-9397-4d4bf30bf812
+      - 4154a4db-c78a-4627-aded-d7d61dee5b26
     status: 200 OK
     code: 200
     duration: ""
@@ -3295,25 +3389,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[{"creation_date":"2023-10-18T08:57:57.648825+00:00","id":"6d1efb9b-5583-4a45-b707-317f72355a8d","mac_address":"02:00:00:14:49:86","modification_date":"2023-10-18T08:58:28.873938+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[{"creation_date":"2023-10-20T13:48:50.392896+00:00","id":"44dfb4ad-f027-4412-b2d8-38e96d9ba904","mac_address":"02:00:00:14:57:aa","modification_date":"2023-10-20T13:49:21.629727+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3169"
+      - "3166"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:32 GMT
+      - Fri, 20 Oct 2023 13:49:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3323,7 +3417,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c09424b5-20f7-484e-af6c-304da108ed5a
+      - 581bb34b-4f96-42ea-9d3a-ce458fbebab9
     status: 200 OK
     code: 200
     duration: ""
@@ -3334,10 +3428,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-18T08:57:57.648825+00:00","id":"6d1efb9b-5583-4a45-b707-317f72355a8d","mac_address":"02:00:00:14:49:86","modification_date":"2023-10-18T08:58:28.873938+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T13:48:50.392896+00:00","id":"44dfb4ad-f027-4412-b2d8-38e96d9ba904","mac_address":"02:00:00:14:57:aa","modification_date":"2023-10-20T13:49:21.629727+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -3346,9 +3440,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:32 GMT
+      - Fri, 20 Oct 2023 13:49:26 GMT
       Link:
-      - </servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics?page=1&per_page=50&>;
+      - </servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -3359,7 +3453,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6911e848-2393-4434-8e5e-40910b568261
+      - fd076d12-80ef-4792-bb4e-cf0fd09c54fd
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -3372,25 +3466,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[{"creation_date":"2023-10-18T08:57:57.648825+00:00","id":"6d1efb9b-5583-4a45-b707-317f72355a8d","mac_address":"02:00:00:14:49:86","modification_date":"2023-10-18T08:58:28.873938+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[{"creation_date":"2023-10-20T13:48:50.392896+00:00","id":"44dfb4ad-f027-4412-b2d8-38e96d9ba904","mac_address":"02:00:00:14:57:aa","modification_date":"2023-10-20T13:49:21.629727+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3169"
+      - "3166"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:33 GMT
+      - Fri, 20 Oct 2023 13:49:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3400,7 +3494,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf57fa8f-c4be-4131-a2d0-d05d745b0ea3
+      - 90812068-5608-4727-9f8f-29cb4aac01b8
     status: 200 OK
     code: 200
     duration: ""
@@ -3411,10 +3505,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/6d1efb9b-5583-4a45-b707-317f72355a8d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/44dfb4ad-f027-4412-b2d8-38e96d9ba904
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:57:57.648825+00:00","id":"6d1efb9b-5583-4a45-b707-317f72355a8d","mac_address":"02:00:00:14:49:86","modification_date":"2023-10-18T08:58:28.873938+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:48:50.392896+00:00","id":"44dfb4ad-f027-4412-b2d8-38e96d9ba904","mac_address":"02:00:00:14:57:aa","modification_date":"2023-10-20T13:49:21.629727+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -3423,7 +3517,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:33 GMT
+      - Fri, 20 Oct 2023 13:49:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3433,7 +3527,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f305843-d888-4bbe-b490-78d4c5a6c102
+      - e709409b-b766-4b62-81ef-4f48bb6b4460
     status: 200 OK
     code: 200
     duration: ""
@@ -3444,7 +3538,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/6d1efb9b-5583-4a45-b707-317f72355a8d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/44dfb4ad-f027-4412-b2d8-38e96d9ba904
     method: DELETE
   response:
     body: ""
@@ -3452,7 +3546,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Wed, 18 Oct 2023 08:58:33 GMT
+      - Fri, 20 Oct 2023 13:49:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3462,7 +3556,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7220bd8-4af4-4cb6-983b-eaef7ccff8e8
+      - 9bbc4f83-cb7c-4244-a0aa-325d7332e4fe
     status: 204 No Content
     code: 204
     duration: ""
@@ -3473,10 +3567,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/6d1efb9b-5583-4a45-b707-317f72355a8d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/44dfb4ad-f027-4412-b2d8-38e96d9ba904
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"6d1efb9b-5583-4a45-b707-317f72355a8d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"44dfb4ad-f027-4412-b2d8-38e96d9ba904","type":"not_found"}'
     headers:
       Content-Length:
       - "148"
@@ -3485,7 +3579,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:33 GMT
+      - Fri, 20 Oct 2023 13:49:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3495,12 +3589,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5345dbd-3333-4ef4-9f64-422882082b79
+      - 96ee0c84-a500-4c7d-bdeb-76eede67f391
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b"}'
+    body: '{"private_network_id":"fe18faa7-6634-4132-b109-07403444845f"}'
     form: {}
     headers:
       Content-Type:
@@ -3508,10 +3602,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:33.760793+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:27.695247+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -3520,7 +3614,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:34 GMT
+      - Fri, 20 Oct 2023 13:49:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3530,7 +3624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5adc242d-ca7f-499b-aa5b-63034d5bbdf1
+      - 579bac5f-42a2-4e59-ae30-b4acc113d54e
     status: 201 Created
     code: 201
     duration: ""
@@ -3541,10 +3635,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/f5b5e5e1-32e2-4ff2-968f-0425417183bb
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:33.760793+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:27.695247+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -3553,7 +3647,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:34 GMT
+      - Fri, 20 Oct 2023 13:49:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3563,7 +3657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb954f74-e4c2-41e5-8dce-40a2bf587dbe
+      - 4e6e94ef-4d07-4f26-9b32-7a33a5fa0b1d
     status: 200 OK
     code: 200
     duration: ""
@@ -3574,10 +3668,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/f5b5e5e1-32e2-4ff2-968f-0425417183bb
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -3586,7 +3680,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:39 GMT
+      - Fri, 20 Oct 2023 13:49:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3596,7 +3690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df7cfeeb-8915-46f1-8f01-039d1793d2d1
+      - 2dbdef86-65cb-4145-b8e6-631350729818
     status: 200 OK
     code: 200
     duration: ""
@@ -3607,10 +3701,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/f5b5e5e1-32e2-4ff2-968f-0425417183bb
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -3619,7 +3713,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:39 GMT
+      - Fri, 20 Oct 2023 13:49:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3629,7 +3723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8304bc3f-b651-4dd6-8dee-39ded01d7b0a
+      - 04f1f57b-69aa-4c2d-bbc3-d150dcc009c0
     status: 200 OK
     code: 200
     duration: ""
@@ -3642,25 +3736,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: PATCH
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3169"
+      - "3166"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:40 GMT
+      - Fri, 20 Oct 2023 13:49:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3670,7 +3764,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06626ae9-28f1-47c8-a13e-2645a1799dda
+      - 643ff804-d6a0-4cf9-84dc-e379906844b0
     status: 200 OK
     code: 200
     duration: ""
@@ -3681,25 +3775,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3169"
+      - "3166"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:40 GMT
+      - Fri, 20 Oct 2023 13:49:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3709,7 +3803,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2441313-0269-438e-b61f-8e05b6737503
+      - 3fe632ea-9fe6-47f5-be83-b04773c9daaa
     status: 200 OK
     code: 200
     duration: ""
@@ -3720,25 +3814,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3169"
+      - "3166"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:40 GMT
+      - Fri, 20 Oct 2023 13:49:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3748,7 +3842,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87c8026d-1129-4d14-b291-cf293a129797
+      - 9c878387-585d-4a91-9f56-91b294d237a0
     status: 200 OK
     code: 200
     duration: ""
@@ -3759,7 +3853,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -3771,7 +3865,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:40 GMT
+      - Fri, 20 Oct 2023 13:49:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3781,7 +3875,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc641dbe-f724-4c8a-81e9-348e97f18d48
+      - e5252343-161f-45a6-ac5b-0480f62beec2
     status: 200 OK
     code: 200
     duration: ""
@@ -3792,10 +3886,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -3804,9 +3898,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:40 GMT
+      - Fri, 20 Oct 2023 13:49:34 GMT
       Link:
-      - </servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics?page=1&per_page=50&>;
+      - </servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -3817,7 +3911,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b57abc8e-6920-45e1-96a4-8398e51a1579
+      - 54d06d6b-d40e-4055-814f-430008115d88
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -3830,10 +3924,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -3842,9 +3936,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:40 GMT
+      - Fri, 20 Oct 2023 13:49:34 GMT
       Link:
-      - </servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics?page=1&per_page=50&>;
+      - </servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -3855,7 +3949,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 761a5429-6ccb-4005-9e33-7283330ce407
+      - 1f448cab-54bf-4e18-96b5-fcbc9cab2d6c
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -3868,43 +3962,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b4297f49-9804-45eb-a83b-40de42f4384b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6144b80b-8a12-4993-aa65-073e23fd774c
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T08:58:31.837558Z","dhcp_enabled":true,"id":"b4297f49-9804-45eb-a83b-40de42f4384b","name":"private_network_instance_02","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","subnets":[{"created_at":"2023-10-18T08:58:31.837558Z","id":"1bded4a4-b339-4c73-9aa9-66186737568a","subnet":"172.16.76.0/22","updated_at":"2023-10-18T08:58:31.837558Z"},{"created_at":"2023-10-18T08:58:31.837558Z","id":"665f118c-6b37-460e-8b9b-55286dcfaa34","subnet":"fd4a:c18e:554d:fe68::/64","updated_at":"2023-10-18T08:58:31.837558Z"}],"tags":[],"updated_at":"2023-10-18T08:58:31.837558Z","vpc_id":"53e50f63-f6c0-44f7-8576-d6edcb965d9c"}'
-    headers:
-      Content-Length:
-      - "728"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 08:58:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 89f63d0d-0c8c-46c4-8552-32d587d8e4a4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1fdff68c-4feb-4634-be51-e8c3fd767556
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T08:57:38.125186Z","dhcp_enabled":true,"id":"1fdff68c-4feb-4634-be51-e8c3fd767556","name":"private_network_instance","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","subnets":[{"created_at":"2023-10-18T08:57:38.125186Z","id":"49f398fd-5f2b-4ffb-9709-acba45e37bc2","subnet":"172.16.60.0/22","updated_at":"2023-10-18T08:57:38.125186Z"},{"created_at":"2023-10-18T08:57:38.125186Z","id":"dacd056b-0d3b-44e5-ad71-393caad4402f","subnet":"fd4a:c18e:554d:825e::/64","updated_at":"2023-10-18T08:57:38.125186Z"}],"tags":[],"updated_at":"2023-10-18T08:57:38.125186Z","vpc_id":"53e50f63-f6c0-44f7-8576-d6edcb965d9c"}'
+    body: '{"created_at":"2023-10-20T13:48:31.136221Z","dhcp_enabled":true,"id":"6144b80b-8a12-4993-aa65-073e23fd774c","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:48:31.136221Z","id":"68d333ba-17fb-442e-bada-c92078d27a6d","subnet":"172.16.80.0/22","updated_at":"2023-10-20T13:48:31.136221Z"},{"created_at":"2023-10-20T13:48:31.136221Z","id":"70ec41bb-524c-48f3-b031-5d9b088ba7bd","subnet":"fd5f:519c:6d46:d64d::/64","updated_at":"2023-10-20T13:48:31.136221Z"}],"tags":[],"updated_at":"2023-10-20T13:48:31.136221Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "725"
@@ -3913,7 +3974,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:41 GMT
+      - Fri, 20 Oct 2023 13:49:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3923,7 +3984,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 570dcb54-5c79-4174-9b26-e910ca4f6819
+      - 59ce4431-1ccf-4872-882f-e3ca6d81b8b0
     status: 200 OK
     code: 200
     duration: ""
@@ -3934,25 +3995,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fe18faa7-6634-4132-b109-07403444845f
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    body: '{"created_at":"2023-10-20T13:49:25.601184Z","dhcp_enabled":true,"id":"fe18faa7-6634-4132-b109-07403444845f","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:49:25.601184Z","id":"2f505869-a87d-4ef1-9c50-26a0bf30354e","subnet":"172.16.136.0/22","updated_at":"2023-10-20T13:49:25.601184Z"},{"created_at":"2023-10-20T13:49:25.601184Z","id":"f5e76938-9011-4fbc-8ebf-6828c040f65f","subnet":"fd5f:519c:6d46:cb90::/64","updated_at":"2023-10-20T13:49:25.601184Z"}],"tags":[],"updated_at":"2023-10-20T13:49:25.601184Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "3169"
+      - "729"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:41 GMT
+      - Fri, 20 Oct 2023 13:49:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3962,7 +4017,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64a12dfe-805e-4bfe-93c0-799eb3c7add1
+      - dbf89ca5-10bd-4fd6-8d8f-b70f06279e8d
     status: 200 OK
     code: 200
     duration: ""
@@ -3973,7 +4028,46 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3166"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 13:49:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c8153d32-bdc0-4d3a-bfcd-2d87a16cb503
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -3985,7 +4079,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:41 GMT
+      - Fri, 20 Oct 2023 13:49:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3995,7 +4089,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e03691d-9cef-41b3-8836-87febcf82bc6
+      - 139da04f-f989-480b-8edd-89802d05b3f7
     status: 200 OK
     code: 200
     duration: ""
@@ -4006,10 +4100,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -4018,9 +4112,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:41 GMT
+      - Fri, 20 Oct 2023 13:49:35 GMT
       Link:
-      - </servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics?page=1&per_page=50&>;
+      - </servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -4031,7 +4125,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e887b68-96b4-465a-ad98-cfee4e29e987
+      - dcc5c470-ed41-4407-83e6-b70c379723de
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -4044,19 +4138,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b4297f49-9804-45eb-a83b-40de42f4384b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fe18faa7-6634-4132-b109-07403444845f
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T08:58:31.837558Z","dhcp_enabled":true,"id":"b4297f49-9804-45eb-a83b-40de42f4384b","name":"private_network_instance_02","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","subnets":[{"created_at":"2023-10-18T08:58:31.837558Z","id":"1bded4a4-b339-4c73-9aa9-66186737568a","subnet":"172.16.76.0/22","updated_at":"2023-10-18T08:58:31.837558Z"},{"created_at":"2023-10-18T08:58:31.837558Z","id":"665f118c-6b37-460e-8b9b-55286dcfaa34","subnet":"fd4a:c18e:554d:fe68::/64","updated_at":"2023-10-18T08:58:31.837558Z"}],"tags":[],"updated_at":"2023-10-18T08:58:31.837558Z","vpc_id":"53e50f63-f6c0-44f7-8576-d6edcb965d9c"}'
+    body: '{"created_at":"2023-10-20T13:49:25.601184Z","dhcp_enabled":true,"id":"fe18faa7-6634-4132-b109-07403444845f","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:49:25.601184Z","id":"2f505869-a87d-4ef1-9c50-26a0bf30354e","subnet":"172.16.136.0/22","updated_at":"2023-10-20T13:49:25.601184Z"},{"created_at":"2023-10-20T13:49:25.601184Z","id":"f5e76938-9011-4fbc-8ebf-6828c040f65f","subnet":"fd5f:519c:6d46:cb90::/64","updated_at":"2023-10-20T13:49:25.601184Z"}],"tags":[],"updated_at":"2023-10-20T13:49:25.601184Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "728"
+      - "729"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:42 GMT
+      - Fri, 20 Oct 2023 13:49:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4066,7 +4160,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38d96b2e-a2ab-44dd-9ab2-7f51c07aef31
+      - 46f0ffb0-9242-4c13-9b30-c6f11d602fef
     status: 200 OK
     code: 200
     duration: ""
@@ -4077,10 +4171,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1fdff68c-4feb-4634-be51-e8c3fd767556
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6144b80b-8a12-4993-aa65-073e23fd774c
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T08:57:38.125186Z","dhcp_enabled":true,"id":"1fdff68c-4feb-4634-be51-e8c3fd767556","name":"private_network_instance","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","subnets":[{"created_at":"2023-10-18T08:57:38.125186Z","id":"49f398fd-5f2b-4ffb-9709-acba45e37bc2","subnet":"172.16.60.0/22","updated_at":"2023-10-18T08:57:38.125186Z"},{"created_at":"2023-10-18T08:57:38.125186Z","id":"dacd056b-0d3b-44e5-ad71-393caad4402f","subnet":"fd4a:c18e:554d:825e::/64","updated_at":"2023-10-18T08:57:38.125186Z"}],"tags":[],"updated_at":"2023-10-18T08:57:38.125186Z","vpc_id":"53e50f63-f6c0-44f7-8576-d6edcb965d9c"}'
+    body: '{"created_at":"2023-10-20T13:48:31.136221Z","dhcp_enabled":true,"id":"6144b80b-8a12-4993-aa65-073e23fd774c","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:48:31.136221Z","id":"68d333ba-17fb-442e-bada-c92078d27a6d","subnet":"172.16.80.0/22","updated_at":"2023-10-20T13:48:31.136221Z"},{"created_at":"2023-10-20T13:48:31.136221Z","id":"70ec41bb-524c-48f3-b031-5d9b088ba7bd","subnet":"fd5f:519c:6d46:d64d::/64","updated_at":"2023-10-20T13:48:31.136221Z"}],"tags":[],"updated_at":"2023-10-20T13:48:31.136221Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "725"
@@ -4089,7 +4183,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:42 GMT
+      - Fri, 20 Oct 2023 13:49:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4099,7 +4193,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 832918e5-04cc-45e9-86f7-8dd087b427a2
+      - 40c2dd0a-58d1-45f9-99b6-0389e4a7698b
     status: 200 OK
     code: 200
     duration: ""
@@ -4110,25 +4204,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3169"
+      - "3166"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:42 GMT
+      - Fri, 20 Oct 2023 13:49:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4138,7 +4232,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 780320e4-c3a6-4a45-b46a-4e142a006ace
+      - 2c8b0aa5-98a0-4ed3-8e6b-8e06100fda77
     status: 200 OK
     code: 200
     duration: ""
@@ -4149,7 +4243,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -4161,7 +4255,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:42 GMT
+      - Fri, 20 Oct 2023 13:49:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4171,7 +4265,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 173e95d5-db24-433c-9dc1-0aa692ec8649
+      - 3ca46457-8964-457e-b729-6e482ab7bb24
     status: 200 OK
     code: 200
     duration: ""
@@ -4182,10 +4276,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -4194,9 +4288,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:42 GMT
+      - Fri, 20 Oct 2023 13:49:36 GMT
       Link:
-      - </servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics?page=1&per_page=50&>;
+      - </servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -4207,7 +4301,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc9dc41b-59e3-4aab-aabc-eb386fbf66e3
+      - f8bef8a8-0d7f-4ab4-ab5a-79579c8bc98e
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -4220,25 +4314,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3169"
+      - "3166"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:43 GMT
+      - Fri, 20 Oct 2023 13:49:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4248,7 +4342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ebfab281-cf1a-47dd-a7f2-9bf7573d9eb7
+      - a6325e19-7456-4de7-af27-81ba958d73ed
     status: 200 OK
     code: 200
     duration: ""
@@ -4259,10 +4353,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -4271,9 +4365,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:43 GMT
+      - Fri, 20 Oct 2023 13:49:37 GMT
       Link:
-      - </servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics?page=1&per_page=50&>;
+      - </servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -4284,7 +4378,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2768d61d-adb6-4d45-b4bd-0cf083c45028
+      - 5b77402a-5aac-402d-9663-5a03e45f61dc
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -4297,25 +4391,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3169"
+      - "3166"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:43 GMT
+      - Fri, 20 Oct 2023 13:49:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4325,12 +4419,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 445ae5e6-0344-4e18-b92a-f25f53983220
+      - 9b6ba253-167c-48fd-921a-1f73d0748adc
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556"}'
+    body: '{"private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c"}'
     form: {}
     headers:
       Content-Type:
@@ -4338,10 +4432,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:58:43.908780+00:00","id":"4b055a73-f628-43c4-a701-8088dd2a2106","mac_address":"02:00:00:14:49:8b","modification_date":"2023-10-18T08:58:43.908780+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:49:37.761036+00:00","id":"3daa88c2-a585-4366-88d5-ba60ce1d8d57","mac_address":"02:00:00:14:57:ad","modification_date":"2023-10-20T13:49:37.761036+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -4350,7 +4444,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:44 GMT
+      - Fri, 20 Oct 2023 13:49:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4360,7 +4454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 545035d4-dc85-47ef-856b-8c8fe9d49c72
+      - 09024d32-0a0e-4ede-885d-4153f36b7f18
     status: 201 Created
     code: 201
     duration: ""
@@ -4371,10 +4465,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/4b055a73-f628-43c4-a701-8088dd2a2106
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/3daa88c2-a585-4366-88d5-ba60ce1d8d57
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:58:43.908780+00:00","id":"4b055a73-f628-43c4-a701-8088dd2a2106","mac_address":"02:00:00:14:49:8b","modification_date":"2023-10-18T08:58:43.908780+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:49:37.761036+00:00","id":"3daa88c2-a585-4366-88d5-ba60ce1d8d57","mac_address":"02:00:00:14:57:ad","modification_date":"2023-10-20T13:49:37.761036+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -4383,7 +4477,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:44 GMT
+      - Fri, 20 Oct 2023 13:49:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4393,7 +4487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ee59858-39ef-44d4-83c4-28c23bd901b8
+      - 437a4928-2302-44a1-bb73-e51789d4ba23
     status: 200 OK
     code: 200
     duration: ""
@@ -4404,10 +4498,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/4b055a73-f628-43c4-a701-8088dd2a2106
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/3daa88c2-a585-4366-88d5-ba60ce1d8d57
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:58:43.908780+00:00","id":"4b055a73-f628-43c4-a701-8088dd2a2106","mac_address":"02:00:00:14:49:8b","modification_date":"2023-10-18T08:58:45.708546+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:49:37.761036+00:00","id":"3daa88c2-a585-4366-88d5-ba60ce1d8d57","mac_address":"02:00:00:14:57:ad","modification_date":"2023-10-20T13:49:38.613222+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -4416,7 +4510,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:50 GMT
+      - Fri, 20 Oct 2023 13:49:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4426,7 +4520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb7709cd-ee94-416d-ba5a-d187b15b1400
+      - 9c462803-26e4-4795-8ea1-1ec2dba5a0e1
     status: 200 OK
     code: 200
     duration: ""
@@ -4437,10 +4531,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/4b055a73-f628-43c4-a701-8088dd2a2106
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/3daa88c2-a585-4366-88d5-ba60ce1d8d57
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:58:43.908780+00:00","id":"4b055a73-f628-43c4-a701-8088dd2a2106","mac_address":"02:00:00:14:49:8b","modification_date":"2023-10-18T08:58:45.708546+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:49:37.761036+00:00","id":"3daa88c2-a585-4366-88d5-ba60ce1d8d57","mac_address":"02:00:00:14:57:ad","modification_date":"2023-10-20T13:49:38.613222+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -4449,7 +4543,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:50 GMT
+      - Fri, 20 Oct 2023 13:49:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4459,7 +4553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - deab80da-660c-4c12-bac9-2874400e238d
+      - cb880df8-83dc-48ad-8f9c-632bea3c82db
     status: 200 OK
     code: 200
     duration: ""
@@ -4472,25 +4566,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: PATCH
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-18T08:58:43.908780+00:00","id":"4b055a73-f628-43c4-a701-8088dd2a2106","mac_address":"02:00:00:14:49:8b","modification_date":"2023-10-18T08:58:45.708546+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[{"creation_date":"2023-10-20T13:49:37.761036+00:00","id":"3daa88c2-a585-4366-88d5-ba60ce1d8d57","mac_address":"02:00:00:14:57:ad","modification_date":"2023-10-20T13:49:38.613222+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3532"
+      - "3529"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:50 GMT
+      - Fri, 20 Oct 2023 13:49:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4500,7 +4594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7e3adaf-a4e5-40f8-a446-8c96a95b923c
+      - e70ac17f-05a8-4506-8b9a-3b1681008c98
     status: 200 OK
     code: 200
     duration: ""
@@ -4511,25 +4605,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-18T08:58:43.908780+00:00","id":"4b055a73-f628-43c4-a701-8088dd2a2106","mac_address":"02:00:00:14:49:8b","modification_date":"2023-10-18T08:58:45.708546+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[{"creation_date":"2023-10-20T13:49:37.761036+00:00","id":"3daa88c2-a585-4366-88d5-ba60ce1d8d57","mac_address":"02:00:00:14:57:ad","modification_date":"2023-10-20T13:49:38.613222+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3532"
+      - "3529"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:50 GMT
+      - Fri, 20 Oct 2023 13:49:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4539,7 +4633,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f633b326-3cf6-4c42-8722-85e1d37ce37d
+      - 2eb329cc-4c05-4d13-bdba-51ff7816666e
     status: 200 OK
     code: 200
     duration: ""
@@ -4550,25 +4644,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-18T08:58:43.908780+00:00","id":"4b055a73-f628-43c4-a701-8088dd2a2106","mac_address":"02:00:00:14:49:8b","modification_date":"2023-10-18T08:58:45.708546+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[{"creation_date":"2023-10-20T13:49:37.761036+00:00","id":"3daa88c2-a585-4366-88d5-ba60ce1d8d57","mac_address":"02:00:00:14:57:ad","modification_date":"2023-10-20T13:49:38.613222+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3532"
+      - "3529"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:50 GMT
+      - Fri, 20 Oct 2023 13:49:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4578,7 +4672,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1fb11514-6ef5-4e91-9053-26ed6a2fae0d
+      - db685438-723f-4f86-9a67-5927e26ed2e5
     status: 200 OK
     code: 200
     duration: ""
@@ -4589,7 +4683,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -4601,7 +4695,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:50 GMT
+      - Fri, 20 Oct 2023 13:49:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4611,7 +4705,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8227f892-b64b-4754-b39c-b66f24334e1a
+      - 5b5ebee7-52e1-4885-81b9-b8553e9c86b5
     status: 200 OK
     code: 200
     duration: ""
@@ -4622,10 +4716,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-18T08:58:43.908780+00:00","id":"4b055a73-f628-43c4-a701-8088dd2a2106","mac_address":"02:00:00:14:49:8b","modification_date":"2023-10-18T08:58:45.708546+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T13:49:37.761036+00:00","id":"3daa88c2-a585-4366-88d5-ba60ce1d8d57","mac_address":"02:00:00:14:57:ad","modification_date":"2023-10-20T13:49:38.613222+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "744"
@@ -4634,9 +4728,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:51 GMT
+      - Fri, 20 Oct 2023 13:49:44 GMT
       Link:
-      - </servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics?page=1&per_page=50&>;
+      - </servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -4647,7 +4741,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43d041a3-ace4-471b-8295-33ac25efcdf3
+      - 8c961ff1-2eeb-4243-822e-55e298ec432d
       X-Total-Count:
       - "2"
     status: 200 OK
@@ -4660,10 +4754,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-18T08:58:43.908780+00:00","id":"4b055a73-f628-43c4-a701-8088dd2a2106","mac_address":"02:00:00:14:49:8b","modification_date":"2023-10-18T08:58:45.708546+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T13:49:37.761036+00:00","id":"3daa88c2-a585-4366-88d5-ba60ce1d8d57","mac_address":"02:00:00:14:57:ad","modification_date":"2023-10-20T13:49:38.613222+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "744"
@@ -4672,9 +4766,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:51 GMT
+      - Fri, 20 Oct 2023 13:49:44 GMT
       Link:
-      - </servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics?page=1&per_page=50&>;
+      - </servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -4685,7 +4779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a981ad0-be55-40ba-b699-18a7ad7a7ae7
+      - 34aeb481-142d-4d02-8dc0-32a105f82ad5
       X-Total-Count:
       - "2"
     status: 200 OK
@@ -4698,10 +4792,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1fdff68c-4feb-4634-be51-e8c3fd767556
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fe18faa7-6634-4132-b109-07403444845f
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T08:57:38.125186Z","dhcp_enabled":true,"id":"1fdff68c-4feb-4634-be51-e8c3fd767556","name":"private_network_instance","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","subnets":[{"created_at":"2023-10-18T08:57:38.125186Z","id":"49f398fd-5f2b-4ffb-9709-acba45e37bc2","subnet":"172.16.60.0/22","updated_at":"2023-10-18T08:57:38.125186Z"},{"created_at":"2023-10-18T08:57:38.125186Z","id":"dacd056b-0d3b-44e5-ad71-393caad4402f","subnet":"fd4a:c18e:554d:825e::/64","updated_at":"2023-10-18T08:57:38.125186Z"}],"tags":[],"updated_at":"2023-10-18T08:57:38.125186Z","vpc_id":"53e50f63-f6c0-44f7-8576-d6edcb965d9c"}'
+    body: '{"created_at":"2023-10-20T13:49:25.601184Z","dhcp_enabled":true,"id":"fe18faa7-6634-4132-b109-07403444845f","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:49:25.601184Z","id":"2f505869-a87d-4ef1-9c50-26a0bf30354e","subnet":"172.16.136.0/22","updated_at":"2023-10-20T13:49:25.601184Z"},{"created_at":"2023-10-20T13:49:25.601184Z","id":"f5e76938-9011-4fbc-8ebf-6828c040f65f","subnet":"fd5f:519c:6d46:cb90::/64","updated_at":"2023-10-20T13:49:25.601184Z"}],"tags":[],"updated_at":"2023-10-20T13:49:25.601184Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "729"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 13:49:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 40512577-2949-435e-994c-dd9725d7f708
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6144b80b-8a12-4993-aa65-073e23fd774c
+    method: GET
+  response:
+    body: '{"created_at":"2023-10-20T13:48:31.136221Z","dhcp_enabled":true,"id":"6144b80b-8a12-4993-aa65-073e23fd774c","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:48:31.136221Z","id":"68d333ba-17fb-442e-bada-c92078d27a6d","subnet":"172.16.80.0/22","updated_at":"2023-10-20T13:48:31.136221Z"},{"created_at":"2023-10-20T13:48:31.136221Z","id":"70ec41bb-524c-48f3-b031-5d9b088ba7bd","subnet":"fd5f:519c:6d46:d64d::/64","updated_at":"2023-10-20T13:48:31.136221Z"}],"tags":[],"updated_at":"2023-10-20T13:48:31.136221Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "725"
@@ -4710,7 +4837,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:51 GMT
+      - Fri, 20 Oct 2023 13:49:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4720,7 +4847,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d68bc537-8a9a-488c-b1df-2e87a97781bb
+      - 3884e3c7-f3a1-4d0e-8489-fb2e25bd20cf
     status: 200 OK
     code: 200
     duration: ""
@@ -4731,58 +4858,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b4297f49-9804-45eb-a83b-40de42f4384b
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T08:58:31.837558Z","dhcp_enabled":true,"id":"b4297f49-9804-45eb-a83b-40de42f4384b","name":"private_network_instance_02","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","subnets":[{"created_at":"2023-10-18T08:58:31.837558Z","id":"1bded4a4-b339-4c73-9aa9-66186737568a","subnet":"172.16.76.0/22","updated_at":"2023-10-18T08:58:31.837558Z"},{"created_at":"2023-10-18T08:58:31.837558Z","id":"665f118c-6b37-460e-8b9b-55286dcfaa34","subnet":"fd4a:c18e:554d:fe68::/64","updated_at":"2023-10-18T08:58:31.837558Z"}],"tags":[],"updated_at":"2023-10-18T08:58:31.837558Z","vpc_id":"53e50f63-f6c0-44f7-8576-d6edcb965d9c"}'
-    headers:
-      Content-Length:
-      - "728"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 08:58:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 349304cb-8f0e-4ca9-bd37-c23ddaf2b3a3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-18T08:58:43.908780+00:00","id":"4b055a73-f628-43c4-a701-8088dd2a2106","mac_address":"02:00:00:14:49:8b","modification_date":"2023-10-18T08:58:45.708546+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[{"creation_date":"2023-10-20T13:49:37.761036+00:00","id":"3daa88c2-a585-4366-88d5-ba60ce1d8d57","mac_address":"02:00:00:14:57:ad","modification_date":"2023-10-20T13:49:38.613222+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3532"
+      - "3529"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:51 GMT
+      - Fri, 20 Oct 2023 13:49:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4792,7 +4886,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7f03577-94a3-4f08-8db4-b7ad89ae257d
+      - 637fb256-110c-4bae-abeb-7e21ecf030d4
     status: 200 OK
     code: 200
     duration: ""
@@ -4803,7 +4897,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -4815,7 +4909,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:52 GMT
+      - Fri, 20 Oct 2023 13:49:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4825,7 +4919,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbb3cab1-88f2-4821-babc-522b4b1d4d9f
+      - b6a821b3-a8ac-41f1-b375-2078a1c0cac8
     status: 200 OK
     code: 200
     duration: ""
@@ -4836,10 +4930,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-18T08:58:43.908780+00:00","id":"4b055a73-f628-43c4-a701-8088dd2a2106","mac_address":"02:00:00:14:49:8b","modification_date":"2023-10-18T08:58:45.708546+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T13:49:37.761036+00:00","id":"3daa88c2-a585-4366-88d5-ba60ce1d8d57","mac_address":"02:00:00:14:57:ad","modification_date":"2023-10-20T13:49:38.613222+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "744"
@@ -4848,9 +4942,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:52 GMT
+      - Fri, 20 Oct 2023 13:49:45 GMT
       Link:
-      - </servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics?page=1&per_page=50&>;
+      - </servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -4861,7 +4955,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10a0d370-a373-4bf5-81f8-5a499699a8df
+      - 1fbb28bc-955e-49bd-a42c-55abd893e2a0
       X-Total-Count:
       - "2"
     status: 200 OK
@@ -4874,43 +4968,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b4297f49-9804-45eb-a83b-40de42f4384b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6144b80b-8a12-4993-aa65-073e23fd774c
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T08:58:31.837558Z","dhcp_enabled":true,"id":"b4297f49-9804-45eb-a83b-40de42f4384b","name":"private_network_instance_02","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","subnets":[{"created_at":"2023-10-18T08:58:31.837558Z","id":"1bded4a4-b339-4c73-9aa9-66186737568a","subnet":"172.16.76.0/22","updated_at":"2023-10-18T08:58:31.837558Z"},{"created_at":"2023-10-18T08:58:31.837558Z","id":"665f118c-6b37-460e-8b9b-55286dcfaa34","subnet":"fd4a:c18e:554d:fe68::/64","updated_at":"2023-10-18T08:58:31.837558Z"}],"tags":[],"updated_at":"2023-10-18T08:58:31.837558Z","vpc_id":"53e50f63-f6c0-44f7-8576-d6edcb965d9c"}'
-    headers:
-      Content-Length:
-      - "728"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 08:58:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 117a5278-4602-43c8-bd8f-6e64b38720de
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1fdff68c-4feb-4634-be51-e8c3fd767556
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T08:57:38.125186Z","dhcp_enabled":true,"id":"1fdff68c-4feb-4634-be51-e8c3fd767556","name":"private_network_instance","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","subnets":[{"created_at":"2023-10-18T08:57:38.125186Z","id":"49f398fd-5f2b-4ffb-9709-acba45e37bc2","subnet":"172.16.60.0/22","updated_at":"2023-10-18T08:57:38.125186Z"},{"created_at":"2023-10-18T08:57:38.125186Z","id":"dacd056b-0d3b-44e5-ad71-393caad4402f","subnet":"fd4a:c18e:554d:825e::/64","updated_at":"2023-10-18T08:57:38.125186Z"}],"tags":[],"updated_at":"2023-10-18T08:57:38.125186Z","vpc_id":"53e50f63-f6c0-44f7-8576-d6edcb965d9c"}'
+    body: '{"created_at":"2023-10-20T13:48:31.136221Z","dhcp_enabled":true,"id":"6144b80b-8a12-4993-aa65-073e23fd774c","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:48:31.136221Z","id":"68d333ba-17fb-442e-bada-c92078d27a6d","subnet":"172.16.80.0/22","updated_at":"2023-10-20T13:48:31.136221Z"},{"created_at":"2023-10-20T13:48:31.136221Z","id":"70ec41bb-524c-48f3-b031-5d9b088ba7bd","subnet":"fd5f:519c:6d46:d64d::/64","updated_at":"2023-10-20T13:48:31.136221Z"}],"tags":[],"updated_at":"2023-10-20T13:48:31.136221Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "725"
@@ -4919,7 +4980,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:52 GMT
+      - Fri, 20 Oct 2023 13:49:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4929,7 +4990,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40f39065-2381-457c-9a5d-dbcc9d1571e9
+      - 7035c444-c144-4701-b790-3bb44d0b7ea3
     status: 200 OK
     code: 200
     duration: ""
@@ -4940,25 +5001,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fe18faa7-6634-4132-b109-07403444845f
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-18T08:58:43.908780+00:00","id":"4b055a73-f628-43c4-a701-8088dd2a2106","mac_address":"02:00:00:14:49:8b","modification_date":"2023-10-18T08:58:45.708546+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    body: '{"created_at":"2023-10-20T13:49:25.601184Z","dhcp_enabled":true,"id":"fe18faa7-6634-4132-b109-07403444845f","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:49:25.601184Z","id":"2f505869-a87d-4ef1-9c50-26a0bf30354e","subnet":"172.16.136.0/22","updated_at":"2023-10-20T13:49:25.601184Z"},{"created_at":"2023-10-20T13:49:25.601184Z","id":"f5e76938-9011-4fbc-8ebf-6828c040f65f","subnet":"fd5f:519c:6d46:cb90::/64","updated_at":"2023-10-20T13:49:25.601184Z"}],"tags":[],"updated_at":"2023-10-20T13:49:25.601184Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "3532"
+      - "729"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:52 GMT
+      - Fri, 20 Oct 2023 13:49:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4968,7 +5023,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cadc3256-823b-4ff3-8279-88dd3096b331
+      - 8c3bdb84-f339-41f6-b4c9-36410b6a7c64
     status: 200 OK
     code: 200
     duration: ""
@@ -4979,7 +5034,46 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[{"creation_date":"2023-10-20T13:49:37.761036+00:00","id":"3daa88c2-a585-4366-88d5-ba60ce1d8d57","mac_address":"02:00:00:14:57:ad","modification_date":"2023-10-20T13:49:38.613222+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3529"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 13:49:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 42ee54c7-9200-486e-9601-809cea0ebba5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -4991,7 +5085,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:52 GMT
+      - Fri, 20 Oct 2023 13:49:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5001,7 +5095,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dfdb80f8-d79c-4b91-8bfb-320e3902adfb
+      - 4f482f49-aab2-4a6e-92b9-34220b9c77bd
     status: 200 OK
     code: 200
     duration: ""
@@ -5012,10 +5106,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-18T08:58:43.908780+00:00","id":"4b055a73-f628-43c4-a701-8088dd2a2106","mac_address":"02:00:00:14:49:8b","modification_date":"2023-10-18T08:58:45.708546+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T13:49:37.761036+00:00","id":"3daa88c2-a585-4366-88d5-ba60ce1d8d57","mac_address":"02:00:00:14:57:ad","modification_date":"2023-10-20T13:49:38.613222+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "744"
@@ -5024,9 +5118,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:52 GMT
+      - Fri, 20 Oct 2023 13:49:46 GMT
       Link:
-      - </servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics?page=1&per_page=50&>;
+      - </servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -5037,7 +5131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30ef0840-bd0f-412b-9230-3212c916372a
+      - 2aa56a65-36cd-4a89-8256-56cac8895f76
       X-Total-Count:
       - "2"
     status: 200 OK
@@ -5050,25 +5144,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-18T08:58:43.908780+00:00","id":"4b055a73-f628-43c4-a701-8088dd2a2106","mac_address":"02:00:00:14:49:8b","modification_date":"2023-10-18T08:58:45.708546+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[{"creation_date":"2023-10-20T13:49:37.761036+00:00","id":"3daa88c2-a585-4366-88d5-ba60ce1d8d57","mac_address":"02:00:00:14:57:ad","modification_date":"2023-10-20T13:49:38.613222+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3532"
+      - "3529"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:53 GMT
+      - Fri, 20 Oct 2023 13:49:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5078,7 +5172,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0faab441-c5ee-471c-8da1-d9106cd5ce1f
+      - e9bfa5f9-4c9e-4e97-b8dc-578404cfb79a
     status: 200 OK
     code: 200
     duration: ""
@@ -5089,10 +5183,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-18T08:58:43.908780+00:00","id":"4b055a73-f628-43c4-a701-8088dd2a2106","mac_address":"02:00:00:14:49:8b","modification_date":"2023-10-18T08:58:45.708546+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T13:49:37.761036+00:00","id":"3daa88c2-a585-4366-88d5-ba60ce1d8d57","mac_address":"02:00:00:14:57:ad","modification_date":"2023-10-20T13:49:38.613222+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "744"
@@ -5101,9 +5195,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:53 GMT
+      - Fri, 20 Oct 2023 13:49:47 GMT
       Link:
-      - </servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics?page=1&per_page=50&>;
+      - </servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -5114,7 +5208,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb12cb2b-9923-4af0-944a-36ecf498a753
+      - d3748eb0-e88f-4ff4-8176-a2617f7746e0
       X-Total-Count:
       - "2"
     status: 200 OK
@@ -5127,25 +5221,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-18T08:58:43.908780+00:00","id":"4b055a73-f628-43c4-a701-8088dd2a2106","mac_address":"02:00:00:14:49:8b","modification_date":"2023-10-18T08:58:45.708546+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[{"creation_date":"2023-10-20T13:49:37.761036+00:00","id":"3daa88c2-a585-4366-88d5-ba60ce1d8d57","mac_address":"02:00:00:14:57:ad","modification_date":"2023-10-20T13:49:38.613222+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3532"
+      - "3529"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:53 GMT
+      - Fri, 20 Oct 2023 13:49:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5155,7 +5249,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aba6a5b0-5098-400a-a755-09205e547ac4
+      - 08c2aacf-ba7e-435d-8c66-47c977a54c4a
     status: 200 OK
     code: 200
     duration: ""
@@ -5166,10 +5260,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/f5b5e5e1-32e2-4ff2-968f-0425417183bb
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:58:33.760793+00:00","id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","mac_address":"02:00:00:14:49:8a","modification_date":"2023-10-18T08:58:34.728825+00:00","private_network_id":"b4297f49-9804-45eb-a83b-40de42f4384b","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:49:27.695247+00:00","id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","mac_address":"02:00:00:14:57:ac","modification_date":"2023-10-20T13:49:28.550515+00:00","private_network_id":"fe18faa7-6634-4132-b109-07403444845f","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -5178,7 +5272,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:53 GMT
+      - Fri, 20 Oct 2023 13:49:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5188,7 +5282,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 445236a7-b8fb-45cd-ac33-20b1b5a10131
+      - 9efa880f-1fbf-45d7-a05c-c512995d0df6
     status: 200 OK
     code: 200
     duration: ""
@@ -5199,7 +5293,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/f5b5e5e1-32e2-4ff2-968f-0425417183bb
     method: DELETE
   response:
     body: ""
@@ -5207,7 +5301,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Wed, 18 Oct 2023 08:58:54 GMT
+      - Fri, 20 Oct 2023 13:49:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5217,7 +5311,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8dbcd068-64b5-4c2c-a207-ddbf3dd8bc8e
+      - 54f81ecd-60ea-41b6-9986-e34aae1f5b67
     status: 204 No Content
     code: 204
     duration: ""
@@ -5228,10 +5322,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/f5b5e5e1-32e2-4ff2-968f-0425417183bb
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"56a90a35-8ef7-4ac2-8d03-ca38bc0dacc6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"f5b5e5e1-32e2-4ff2-968f-0425417183bb","type":"not_found"}'
     headers:
       Content-Length:
       - "148"
@@ -5240,7 +5334,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:54 GMT
+      - Fri, 20 Oct 2023 13:49:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5250,7 +5344,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e19de09d-b204-41b7-95ba-0369b0db4521
+      - cff4f4a6-fc50-4cc4-bb52-088bbfc0e814
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5261,25 +5355,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[{"creation_date":"2023-10-18T08:58:43.908780+00:00","id":"4b055a73-f628-43c4-a701-8088dd2a2106","mac_address":"02:00:00:14:49:8b","modification_date":"2023-10-18T08:58:45.708546+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[{"creation_date":"2023-10-20T13:49:37.761036+00:00","id":"3daa88c2-a585-4366-88d5-ba60ce1d8d57","mac_address":"02:00:00:14:57:ad","modification_date":"2023-10-20T13:49:38.613222+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3169"
+      - "3166"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:54 GMT
+      - Fri, 20 Oct 2023 13:49:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5289,7 +5383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62b4946d-e0f5-4246-a0f7-cb90a9aefa76
+      - db806e9c-9343-4e3a-977b-dd0ceee2138f
     status: 200 OK
     code: 200
     duration: ""
@@ -5300,10 +5394,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/4b055a73-f628-43c4-a701-8088dd2a2106
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/3daa88c2-a585-4366-88d5-ba60ce1d8d57
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-18T08:58:43.908780+00:00","id":"4b055a73-f628-43c4-a701-8088dd2a2106","mac_address":"02:00:00:14:49:8b","modification_date":"2023-10-18T08:58:45.708546+00:00","private_network_id":"1fdff68c-4feb-4634-be51-e8c3fd767556","server_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T13:49:37.761036+00:00","id":"3daa88c2-a585-4366-88d5-ba60ce1d8d57","mac_address":"02:00:00:14:57:ad","modification_date":"2023-10-20T13:49:38.613222+00:00","private_network_id":"6144b80b-8a12-4993-aa65-073e23fd774c","server_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -5312,7 +5406,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:54 GMT
+      - Fri, 20 Oct 2023 13:49:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5322,7 +5416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a3036d0-daa2-47cb-9a0d-2fbdca72194a
+      - d6315ea6-06e2-428e-8190-d09ba4eb6744
     status: 200 OK
     code: 200
     duration: ""
@@ -5333,7 +5427,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/4b055a73-f628-43c4-a701-8088dd2a2106
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/3daa88c2-a585-4366-88d5-ba60ce1d8d57
     method: DELETE
   response:
     body: ""
@@ -5341,7 +5435,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Wed, 18 Oct 2023 08:58:55 GMT
+      - Fri, 20 Oct 2023 13:49:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5351,7 +5445,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4be9ec3b-3655-4772-adb7-c3ff7d27e2de
+      - e78a3345-98db-43bc-8321-61d3eb09b894
     status: 204 No Content
     code: 204
     duration: ""
@@ -5362,10 +5456,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics/4b055a73-f628-43c4-a701-8088dd2a2106
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics/3daa88c2-a585-4366-88d5-ba60ce1d8d57
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"4b055a73-f628-43c4-a701-8088dd2a2106","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"3daa88c2-a585-4366-88d5-ba60ce1d8d57","type":"not_found"}'
     headers:
       Content-Length:
       - "148"
@@ -5374,7 +5468,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:55 GMT
+      - Fri, 20 Oct 2023 13:49:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5384,7 +5478,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e277f1de-50b2-4e69-8048-c562c61cba62
+      - a4ec29a4-64a8-4bfd-83e0-dd501751b9e8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5397,25 +5491,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: PATCH
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2808"
+      - "2805"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:55 GMT
+      - Fri, 20 Oct 2023 13:49:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5425,7 +5519,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68fd5975-e7f3-4789-bb0d-737736021163
+      - 3770000f-01bf-4e1d-ad60-41d65390ef5d
     status: 200 OK
     code: 200
     duration: ""
@@ -5436,25 +5530,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2808"
+      - "2805"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:55 GMT
+      - Fri, 20 Oct 2023 13:49:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5464,7 +5558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be62d403-4b0e-4fea-80ad-9d5c5439aff0
+      - 9db84d0a-fd75-4d19-8256-45db93aed023
     status: 200 OK
     code: 200
     duration: ""
@@ -5475,25 +5569,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2808"
+      - "2805"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:55 GMT
+      - Fri, 20 Oct 2023 13:49:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5503,7 +5597,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 217a8071-687e-4801-a22e-e693903de193
+      - 7b5baecc-84b0-45f9-985c-59cd8ee068bb
     status: 200 OK
     code: 200
     duration: ""
@@ -5514,7 +5608,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -5526,7 +5620,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:55 GMT
+      - Fri, 20 Oct 2023 13:49:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5536,7 +5630,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d95c565c-4023-40db-b209-e671c80490fe
+      - 7efc9577-913b-4828-9056-a535f5dd16fb
     status: 200 OK
     code: 200
     duration: ""
@@ -5547,7 +5641,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -5559,9 +5653,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:56 GMT
+      - Fri, 20 Oct 2023 13:49:50 GMT
       Link:
-      - </servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics?page=0&per_page=50&>;
+      - </servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -5572,7 +5666,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e17202c8-913d-4097-887f-aa55622e1b80
+      - 98760db6-faf3-48ea-9aa6-94ebea349ee3
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -5585,25 +5679,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2808"
+      - "2805"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:56 GMT
+      - Fri, 20 Oct 2023 13:49:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5613,7 +5707,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a80dbdf7-3d5a-40e0-9b5c-d130d0ee851b
+      - c50a1619-0f6c-417c-ba01-da39f8fab2da
     status: 200 OK
     code: 200
     duration: ""
@@ -5624,10 +5718,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1fdff68c-4feb-4634-be51-e8c3fd767556
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6144b80b-8a12-4993-aa65-073e23fd774c
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T08:57:38.125186Z","dhcp_enabled":true,"id":"1fdff68c-4feb-4634-be51-e8c3fd767556","name":"private_network_instance","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","subnets":[{"created_at":"2023-10-18T08:57:38.125186Z","id":"49f398fd-5f2b-4ffb-9709-acba45e37bc2","subnet":"172.16.60.0/22","updated_at":"2023-10-18T08:57:38.125186Z"},{"created_at":"2023-10-18T08:57:38.125186Z","id":"dacd056b-0d3b-44e5-ad71-393caad4402f","subnet":"fd4a:c18e:554d:825e::/64","updated_at":"2023-10-18T08:57:38.125186Z"}],"tags":[],"updated_at":"2023-10-18T08:57:38.125186Z","vpc_id":"53e50f63-f6c0-44f7-8576-d6edcb965d9c"}'
+    body: '{"created_at":"2023-10-20T13:48:31.136221Z","dhcp_enabled":true,"id":"6144b80b-8a12-4993-aa65-073e23fd774c","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:48:31.136221Z","id":"68d333ba-17fb-442e-bada-c92078d27a6d","subnet":"172.16.80.0/22","updated_at":"2023-10-20T13:48:31.136221Z"},{"created_at":"2023-10-20T13:48:31.136221Z","id":"70ec41bb-524c-48f3-b031-5d9b088ba7bd","subnet":"fd5f:519c:6d46:d64d::/64","updated_at":"2023-10-20T13:48:31.136221Z"}],"tags":[],"updated_at":"2023-10-20T13:48:31.136221Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "725"
@@ -5636,7 +5730,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:56 GMT
+      - Fri, 20 Oct 2023 13:49:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5646,7 +5740,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc6ae225-b6fa-407f-84c3-b270488ba9a1
+      - ad73ea5e-99d3-49ca-b085-4f936dfc8252
     status: 200 OK
     code: 200
     duration: ""
@@ -5657,19 +5751,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b4297f49-9804-45eb-a83b-40de42f4384b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fe18faa7-6634-4132-b109-07403444845f
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T08:58:31.837558Z","dhcp_enabled":true,"id":"b4297f49-9804-45eb-a83b-40de42f4384b","name":"private_network_instance_02","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","subnets":[{"created_at":"2023-10-18T08:58:31.837558Z","id":"1bded4a4-b339-4c73-9aa9-66186737568a","subnet":"172.16.76.0/22","updated_at":"2023-10-18T08:58:31.837558Z"},{"created_at":"2023-10-18T08:58:31.837558Z","id":"665f118c-6b37-460e-8b9b-55286dcfaa34","subnet":"fd4a:c18e:554d:fe68::/64","updated_at":"2023-10-18T08:58:31.837558Z"}],"tags":[],"updated_at":"2023-10-18T08:58:31.837558Z","vpc_id":"53e50f63-f6c0-44f7-8576-d6edcb965d9c"}'
+    body: '{"created_at":"2023-10-20T13:49:25.601184Z","dhcp_enabled":true,"id":"fe18faa7-6634-4132-b109-07403444845f","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:49:25.601184Z","id":"2f505869-a87d-4ef1-9c50-26a0bf30354e","subnet":"172.16.136.0/22","updated_at":"2023-10-20T13:49:25.601184Z"},{"created_at":"2023-10-20T13:49:25.601184Z","id":"f5e76938-9011-4fbc-8ebf-6828c040f65f","subnet":"fd5f:519c:6d46:cb90::/64","updated_at":"2023-10-20T13:49:25.601184Z"}],"tags":[],"updated_at":"2023-10-20T13:49:25.601184Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "728"
+      - "729"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:56 GMT
+      - Fri, 20 Oct 2023 13:49:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5679,7 +5773,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5d557c8-426b-443f-9779-f42b1b84ece4
+      - 686f500c-d7d4-4044-b41a-5734fb505bc4
     status: 200 OK
     code: 200
     duration: ""
@@ -5690,25 +5784,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2808"
+      - "2805"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:56 GMT
+      - Fri, 20 Oct 2023 13:49:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5718,7 +5812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58d8770a-697f-43f8-b0db-bff209d0bbc8
+      - 34e5f28b-4d8a-4f6b-a59c-8ef0aab5f55a
     status: 200 OK
     code: 200
     duration: ""
@@ -5729,7 +5823,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -5741,7 +5835,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:57 GMT
+      - Fri, 20 Oct 2023 13:49:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5751,7 +5845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9016e4a7-568d-4efb-a8a3-605aa4a953e0
+      - c7541df0-d15d-456a-a10f-39f982fc3ab8
     status: 200 OK
     code: 200
     duration: ""
@@ -5762,7 +5856,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -5774,9 +5868,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:57 GMT
+      - Fri, 20 Oct 2023 13:49:51 GMT
       Link:
-      - </servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/private_nics?page=0&per_page=50&>;
+      - </servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -5787,7 +5881,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 623f5daa-dc75-4b8b-a347-54f28f164637
+      - 049fdbc3-e887-413c-9f8d-ded1132f6d11
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -5800,25 +5894,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:57:54.255639+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:48:45.574146+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2808"
+      - "2805"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:57 GMT
+      - Fri, 20 Oct 2023 13:49:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5828,40 +5922,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff9330d5-007a-41e5-a5fd-4f7457a2c24a
+      - b86ec615-3111-4240-8699-50729b692b62
     status: 200 OK
     code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1fdff68c-4feb-4634-be51-e8c3fd767556
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 08:58:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 747be3cc-e85e-4701-98d0-4f4c5773b068
-    status: 204 No Content
-    code: 204
     duration: ""
 - request:
     body: '{"action":"poweroff"}'
@@ -5872,10 +5935,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd/action","href_result":"/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd","id":"6d0edfe1-a37f-483a-ae14-c3a5b867c080","started_at":"2023-10-18T08:58:58.386965+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409/action","href_result":"/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409","id":"fe4540c2-9327-4e24-9a19-cd919053ee23","started_at":"2023-10-20T13:49:52.516512+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -5884,9 +5947,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:58 GMT
+      - Fri, 20 Oct 2023 13:49:52 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/6d0edfe1-a37f-483a-ae14-c3a5b867c080
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/fe4540c2-9327-4e24-9a19-cd919053ee23
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5896,7 +5959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74f14e8b-53cf-455a-b9c9-97264c5d5de4
+      - 04dc89f8-74a4-4c22-9061-12843604b4db
     status: 202 Accepted
     code: 202
     duration: ""
@@ -5907,7 +5970,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b4297f49-9804-45eb-a83b-40de42f4384b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fe18faa7-6634-4132-b109-07403444845f
     method: DELETE
   response:
     body: ""
@@ -5917,7 +5980,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:58:58 GMT
+      - Fri, 20 Oct 2023 13:49:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5927,7 +5990,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c311ef78-354b-4dc4-b29a-d9e504752de9
+      - 0d48820c-a437-4059-8358-07cf7cbf72c2
     status: 204 No Content
     code: 204
     duration: ""
@@ -5938,288 +6001,17 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:58:57.871897+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2776"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 08:58:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a5bf05b1-0f88-4660-8a71-adb95bf602cd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:58:57.871897+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2776"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 08:59:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 52cdcc85-d508-445c-8663-b87755ce2e68
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:58:57.871897+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2776"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 08:59:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c95a51b8-f634-48aa-8c8a-6464fd97c848
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:58:57.871897+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2776"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 08:59:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ae3d9da9-d895-4eb1-adb6-b071da22993f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"801","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:58:57.871897+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.69.108.43","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2776"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 08:59:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fc598677-415c-409a-9995-54fdbb034999
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:59:22.440094+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":null,"private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2654"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 08:59:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 467e1e19-ae64-4c9b-b968-eac34e93e800
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-18T08:57:40.186570+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-focused-mendeleev","id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:45:05","maintenances":[],"modification_date":"2023-10-18T08:59:22.440094+00:00","name":"tf-srv-focused-mendeleev","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":null,"private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T08:57:40.186570+00:00","export_uri":null,"id":"e404c51d-0cb7-4193-829f-bdf087983f58","modification_date":"2023-10-18T08:57:40.186570+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","name":"tf-srv-focused-mendeleev"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2654"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 08:59:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ba5984f2-6b8d-4836-8e3b-b09164180b9a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6144b80b-8a12-4993-aa65-073e23fd774c
     method: DELETE
   response:
     body: ""
     headers:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
       Date:
-      - Wed, 18 Oct 2023 08:59:25 GMT
+      - Fri, 20 Oct 2023 13:49:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6229,7 +6021,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14d615d6-ed40-40cd-901b-5c0323ec4087
+      - 3379eeea-f05c-42c4-834d-8676819d4587
     status: 204 No Content
     code: 204
     duration: ""
@@ -6240,10 +6032,312 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","type":"not_found"}'
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:49:52.188763+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2773"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 13:49:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 958db146-5d3c-49e3-a32b-a99a97167700
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:49:52.188763+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2773"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 13:49:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f1b30903-d7f2-4aea-9ced-940a103fccd2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:49:52.188763+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2773"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 13:50:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c05d68dc-73b1-424c-9ca1-0be12fa06d42
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:49:52.188763+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2773"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 13:50:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - add4589e-0316-43da-8c9f-feb30c39bb99
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:49:52.188763+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.22.9","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2773"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 13:50:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bf75da52-8aef-41be-b3b3-eb7019dab7e8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:50:14.737218+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2654"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 13:50:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e51594dd-7955-4de4-b74b-0bb7c50e418c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T13:48:32.530862+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-peaceful-hamilton","id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:af:a3","maintenances":[],"modification_date":"2023-10-20T13:50:14.737218+00:00","name":"tf-srv-peaceful-hamilton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T13:48:32.530862+00:00","export_uri":null,"id":"30bde23a-b54c-4434-945a-8622afd3933a","modification_date":"2023-10-20T13:48:32.530862+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","name":"tf-srv-peaceful-hamilton"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2654"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 13:50:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a2780e61-cb4d-4718-98bb-495a58ea01ad
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Fri, 20 Oct 2023 13:50:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0c0adbab-79f8-4206-81a6-c2ec06917941
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -6252,7 +6346,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:59:25 GMT
+      - Fri, 20 Oct 2023 13:50:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6262,7 +6356,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e55859e-4657-435d-aa5c-a4e9eee94f9d
+      - 7eddaa18-3f6a-4d4e-91f2-518a6808de76
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6273,7 +6367,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e404c51d-0cb7-4193-829f-bdf087983f58
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/30bde23a-b54c-4434-945a-8622afd3933a
     method: DELETE
   response:
     body: ""
@@ -6281,7 +6375,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Wed, 18 Oct 2023 08:59:25 GMT
+      - Fri, 20 Oct 2023 13:50:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6291,7 +6385,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10ad6772-2eb6-42ac-aa96-a28b188b66fb
+      - 0511c6e5-d3eb-4285-ac7f-91f6da838720
     status: 204 No Content
     code: 204
     duration: ""
@@ -6302,10 +6396,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e0c90c76-6de8-4c21-9168-0c87b1bef8fd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4b3811c0-d59b-4d1e-ac35-6595d803b409
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"e0c90c76-6de8-4c21-9168-0c87b1bef8fd","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"4b3811c0-d59b-4d1e-ac35-6595d803b409","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -6314,7 +6408,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 08:59:25 GMT
+      - Fri, 20 Oct 2023 13:50:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6324,7 +6418,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f3bd068-3475-4e84-b57d-a097e1f867ad
+      - 35a63b77-851f-4491-a547-4587f87b9ad7
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/lblb-different-locality-ipid.cassette.yaml
+++ b/scaleway/testdata/lblb-different-locality-ipid.cassette.yaml
@@ -2,27 +2,27 @@
 version: 1
 interactions:
 - request:
-    body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","reverse":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/lb/v1/zones/fr-par-2/ips
     method: POST
   response:
-    body: '{"id":"219a5e42-9bc6-4d1e-a33a-9c59de54e758","ip_address":"51.159.87.170","lb_id":null,"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","reverse":"51-159-87-170.lb.fr-par.scw.cloud","zone":"fr-par-2"}'
+    body: '{"id":"58ab4591-6e1c-4177-90c5-e6e26fc60904","ip_address":"51.159.86.186","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-86-186.lb.fr-par.scw.cloud","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "278"
+      - "285"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 03 Jan 2023 10:05:05 GMT
+      - Fri, 20 Oct 2023 14:18:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b20f0007-eb10-4864-b531-fec1b1612aeb
+      - 77db48be-d307-475a-913b-def7900eda96
     status: 200 OK
     code: 200
     duration: ""
@@ -41,21 +41,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-2/ips/219a5e42-9bc6-4d1e-a33a-9c59de54e758
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-2/ips/58ab4591-6e1c-4177-90c5-e6e26fc60904
     method: GET
   response:
-    body: '{"id":"219a5e42-9bc6-4d1e-a33a-9c59de54e758","ip_address":"51.159.87.170","lb_id":null,"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","reverse":"51-159-87-170.lb.fr-par.scw.cloud","zone":"fr-par-2"}'
+    body: '{"id":"58ab4591-6e1c-4177-90c5-e6e26fc60904","ip_address":"51.159.86.186","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-86-186.lb.fr-par.scw.cloud","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "278"
+      - "285"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 03 Jan 2023 10:05:05 GMT
+      - Fri, 20 Oct 2023 14:18:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c27d102e-cfd9-4ca9-b73e-5ae19bd7023a
+      - 9087a291-d91e-460a-b58f-3320eb136965
     status: 200 OK
     code: 200
     duration: ""
@@ -74,21 +74,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-2/ips/219a5e42-9bc6-4d1e-a33a-9c59de54e758
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-2/ips/58ab4591-6e1c-4177-90c5-e6e26fc60904
     method: GET
   response:
-    body: '{"id":"219a5e42-9bc6-4d1e-a33a-9c59de54e758","ip_address":"51.159.87.170","lb_id":null,"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","reverse":"51-159-87-170.lb.fr-par.scw.cloud","zone":"fr-par-2"}'
+    body: '{"id":"58ab4591-6e1c-4177-90c5-e6e26fc60904","ip_address":"51.159.86.186","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-86-186.lb.fr-par.scw.cloud","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "278"
+      - "285"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 03 Jan 2023 10:05:05 GMT
+      - Fri, 20 Oct 2023 14:18:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee055e6d-e687-4178-a171-5605157e9e92
+      - 5346f00c-934a-4a13-bc47-e92b66441aeb
     status: 200 OK
     code: 200
     duration: ""
@@ -107,21 +107,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-2/ips/219a5e42-9bc6-4d1e-a33a-9c59de54e758
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-2/ips/58ab4591-6e1c-4177-90c5-e6e26fc60904
     method: GET
   response:
-    body: '{"id":"219a5e42-9bc6-4d1e-a33a-9c59de54e758","ip_address":"51.159.87.170","lb_id":null,"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","reverse":"51-159-87-170.lb.fr-par.scw.cloud","zone":"fr-par-2"}'
+    body: '{"id":"58ab4591-6e1c-4177-90c5-e6e26fc60904","ip_address":"51.159.86.186","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-86-186.lb.fr-par.scw.cloud","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "278"
+      - "285"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 03 Jan 2023 10:05:05 GMT
+      - Fri, 20 Oct 2023 14:18:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -131,7 +131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54de9cc7-3d51-4307-a973-dfbcb961ecee
+      - 84815af8-9990-4677-879f-798ac45336fd
     status: 200 OK
     code: 200
     duration: ""
@@ -140,21 +140,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-2/ips/219a5e42-9bc6-4d1e-a33a-9c59de54e758
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-2/ips/58ab4591-6e1c-4177-90c5-e6e26fc60904
     method: GET
   response:
-    body: '{"id":"219a5e42-9bc6-4d1e-a33a-9c59de54e758","ip_address":"51.159.87.170","lb_id":null,"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","reverse":"51-159-87-170.lb.fr-par.scw.cloud","zone":"fr-par-2"}'
+    body: '{"id":"58ab4591-6e1c-4177-90c5-e6e26fc60904","ip_address":"51.159.86.186","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-86-186.lb.fr-par.scw.cloud","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "278"
+      - "285"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 03 Jan 2023 10:05:06 GMT
+      - Fri, 20 Oct 2023 14:18:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -164,7 +164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9413a3f-bbea-4177-a976-9ef9a3220259
+      - 4283b6cc-21bb-4eed-aee3-8058127dc57c
     status: 200 OK
     code: 200
     duration: ""
@@ -173,21 +173,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-2/ips/219a5e42-9bc6-4d1e-a33a-9c59de54e758
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-2/ips/58ab4591-6e1c-4177-90c5-e6e26fc60904
     method: GET
   response:
-    body: '{"id":"219a5e42-9bc6-4d1e-a33a-9c59de54e758","ip_address":"51.159.87.170","lb_id":null,"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","reverse":"51-159-87-170.lb.fr-par.scw.cloud","zone":"fr-par-2"}'
+    body: '{"id":"58ab4591-6e1c-4177-90c5-e6e26fc60904","ip_address":"51.159.86.186","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-86-186.lb.fr-par.scw.cloud","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "278"
+      - "285"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 03 Jan 2023 10:05:06 GMT
+      - Fri, 20 Oct 2023 14:18:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -197,7 +197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ead5186a-e104-4eeb-9d6d-c799ac6c8ff1
+      - 3b06ea74-45c1-4d34-b29b-5699ef1124d6
     status: 200 OK
     code: 200
     duration: ""
@@ -206,21 +206,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-2/ips/219a5e42-9bc6-4d1e-a33a-9c59de54e758
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-2/ips/58ab4591-6e1c-4177-90c5-e6e26fc60904
     method: GET
   response:
-    body: '{"id":"219a5e42-9bc6-4d1e-a33a-9c59de54e758","ip_address":"51.159.87.170","lb_id":null,"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","reverse":"51-159-87-170.lb.fr-par.scw.cloud","zone":"fr-par-2"}'
+    body: '{"id":"58ab4591-6e1c-4177-90c5-e6e26fc60904","ip_address":"51.159.86.186","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-86-186.lb.fr-par.scw.cloud","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "278"
+      - "285"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 03 Jan 2023 10:05:06 GMT
+      - Fri, 20 Oct 2023 14:18:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -230,7 +230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a121c1e-b491-41ba-8d08-b22c334f2466
+      - c58549aa-d5bd-4598-9203-92dfd0deb59c
     status: 200 OK
     code: 200
     duration: ""
@@ -239,9 +239,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-2/ips/219a5e42-9bc6-4d1e-a33a-9c59de54e758
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-2/ips/58ab4591-6e1c-4177-90c5-e6e26fc60904
     method: DELETE
   response:
     body: ""
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 03 Jan 2023 10:05:07 GMT
+      - Fri, 20 Oct 2023 14:18:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -261,7 +261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75122b98-dd5c-42bd-b38a-34c252a8454e
+      - 4120043c-64f7-4937-9cdb-c286436d9d81
     status: 204 No Content
     code: 204
     duration: ""

--- a/scaleway/testdata/lblb-invalid-static-config.cassette.yaml
+++ b/scaleway/testdata/lblb-invalid-static-config.cassette.yaml
@@ -2,27 +2,27 @@
 version: 1
 interactions:
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips
     method: POST
   response:
-    body: '{"id":"52ec682b-e8d9-4483-b356-ad8ef40fc63e","ip_address":"51.158.57.58","lb_id":null,"organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-58.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
+    body: '{"id":"f83d83d1-cedb-41cf-9da7-2fc655bbef4b","ip_address":"51.159.113.101","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-101.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "276"
+      - "287"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 13 Oct 2023 16:17:50 GMT
+      - Fri, 20 Oct 2023 14:18:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22d47571-c817-4de7-81c1-9085f7b76c85
+      - 1cc3d7a7-ac1a-48d0-894a-2e77f64cb08e
     status: 200 OK
     code: 200
     duration: ""
@@ -41,21 +41,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/52ec682b-e8d9-4483-b356-ad8ef40fc63e
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/f83d83d1-cedb-41cf-9da7-2fc655bbef4b
     method: GET
   response:
-    body: '{"id":"52ec682b-e8d9-4483-b356-ad8ef40fc63e","ip_address":"51.158.57.58","lb_id":null,"organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-58.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
+    body: '{"id":"f83d83d1-cedb-41cf-9da7-2fc655bbef4b","ip_address":"51.159.113.101","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-101.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "276"
+      - "287"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 13 Oct 2023 16:17:50 GMT
+      - Fri, 20 Oct 2023 14:18:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,32 +65,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7774fae-0d15-4436-bd9e-751af2d3aa7d
+      - c6bbfada-2e67-422c-a608-574351827306
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"pn-with-lb-to-static","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"pn-with-lb-to-static","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null,"vpc_id":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-13T16:17:50.861367Z","dhcp_enabled":true,"id":"63450d99-30e3-4fa6-aea7-63fc60d8d22f","name":"pn-with-lb-to-static","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-13T16:17:50.861367Z","id":"48480cce-fcf9-4e98-92a6-e1707dbf99c2","subnet":"172.16.52.0/22","updated_at":"2023-10-13T16:17:50.861367Z"},{"created_at":"2023-10-13T16:17:50.861367Z","id":"dbaa7ad5-358a-4820-9b2c-b4985663b3c7","subnet":"fd46:78ab:30b8:9f3::/64","updated_at":"2023-10-13T16:17:50.861367Z"}],"tags":[],"updated_at":"2023-10-13T16:17:50.861367Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2023-10-20T14:18:26.521911Z","dhcp_enabled":true,"id":"ae92d2fc-76fa-456b-8d09-39314e8c12ea","name":"pn-with-lb-to-static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T14:18:26.521911Z","id":"3541405b-096a-4f5a-8d62-0d0dadf2e62b","subnet":"172.16.120.0/22","updated_at":"2023-10-20T14:18:26.521911Z"},{"created_at":"2023-10-20T14:18:26.521911Z","id":"3d294c2a-ca89-405a-9c11-44693a1cb257","subnet":"fd5f:519c:6d46:b50::/64","updated_at":"2023-10-20T14:18:26.521911Z"}],"tags":[],"updated_at":"2023-10-20T14:18:26.521911Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "703"
+      - "721"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 13 Oct 2023 16:17:51 GMT
+      - Fri, 20 Oct 2023 14:18:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -100,7 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac42daaf-f206-4e82-9e44-b76dc2a9e722
+      - f1a5314a-38eb-4734-91e0-09cbf8ccbe7b
     status: 200 OK
     code: 200
     duration: ""
@@ -109,21 +109,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/63450d99-30e3-4fa6-aea7-63fc60d8d22f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ae92d2fc-76fa-456b-8d09-39314e8c12ea
     method: GET
   response:
-    body: '{"created_at":"2023-10-13T16:17:50.861367Z","dhcp_enabled":true,"id":"63450d99-30e3-4fa6-aea7-63fc60d8d22f","name":"pn-with-lb-to-static","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-13T16:17:50.861367Z","id":"48480cce-fcf9-4e98-92a6-e1707dbf99c2","subnet":"172.16.52.0/22","updated_at":"2023-10-13T16:17:50.861367Z"},{"created_at":"2023-10-13T16:17:50.861367Z","id":"dbaa7ad5-358a-4820-9b2c-b4985663b3c7","subnet":"fd46:78ab:30b8:9f3::/64","updated_at":"2023-10-13T16:17:50.861367Z"}],"tags":[],"updated_at":"2023-10-13T16:17:50.861367Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2023-10-20T14:18:26.521911Z","dhcp_enabled":true,"id":"ae92d2fc-76fa-456b-8d09-39314e8c12ea","name":"pn-with-lb-to-static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T14:18:26.521911Z","id":"3541405b-096a-4f5a-8d62-0d0dadf2e62b","subnet":"172.16.120.0/22","updated_at":"2023-10-20T14:18:26.521911Z"},{"created_at":"2023-10-20T14:18:26.521911Z","id":"3d294c2a-ca89-405a-9c11-44693a1cb257","subnet":"fd5f:519c:6d46:b50::/64","updated_at":"2023-10-20T14:18:26.521911Z"}],"tags":[],"updated_at":"2023-10-20T14:18:26.521911Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "703"
+      - "721"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 13 Oct 2023 16:17:51 GMT
+      - Fri, 20 Oct 2023 14:18:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -133,7 +133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 316d370e-efc8-47fa-9079-9a45f7b495a3
+      - fe3c15d6-c398-49f8-8be4-b371b25fb23c
     status: 200 OK
     code: 200
     duration: ""
@@ -142,21 +142,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/52ec682b-e8d9-4483-b356-ad8ef40fc63e
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/f83d83d1-cedb-41cf-9da7-2fc655bbef4b
     method: GET
   response:
-    body: '{"id":"52ec682b-e8d9-4483-b356-ad8ef40fc63e","ip_address":"51.158.57.58","lb_id":null,"organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-58.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
+    body: '{"id":"f83d83d1-cedb-41cf-9da7-2fc655bbef4b","ip_address":"51.159.113.101","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-101.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "276"
+      - "287"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 13 Oct 2023 16:17:51 GMT
+      - Fri, 20 Oct 2023 14:18:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -166,7 +166,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61e6a29c-0bf0-476f-9c9f-87440fb57617
+      - e9815fd9-c925-4e4e-aaec-681586abbbc8
     status: 200 OK
     code: 200
     duration: ""
@@ -175,9 +175,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/52ec682b-e8d9-4483-b356-ad8ef40fc63e
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/f83d83d1-cedb-41cf-9da7-2fc655bbef4b
     method: DELETE
   response:
     body: ""
@@ -187,7 +187,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 13 Oct 2023 16:17:52 GMT
+      - Fri, 20 Oct 2023 14:18:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -197,7 +197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f597c77-dce9-4c12-8483-ecad600475a8
+      - f1e4e1db-df33-4361-b0ec-0a108ad38421
     status: 204 No Content
     code: 204
     duration: ""
@@ -206,9 +206,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/63450d99-30e3-4fa6-aea7-63fc60d8d22f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ae92d2fc-76fa-456b-8d09-39314e8c12ea
     method: DELETE
   response:
     body: ""
@@ -218,7 +218,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 13 Oct 2023 16:17:52 GMT
+      - Fri, 20 Oct 2023 14:18:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -228,7 +228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b288760c-2a68-474a-b467-23fbba680561
+      - dac73f95-9619-4bc9-badc-968a0c91f4ff
     status: 204 No Content
     code: 204
     duration: ""

--- a/scaleway/testdata/lblb-with-private-networks-on-dhcp-config.cassette.yaml
+++ b/scaleway/testdata/lblb-with-private-networks-on-dhcp-config.cassette.yaml
@@ -2,27 +2,27 @@
 version: 1
 interactions:
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","subnet":"10.0.0.0/24","address":null,"pool_low":null,"pool_high":null,"enable_dynamic":null,"valid_lifetime":null,"renew_timer":null,"rebind_timer":null,"push_default_route":null,"push_dns_server":null,"dns_servers_override":null,"dns_search":null,"dns_local_name":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"10.0.0.0/24","address":null,"pool_low":null,"pool_high":null,"enable_dynamic":null,"valid_lifetime":null,"renew_timer":null,"rebind_timer":null,"push_default_route":null,"push_dns_server":null,"dns_servers_override":null,"dns_search":null,"dns_local_name":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
     method: POST
   response:
-    body: '{"address":"10.0.0.1","created_at":"2023-07-12T09:43:23.360057Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4ac59b75-000a-4fd7-be45-a33eb2287983","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:43:23.360057Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.307165Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"77bc134a-7df0-4cd8-beae-9bb95127fbff","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.307165Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "556"
+      - "574"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:23 GMT
+      - Fri, 20 Oct 2023 14:18:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,32 +32,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac071080-55b5-48fa-9cdd-15cee262ca4d
+      - 162c4b7d-f5be-4d7e-96c9-a9663b4edc2d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips
     method: POST
   response:
-    body: '{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":null,"organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
+    body: '{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "278"
+      - "283"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:23 GMT
+      - Fri, 20 Oct 2023 14:18:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -67,7 +67,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4079e72-ab98-408b-8a8d-48817485b086
+      - 56bcd3f3-5e5d-41b6-8e76-966a0e6807ad
     status: 200 OK
     code: 200
     duration: ""
@@ -76,21 +76,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/4ac59b75-000a-4fd7-be45-a33eb2287983
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/77bc134a-7df0-4cd8-beae-9bb95127fbff
     method: GET
   response:
-    body: '{"address":"10.0.0.1","created_at":"2023-07-12T09:43:23.360057Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4ac59b75-000a-4fd7-be45-a33eb2287983","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:43:23.360057Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.307165Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"77bc134a-7df0-4cd8-beae-9bb95127fbff","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.307165Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "556"
+      - "574"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:23 GMT
+      - Fri, 20 Oct 2023 14:18:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -100,7 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6005a0c-b2a4-412c-8e5e-fe44a432b250
+      - 334b6cb2-0caf-4382-bb75-85b0f2a1df5a
     status: 200 OK
     code: 200
     duration: ""
@@ -109,21 +109,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/36097131-88b0-4e6b-9baf-6d1e304e81da
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/f8576741-b282-4830-9813-a6b028e3f0ca
     method: GET
   response:
-    body: '{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":null,"organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
+    body: '{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "278"
+      - "283"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:23 GMT
+      - Fri, 20 Oct 2023 14:18:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -133,33 +133,169 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef78eaee-c4a0-4a6f-9b7c-f118c00ede0f
+      - ae82d966-3275-4764-80f2-77108144efce
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"private network with a DHCP config","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
+    method: POST
+  response:
+    body: '{"address":"51.15.139.125","created_at":"2023-10-20T14:18:26.967221Z","gateway_id":null,"id":"f5ad4bfe-5f76-48e3-bfc9-fe61c59d6b56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"125-139-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.967221Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "367"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:18:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 901fd9fe-fb35-4ed0-a240-662d1f455b41
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/f5ad4bfe-5f76-48e3-bfc9-fe61c59d6b56
+    method: GET
+  response:
+    body: '{"address":"51.15.139.125","created_at":"2023-10-20T14:18:26.967221Z","gateway_id":null,"id":"f5ad4bfe-5f76-48e3-bfc9-fe61c59d6b56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"125-139-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.967221Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "367"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:18:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ae28f46f-2fae-4b9e-8909-4016b10c755e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-public-gw","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"f5ad4bfe-5f76-48e3-bfc9-fe61c59d6b56","enable_smtp":false,"enable_bastion":false,"bastion_port":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
+    method: POST
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.100301Z","gateway_networks":[],"id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","ip":{"address":"51.15.139.125","created_at":"2023-10-20T14:18:26.967221Z","gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"f5ad4bfe-5f76-48e3-bfc9-fe61c59d6b56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"125-139-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.967221Z","zone":"fr-par-1"},"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:27.100301Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "980"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:18:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2fca68c7-c8d8-469e-90e9-a62ecf784375
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.100301Z","gateway_networks":[],"id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","ip":{"address":"51.15.139.125","created_at":"2023-10-20T14:18:26.967221Z","gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"f5ad4bfe-5f76-48e3-bfc9-fe61c59d6b56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"125-139-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.967221Z","zone":"fr-par-1"},"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:27.142518Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "983"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:18:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 69a9ed96-f7a8-4def-b25f-401a1083f1da
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"private network with a DHCP config","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null,"vpc_id":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-07-12T09:43:23.395931Z","dhcp_enabled":false,"id":"a32b2fda-5143-40eb-a034-f01629975382","name":"private
-      network with a DHCP config","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-07-12T09:43:23.395931Z","id":"25525de3-cbf9-4727-894d-2cca49ebf678","subnet":"172.16.4.0/22","updated_at":"2023-07-12T09:43:23.395931Z"},{"created_at":"2023-07-12T09:43:23.395931Z","id":"2e3e5d5e-3c76-42d4-8b63-4e98bb1985c6","subnet":"fd46:78ab:30b8:1151::/64","updated_at":"2023-07-12T09:43:23.395931Z"}],"tags":[],"updated_at":"2023-07-12T09:43:23.395931Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2023-10-20T14:18:26.405234Z","dhcp_enabled":true,"id":"487c2354-24bb-4b17-bf88-0d918610cea9","name":"private
+      network with a DHCP config","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T14:18:26.405234Z","id":"6204fe9b-7942-4693-96e7-973d31fd34e7","subnet":"172.16.136.0/22","updated_at":"2023-10-20T14:18:26.405234Z"},{"created_at":"2023-10-20T14:18:26.405234Z","id":"f3d6c0a6-b866-4e96-8981-01110c629b0e","subnet":"fd5f:519c:6d46:9931::/64","updated_at":"2023-10-20T14:18:26.405234Z"}],"tags":[],"updated_at":"2023-10-20T14:18:26.405234Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "718"
+      - "736"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:23 GMT
+      - Fri, 20 Oct 2023 14:18:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -169,7 +305,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f960d2c-77cf-4730-a85a-9a69a1a06623
+      - 6d679555-3a82-4093-9b27-dc49c5c30559
     status: 200 OK
     code: 200
     duration: ""
@@ -178,22 +314,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a32b2fda-5143-40eb-a034-f01629975382
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/487c2354-24bb-4b17-bf88-0d918610cea9
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:43:23.395931Z","dhcp_enabled":false,"id":"a32b2fda-5143-40eb-a034-f01629975382","name":"private
-      network with a DHCP config","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-07-12T09:43:23.395931Z","id":"25525de3-cbf9-4727-894d-2cca49ebf678","subnet":"172.16.4.0/22","updated_at":"2023-07-12T09:43:23.395931Z"},{"created_at":"2023-07-12T09:43:23.395931Z","id":"2e3e5d5e-3c76-42d4-8b63-4e98bb1985c6","subnet":"fd46:78ab:30b8:1151::/64","updated_at":"2023-07-12T09:43:23.395931Z"}],"tags":[],"updated_at":"2023-07-12T09:43:23.395931Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2023-10-20T14:18:26.405234Z","dhcp_enabled":true,"id":"487c2354-24bb-4b17-bf88-0d918610cea9","name":"private
+      network with a DHCP config","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T14:18:26.405234Z","id":"6204fe9b-7942-4693-96e7-973d31fd34e7","subnet":"172.16.136.0/22","updated_at":"2023-10-20T14:18:26.405234Z"},{"created_at":"2023-10-20T14:18:26.405234Z","id":"f3d6c0a6-b866-4e96-8981-01110c629b0e","subnet":"fd5f:519c:6d46:9931::/64","updated_at":"2023-10-20T14:18:26.405234Z"}],"tags":[],"updated_at":"2023-10-20T14:18:26.405234Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "718"
+      - "736"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:23 GMT
+      - Fri, 20 Oct 2023 14:18:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +339,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4031e292-69ba-4f77-917f-6a25002502dc
+      - 601d35cb-1542-4bae-817e-68171ee13607
     status: 200 OK
     code: 200
     duration: ""
@@ -212,21 +348,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=debian_bullseye&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","label":"debian_bullseye","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60"],"id":"92de05f7-7bfa-4920-8fb6-035764ba1792","label":"debian_bullseye","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","label":"debian_bullseye","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"7691a260-ab4a-4692-8c54-862e08826deb","label":"debian_bullseye","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1098"
+      - "1262"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:23 GMT
+      - Fri, 20 Oct 2023 14:18:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +372,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63ca0abe-93e7-4e3d-87ba-21da8b0baae6
+      - b80a6e44-266e-4dd1-8677-f04cb5dcf90d
     status: 200 OK
     code: 200
     duration: ""
@@ -245,21 +381,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
+    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
     headers:
       Content-Length:
-      - "37931"
+      - "38421"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:23 GMT
+      - Fri, 20 Oct 2023 14:18:27 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
@@ -272,7 +408,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9374de83-3e65-4452-b77a-3f13b9e711b9
+      - e67b30d8-ff4e-450e-ac20-e5723da0125e
       X-Total-Count:
       - "56"
     status: 200 OK
@@ -283,21 +419,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
     headers:
       Content-Length:
-      - "4489"
+      - "4865"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:23 GMT
+      - Fri, 20 Oct 2023 14:18:27 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
@@ -310,112 +446,44 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61ad3ac3-5d16-46a4-be87-389ed13ce5be
+      - 738101e4-abb4-423c-b7c4-addf375288c4
       X-Total-Count:
       - "56"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null}'
+    body: '{"name":"Scaleway Terraform Provider","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"92e694e8-5f29-420f-b48d-c3cb88de283d","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
-    method: POST
-  response:
-    body: '{"address":"163.172.142.90","created_at":"2023-07-12T09:43:23.969335Z","gateway_id":null,"id":"f7ffb21f-b279-4b49-a10e-ba7ac7b58d99","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"90-142-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:43:23.969335Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "360"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:43:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - eff14fef-16bc-462f-9b2b-0a33154cf12f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/f7ffb21f-b279-4b49-a10e-ba7ac7b58d99
-    method: GET
-  response:
-    body: '{"address":"163.172.142.90","created_at":"2023-07-12T09:43:23.969335Z","gateway_id":null,"id":"f7ffb21f-b279-4b49-a10e-ba7ac7b58d99","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"90-142-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:43:23.969335Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "360"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:43:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c5360675-1449-4447-b1ef-466160c818bd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"Scaleway Terraform Provider","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:43:24.129491+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:0d","maintenances":[],"modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:43:24.129491+00:00","export_uri":null,"id":"45fdaa44-3af7-4bf4-a09c-e6d7d065ee0c","modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.142624+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b1:73","maintenances":[],"modification_date":"2023-10-20T14:18:28.142624+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.142624+00:00","export_uri":null,"id":"b60cee5c-b097-4855-a3ce-407f0bca70cc","modification_date":"2023-10-20T14:18:28.142624+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2616"
+      - "2636"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:24 GMT
+      - Fri, 20 Oct 2023 14:18:28 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -425,73 +493,38 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e46e0710-3e8e-4531-bc84-87e7a29622bb
+      - 8c51cb1d-6741-4a74-b515-e455072348e3
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","name":"tf-test-public-gw","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"f7ffb21f-b279-4b49-a10e-ba7ac7b58d99","enable_smtp":false,"enable_bastion":false,"bastion_port":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
-    method: POST
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:43:24.390741Z","gateway_networks":[],"id":"98be913f-45a8-4870-ac7e-f41c5c59b906","ip":{"address":"163.172.142.90","created_at":"2023-07-12T09:43:23.969335Z","gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"f7ffb21f-b279-4b49-a10e-ba7ac7b58d99","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"90-142-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:43:23.969335Z","zone":"fr-par-1"},"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:43:24.390741Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "935"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:43:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e02b38f4-cdbf-449d-a1ee-699e85c8facd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
     body: ""
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:43:24.129491+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:0d","maintenances":[],"modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:43:24.129491+00:00","export_uri":null,"id":"45fdaa44-3af7-4bf4-a09c-e6d7d065ee0c","modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.142624+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b1:73","maintenances":[],"modification_date":"2023-10-20T14:18:28.142624+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.142624+00:00","export_uri":null,"id":"b60cee5c-b097-4855-a3ce-407f0bca70cc","modification_date":"2023-10-20T14:18:28.142624+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2616"
+      - "2636"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:24 GMT
+      - Fri, 20 Oct 2023 14:18:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -501,7 +534,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bbc6acdf-6fa3-4c59-935f-5fc3b45fc741
+      - a5a10e09-25aa-4eca-a8b5-a9eb5d09582f
     status: 200 OK
     code: 200
     duration: ""
@@ -510,62 +543,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/98be913f-45a8-4870-ac7e-f41c5c59b906
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:43:24.390741Z","gateway_networks":[],"id":"98be913f-45a8-4870-ac7e-f41c5c59b906","ip":{"address":"163.172.142.90","created_at":"2023-07-12T09:43:23.969335Z","gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"f7ffb21f-b279-4b49-a10e-ba7ac7b58d99","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"90-142-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:43:23.969335Z","zone":"fr-par-1"},"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:43:24.451967Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "938"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:43:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f54a04e5-4207-4206-9cca-781ce3c9964a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:43:24.129491+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:0d","maintenances":[],"modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:43:24.129491+00:00","export_uri":null,"id":"45fdaa44-3af7-4bf4-a09c-e6d7d065ee0c","modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.142624+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b1:73","maintenances":[],"modification_date":"2023-10-20T14:18:28.142624+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.142624+00:00","export_uri":null,"id":"b60cee5c-b097-4855-a3ce-407f0bca70cc","modification_date":"2023-10-20T14:18:28.142624+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2616"
+      - "2636"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:24 GMT
+      - Fri, 20 Oct 2023 14:18:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -575,7 +575,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d2d28ae-66be-4654-b627-6553135ac117
+      - f98a5958-09db-4ceb-b7c9-6d806b85d5c3
     status: 200 OK
     code: 200
     duration: ""
@@ -586,12 +586,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4/action","href_result":"/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4","id":"fe2decc6-c786-487a-8493-0d7f949446a9","started_at":"2023-07-12T09:43:25.038343+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/action","href_result":"/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7","id":"c492a573-1ef5-4cf4-9dfa-9e5384c98619","started_at":"2023-10-20T14:18:29.717256+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -600,9 +600,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:25 GMT
+      - Fri, 20 Oct 2023 14:18:29 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/fe2decc6-c786-487a-8493-0d7f949446a9
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/c492a573-1ef5-4cf4-9dfa-9e5384c98619
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -612,7 +612,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ac02422-d06d-4277-9350-b0ecd82ae385
+      - de6f6f3a-8f41-408d-a5b3-eefc3d42cd37
     status: 202 Accepted
     code: 202
     duration: ""
@@ -621,29 +621,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:43:24.129491+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:0d","maintenances":[],"modification_date":"2023-07-12T09:43:24.669211+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:43:24.129491+00:00","export_uri":null,"id":"45fdaa44-3af7-4bf4-a09c-e6d7d065ee0c","modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.142624+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b1:73","maintenances":[],"modification_date":"2023-10-20T14:18:29.154477+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.142624+00:00","export_uri":null,"id":"b60cee5c-b097-4855-a3ce-407f0bca70cc","modification_date":"2023-10-20T14:18:28.142624+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2638"
+      - "2658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:25 GMT
+      - Fri, 20 Oct 2023 14:18:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -653,7 +653,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d8010a4-f8d2-4cbc-8dca-d13899e36df3
+      - dc862919-df54-4613-86ff-79251aa57c6b
     status: 200 OK
     code: 200
     duration: ""
@@ -662,21 +662,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/98be913f-45a8-4870-ac7e-f41c5c59b906
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:43:24.390741Z","gateway_networks":[],"id":"98be913f-45a8-4870-ac7e-f41c5c59b906","ip":{"address":"163.172.142.90","created_at":"2023-07-12T09:43:23.969335Z","gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"f7ffb21f-b279-4b49-a10e-ba7ac7b58d99","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"90-142-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:43:23.969335Z","zone":"fr-par-1"},"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:43:25.149018Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.100301Z","gateway_networks":[],"id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","ip":{"address":"51.15.139.125","created_at":"2023-10-20T14:18:26.967221Z","gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"f5ad4bfe-5f76-48e3-bfc9-fe61c59d6b56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"125-139-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.967221Z","zone":"fr-par-1"},"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:27.943282Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "935"
+      - "980"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:29 GMT
+      - Fri, 20 Oct 2023 14:18:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -686,7 +686,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f52966c5-4bdd-4364-be19-0be0e18d10a9
+      - 60d26a47-22b7-4436-9a97-da8e65c964e2
     status: 200 OK
     code: 200
     duration: ""
@@ -695,21 +695,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/98be913f-45a8-4870-ac7e-f41c5c59b906
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:43:24.390741Z","gateway_networks":[],"id":"98be913f-45a8-4870-ac7e-f41c5c59b906","ip":{"address":"163.172.142.90","created_at":"2023-07-12T09:43:23.969335Z","gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"f7ffb21f-b279-4b49-a10e-ba7ac7b58d99","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"90-142-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:43:23.969335Z","zone":"fr-par-1"},"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:43:25.149018Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.100301Z","gateway_networks":[],"id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","ip":{"address":"51.15.139.125","created_at":"2023-10-20T14:18:26.967221Z","gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"f5ad4bfe-5f76-48e3-bfc9-fe61c59d6b56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"125-139-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.967221Z","zone":"fr-par-1"},"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:27.943282Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "935"
+      - "980"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:29 GMT
+      - Fri, 20 Oct 2023 14:18:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -719,7 +719,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ade2f1b-a322-4470-9473-3828a4164f1a
+      - bce62539-106e-44e5-9d69-80729cb4e347
     status: 200 OK
     code: 200
     duration: ""
@@ -728,21 +728,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/98be913f-45a8-4870-ac7e-f41c5c59b906
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:43:24.390741Z","gateway_networks":[],"id":"98be913f-45a8-4870-ac7e-f41c5c59b906","ip":{"address":"163.172.142.90","created_at":"2023-07-12T09:43:23.969335Z","gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"f7ffb21f-b279-4b49-a10e-ba7ac7b58d99","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"90-142-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:43:23.969335Z","zone":"fr-par-1"},"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:43:25.149018Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.100301Z","gateway_networks":[],"id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","ip":{"address":"51.15.139.125","created_at":"2023-10-20T14:18:26.967221Z","gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"f5ad4bfe-5f76-48e3-bfc9-fe61c59d6b56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"125-139-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.967221Z","zone":"fr-par-1"},"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:27.943282Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "935"
+      - "980"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:29 GMT
+      - Fri, 20 Oct 2023 14:18:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -752,32 +752,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4124428f-8227-4ee0-9a2d-827f4751f09b
+      - c817b135-3ad9-4310-b1d1-e151bbb87968
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","name":"test-lb-with-private-network-configs","description":"","ip_id":"36097131-88b0-4e6b-9baf-6d1e304e81da","assign_flexible_ip":null,"tags":null,"type":"LB-S","ssl_compatibility_level":"ssl_compatibility_level_intermediate"}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-lb-with-private-network-configs","description":"","ip_id":"f8576741-b282-4830-9813-a6b028e3f0ca","assign_flexible_ip":null,"tags":null,"type":"LB-S","ssl_compatibility_level":"ssl_compatibility_level_intermediate"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs
     method: POST
   response:
-    body: '{"backend_count":0,"created_at":"2023-07-12T09:43:29.715898992Z","description":"","frontend_count":0,"id":"4f821d84-b13a-4832-883e-40a68bbc437c","instances":[],"ip":[{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":"4f821d84-b13a-4832-883e-40a68bbc437c","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_create","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-07-12T09:43:29.715898992Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2023-10-20T14:18:32.564370540Z","description":"","frontend_count":0,"id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","instances":[],"ip":[{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_create","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-20T14:18:32.564370540Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "887"
+      - "911"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:29 GMT
+      - Fri, 20 Oct 2023 14:18:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -787,7 +787,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c69dde68-d1b4-4300-9325-2160e5b04ffd
+      - f4df218e-78b0-4268-a2f3-6e00f11665e0
     status: 200 OK
     code: 200
     duration: ""
@@ -796,21 +796,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2023-07-12T09:43:29.715899Z","description":"","frontend_count":0,"id":"4f821d84-b13a-4832-883e-40a68bbc437c","instances":[],"ip":[{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":"4f821d84-b13a-4832-883e-40a68bbc437c","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_create","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-07-12T09:43:29.715899Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2023-10-20T14:18:32.564371Z","description":"","frontend_count":0,"id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","instances":[],"ip":[{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_create","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-20T14:18:32.564371Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "881"
+      - "905"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:29 GMT
+      - Fri, 20 Oct 2023 14:18:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -820,32 +820,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ad855d0-137a-4cb7-9b86-4fd1e38e8904
+      - 30846eea-6737-4fa0-8049-1bc4533959fc
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","enable_masquerade":true,"dhcp_id":"4ac59b75-000a-4fd7-be45-a33eb2287983","enable_dhcp":true}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.142624+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"601","node_id":"8","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:73","maintenances":[],"modification_date":"2023-10-20T14:18:29.154477+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.100.15","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.142624+00:00","export_uri":null,"id":"b60cee5c-b097-4855-a3ce-407f0bca70cc","modification_date":"2023-10-20T14:18:28.142624+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","name":"Scaleway
+      Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2766"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:18:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a157491e-6672-4c39-9cf9-ec5cb6601f9f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"77bc134a-7df0-4cd8-beae-9bb95127fbff"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:43:30.019601Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:43:23.360057Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4ac59b75-000a-4fd7-be45-a33eb2287983","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:43:23.360057Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"b03f0edc-4729-4771-b167-2b3850a14688","mac_address":null,"private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","status":"created","updated_at":"2023-07-12T09:43:30.019601Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:18:34.664182Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.307165Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"77bc134a-7df0-4cd8-beae-9bb95127fbff","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.307165Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"538d6444-553e-46f3-9635-d08306cd5512","ipam_config":null,"mac_address":null,"private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","status":"created","updated_at":"2023-10-20T14:18:34.664182Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "922"
+      - "971"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:30 GMT
+      - Fri, 20 Oct 2023 14:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -855,7 +896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e040161e-933b-468f-8474-de2588220828
+      - 6b9970b2-88e9-4998-848f-7797f3cd927f
     status: 200 OK
     code: 200
     duration: ""
@@ -864,21 +905,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/98be913f-45a8-4870-ac7e-f41c5c59b906
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:43:24.390741Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:43:30.019601Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:43:23.360057Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4ac59b75-000a-4fd7-be45-a33eb2287983","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:43:23.360057Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"b03f0edc-4729-4771-b167-2b3850a14688","mac_address":null,"private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","status":"created","updated_at":"2023-07-12T09:43:30.019601Z","zone":"fr-par-1"}],"id":"98be913f-45a8-4870-ac7e-f41c5c59b906","ip":{"address":"163.172.142.90","created_at":"2023-07-12T09:43:23.969335Z","gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"f7ffb21f-b279-4b49-a10e-ba7ac7b58d99","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"90-142-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:43:23.969335Z","zone":"fr-par-1"},"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:43:30.115663Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.100301Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:18:34.664182Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.307165Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"77bc134a-7df0-4cd8-beae-9bb95127fbff","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.307165Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"538d6444-553e-46f3-9635-d08306cd5512","ipam_config":null,"mac_address":null,"private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","status":"created","updated_at":"2023-10-20T14:18:34.664182Z","zone":"fr-par-1"}],"id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","ip":{"address":"51.15.139.125","created_at":"2023-10-20T14:18:26.967221Z","gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"f5ad4bfe-5f76-48e3-bfc9-fe61c59d6b56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"125-139-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.967221Z","zone":"fr-par-1"},"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:35.941351Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1861"
+      - "1954"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:30 GMT
+      - Fri, 20 Oct 2023 14:18:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -888,7 +929,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8d6d4d5-aaa4-442b-8747-48bf1a8237fa
+      - e1f8edfa-c4ca-47cb-818a-500a36e84f4c
     status: 200 OK
     code: 200
     duration: ""
@@ -897,29 +938,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:43:24.129491+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"204","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:0d","maintenances":[],"modification_date":"2023-07-12T09:43:24.669211+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.78.55","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:43:24.129491+00:00","export_uri":null,"id":"45fdaa44-3af7-4bf4-a09c-e6d7d065ee0c","modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.142624+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"601","node_id":"8","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:73","maintenances":[],"modification_date":"2023-10-20T14:18:29.154477+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.100.15","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.142624+00:00","export_uri":null,"id":"b60cee5c-b097-4855-a3ce-407f0bca70cc","modification_date":"2023-10-20T14:18:28.142624+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2746"
+      - "2766"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:30 GMT
+      - Fri, 20 Oct 2023 14:18:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -929,7 +970,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05087b45-b92d-43be-8424-9361f79731ea
+      - 5b4c2de2-a4d4-4161-87c3-b7f9a51f0d95
     status: 200 OK
     code: 200
     duration: ""
@@ -938,21 +979,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/98be913f-45a8-4870-ac7e-f41c5c59b906
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:43:24.390741Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:43:30.019601Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:43:23.360057Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4ac59b75-000a-4fd7-be45-a33eb2287983","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:43:23.360057Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"b03f0edc-4729-4771-b167-2b3850a14688","mac_address":null,"private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","status":"created","updated_at":"2023-07-12T09:43:30.019601Z","zone":"fr-par-1"}],"id":"98be913f-45a8-4870-ac7e-f41c5c59b906","ip":{"address":"163.172.142.90","created_at":"2023-07-12T09:43:23.969335Z","gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"f7ffb21f-b279-4b49-a10e-ba7ac7b58d99","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"90-142-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:43:23.969335Z","zone":"fr-par-1"},"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:43:30.115663Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.100301Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:18:34.664182Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.307165Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"77bc134a-7df0-4cd8-beae-9bb95127fbff","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.307165Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"538d6444-553e-46f3-9635-d08306cd5512","ipam_config":null,"mac_address":"02:00:00:14:57:CF","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","status":"ready","updated_at":"2023-10-20T14:18:37.880612Z","zone":"fr-par-1"}],"id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","ip":{"address":"51.15.139.125","created_at":"2023-10-20T14:18:26.967221Z","gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"f5ad4bfe-5f76-48e3-bfc9-fe61c59d6b56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"125-139-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.967221Z","zone":"fr-par-1"},"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:38.010140Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1861"
+      - "1963"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:35 GMT
+      - Fri, 20 Oct 2023 14:18:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -962,7 +1003,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a193d92-ed0f-4136-a765-94d5a254412c
+      - 4fdb73f0-17fe-4b04-9350-dae77f8f2e34
     status: 200 OK
     code: 200
     duration: ""
@@ -971,29 +1012,161 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/538d6444-553e-46f3-9635-d08306cd5512
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"address":null,"created_at":"2023-10-20T14:18:34.664182Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.307165Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"77bc134a-7df0-4cd8-beae-9bb95127fbff","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.307165Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"538d6444-553e-46f3-9635-d08306cd5512","ipam_config":null,"mac_address":"02:00:00:14:57:CF","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","status":"ready","updated_at":"2023-10-20T14:18:37.880612Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "984"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:18:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e4bd977d-a1f6-4421-aba6-dc9bbe53264a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/538d6444-553e-46f3-9635-d08306cd5512
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-20T14:18:34.664182Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.307165Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"77bc134a-7df0-4cd8-beae-9bb95127fbff","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.307165Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"538d6444-553e-46f3-9635-d08306cd5512","ipam_config":null,"mac_address":"02:00:00:14:57:CF","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","status":"ready","updated_at":"2023-10-20T14:18:37.880612Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "984"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:18:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 01cec100-0a29-476f-b4fe-ec488520c330
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.100301Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:18:34.664182Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.307165Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"77bc134a-7df0-4cd8-beae-9bb95127fbff","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.307165Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"538d6444-553e-46f3-9635-d08306cd5512","ipam_config":null,"mac_address":"02:00:00:14:57:CF","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","status":"ready","updated_at":"2023-10-20T14:18:37.880612Z","zone":"fr-par-1"}],"id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","ip":{"address":"51.15.139.125","created_at":"2023-10-20T14:18:26.967221Z","gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"f5ad4bfe-5f76-48e3-bfc9-fe61c59d6b56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"125-139-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.967221Z","zone":"fr-par-1"},"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:38.010140Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1963"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:18:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 041cf5e6-d5ef-49e2-a476-4a8e62e1a846
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/538d6444-553e-46f3-9635-d08306cd5512
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-20T14:18:34.664182Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.307165Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"77bc134a-7df0-4cd8-beae-9bb95127fbff","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.307165Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"538d6444-553e-46f3-9635-d08306cd5512","ipam_config":null,"mac_address":"02:00:00:14:57:CF","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","status":"ready","updated_at":"2023-10-20T14:18:37.880612Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "984"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:18:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e6254f5f-f80c-4cef-8a7d-afd10d750b82
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:43:24.129491+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"204","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:0d","maintenances":[],"modification_date":"2023-07-12T09:43:24.669211+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.78.55","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:43:24.129491+00:00","export_uri":null,"id":"45fdaa44-3af7-4bf4-a09c-e6d7d065ee0c","modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.142624+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"601","node_id":"8","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:73","maintenances":[],"modification_date":"2023-10-20T14:18:45.082650+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.100.15","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.142624+00:00","export_uri":null,"id":"b60cee5c-b097-4855-a3ce-407f0bca70cc","modification_date":"2023-10-20T14:18:28.142624+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2746"
+      - "2797"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:35 GMT
+      - Fri, 20 Oct 2023 14:18:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1003,7 +1176,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff08e597-03e6-477b-8685-fb5105475c5d
+      - 64ee2057-ee51-42d7-b148-a9e2a70a013a
     status: 200 OK
     code: 200
     duration: ""
@@ -1012,21 +1185,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/98be913f-45a8-4870-ac7e-f41c5c59b906
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/487c2354-24bb-4b17-bf88-0d918610cea9
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:43:24.390741Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:43:30.019601Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:43:23.360057Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4ac59b75-000a-4fd7-be45-a33eb2287983","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:43:23.360057Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"b03f0edc-4729-4771-b167-2b3850a14688","mac_address":"02:00:00:13:5D:B8","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","status":"ready","updated_at":"2023-07-12T09:43:37.144523Z","zone":"fr-par-1"}],"id":"98be913f-45a8-4870-ac7e-f41c5c59b906","ip":{"address":"163.172.142.90","created_at":"2023-07-12T09:43:23.969335Z","gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"f7ffb21f-b279-4b49-a10e-ba7ac7b58d99","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"90-142-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:43:23.969335Z","zone":"fr-par-1"},"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:43:37.273762Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T14:18:26.405234Z","id":"487c2354-24bb-4b17-bf88-0d918610cea9","name":"private
+      network with a DHCP config","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnets":["10.0.0.0/24","fd5f:519c:6d46:9931::/64"],"tags":[],"updated_at":"2023-10-20T14:18:37.498750Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1870"
+      - "374"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:40 GMT
+      - Fri, 20 Oct 2023 14:18:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1036,7 +1210,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b87a68a-855d-4b30-a40a-2a8479b8fc67
+      - ed61237e-1829-491c-864b-3c5c6353b0c0
     status: 200 OK
     code: 200
     duration: ""
@@ -1045,161 +1219,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b03f0edc-4729-4771-b167-2b3850a14688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:43:30.019601Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:43:23.360057Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4ac59b75-000a-4fd7-be45-a33eb2287983","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:43:23.360057Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"b03f0edc-4729-4771-b167-2b3850a14688","mac_address":"02:00:00:13:5D:B8","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","status":"ready","updated_at":"2023-07-12T09:43:37.144523Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "935"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:43:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 050f3685-6d66-435f-85f2-842f6190078b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b03f0edc-4729-4771-b167-2b3850a14688
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-07-12T09:43:30.019601Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:43:23.360057Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4ac59b75-000a-4fd7-be45-a33eb2287983","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:43:23.360057Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"b03f0edc-4729-4771-b167-2b3850a14688","mac_address":"02:00:00:13:5D:B8","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","status":"ready","updated_at":"2023-07-12T09:43:37.144523Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "935"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:43:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fcc48c72-2be0-4548-a90b-bfefe0055b2f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/98be913f-45a8-4870-ac7e-f41c5c59b906
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:43:24.390741Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:43:30.019601Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:43:23.360057Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4ac59b75-000a-4fd7-be45-a33eb2287983","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:43:23.360057Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"b03f0edc-4729-4771-b167-2b3850a14688","mac_address":"02:00:00:13:5D:B8","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","status":"ready","updated_at":"2023-07-12T09:43:37.144523Z","zone":"fr-par-1"}],"id":"98be913f-45a8-4870-ac7e-f41c5c59b906","ip":{"address":"163.172.142.90","created_at":"2023-07-12T09:43:23.969335Z","gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"f7ffb21f-b279-4b49-a10e-ba7ac7b58d99","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"90-142-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:43:23.969335Z","zone":"fr-par-1"},"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:43:37.273762Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1870"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:43:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d427922b-3ef2-442f-be40-596554c6d861
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b03f0edc-4729-4771-b167-2b3850a14688
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-07-12T09:43:30.019601Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:43:23.360057Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4ac59b75-000a-4fd7-be45-a33eb2287983","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:43:23.360057Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"b03f0edc-4729-4771-b167-2b3850a14688","mac_address":"02:00:00:13:5D:B8","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","status":"ready","updated_at":"2023-07-12T09:43:37.144523Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "935"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:43:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 447b455a-d412-4b0f-ad84-ccffe4f21650
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:43:24.129491+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"204","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:0d","maintenances":[],"modification_date":"2023-07-12T09:43:24.669211+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.78.55","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:43:24.129491+00:00","export_uri":null,"id":"45fdaa44-3af7-4bf4-a09c-e6d7d065ee0c","modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.142624+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"601","node_id":"8","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:73","maintenances":[],"modification_date":"2023-10-20T14:18:45.082650+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.100.15","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.142624+00:00","export_uri":null,"id":"b60cee5c-b097-4855-a3ce-407f0bca70cc","modification_date":"2023-10-20T14:18:28.142624+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2746"
+      - "2797"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:40 GMT
+      - Fri, 20 Oct 2023 14:18:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1209,180 +1251,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96d52c96-e621-473f-9e44-246cbb89ae0f
+      - 02c6d042-b61e-4255-be67-3e77947ff42e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:43:24.129491+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"204","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:0d","maintenances":[],"modification_date":"2023-07-12T09:43:24.669211+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.78.55","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:43:24.129491+00:00","export_uri":null,"id":"45fdaa44-3af7-4bf4-a09c-e6d7d065ee0c","modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","name":"Scaleway
-      Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2746"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:43:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fed24849-f7e5-405b-8454-cfee4e7a13aa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:43:24.129491+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"204","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:0d","maintenances":[],"modification_date":"2023-07-12T09:43:46.223503+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.78.55","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:43:24.129491+00:00","export_uri":null,"id":"45fdaa44-3af7-4bf4-a09c-e6d7d065ee0c","modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","name":"Scaleway
-      Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2777"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:43:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 50abe3db-ac9e-49cb-958c-c51c949d45b2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/a32b2fda-5143-40eb-a034-f01629975382
-    method: GET
-  response:
-    body: '{"created_at":"2023-07-12T09:43:23.395931Z","id":"a32b2fda-5143-40eb-a034-f01629975382","name":"private
-      network with a DHCP config","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","subnets":["10.0.0.0/24","fd46:78ab:30b8:1151::/64"],"tags":[],"updated_at":"2023-07-12T09:43:36.621944Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "365"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:43:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 566d64e7-08ca-4092-862c-f9175c760746
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:43:24.129491+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"204","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:0d","maintenances":[],"modification_date":"2023-07-12T09:43:46.223503+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.78.55","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:43:24.129491+00:00","export_uri":null,"id":"45fdaa44-3af7-4bf4-a09c-e6d7d065ee0c","modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","name":"Scaleway
-      Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2777"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:43:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5e0fb4bd-f266-44ac-a95a-6d7d2d1eccd1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"private_network_id":"a32b2fda-5143-40eb-a034-f01629975382"}'
+    body: '{"private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:43:51.150738+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:18:45.787475+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1391,7 +1276,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:51 GMT
+      - Fri, 20 Oct 2023 14:18:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1401,7 +1286,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ffd81a74-eaeb-43bf-b3b7-b4f1265c5550
+      - a306bdee-8119-481c-aecc-fee571804404
     status: 201 Created
     code: 201
     duration: ""
@@ -1410,12 +1295,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4/private_nics/420f112b-c0c7-4bf7-ac6c-9b92e0e895c2
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/private_nics/d30911b2-df1e-4160-9363-3872d4594224
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:43:51.150738+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:18:45.787475+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1424,7 +1309,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:51 GMT
+      - Fri, 20 Oct 2023 14:18:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1434,7 +1319,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8fe8c8f3-3fd2-4e1e-a263-3b7d4c134078
+      - 6808ca43-67c2-4969-ae89-310586ea6e8e
     status: 200 OK
     code: 200
     duration: ""
@@ -1443,12 +1328,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4/private_nics/420f112b-c0c7-4bf7-ac6c-9b92e0e895c2
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/private_nics/d30911b2-df1e-4160-9363-3872d4594224
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:43:52.089648+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:18:46.789669+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1457,7 +1342,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:43:57 GMT
+      - Fri, 20 Oct 2023 14:18:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1467,7 +1352,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7db9dfb-8454-4bbb-9202-7e0bb36aeeb2
+      - 2b012f9e-54bb-4af2-8b4e-b290a117c278
     status: 200 OK
     code: 200
     duration: ""
@@ -1476,21 +1361,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/private_nics/d30911b2-df1e-4160-9363-3872d4594224
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2023-07-12T09:43:29.715899Z","description":"","frontend_count":0,"id":"4f821d84-b13a-4832-883e-40a68bbc437c","instances":[{"created_at":"2023-07-12T09:41:33.586562Z","id":"5a3b33d2-5ce4-4fe6-964d-df63ac0f7513","ip_address":"10.74.54.85","region":"fr-par","status":"ready","updated_at":"2023-07-12T09:43:31.137205Z","zone":"fr-par-1"}],"ip":[{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":"4f821d84-b13a-4832-883e-40a68bbc437c","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-07-12T09:43:32.553631Z","zone":"fr-par-1"}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:18:46.789669+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "1088"
+      - "376"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:00 GMT
+      - Fri, 20 Oct 2023 14:18:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1500,7 +1385,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be31439c-8215-4d19-9a1c-7386caff744c
+      - 350e9a17-ee3b-4de0-b1be-db1c19f5c7d7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/private_nics/d30911b2-df1e-4160-9363-3872d4594224
+    method: GET
+  response:
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:18:46.789669+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "376"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 14de15ec-e671-467e-9c9d-5daf4bd60b86
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd
+    method: GET
+  response:
+    body: '{"backend_count":0,"created_at":"2023-10-20T14:18:32.564371Z","description":"","frontend_count":0,"id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","instances":[{"created_at":"2023-10-20T14:12:52.137043Z","id":"a45718f6-ab56-425b-800c-bc95edaa18b0","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-20T14:18:38.756490Z","zone":"fr-par-1"}],"ip":[{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-20T14:18:40.121254Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1107"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 08728f2c-48a2-48d2-8b0d-620af4bd2283
     status: 200 OK
     code: 200
     duration: ""
@@ -1511,21 +1462,21 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c/private-networks/a32b2fda-5143-40eb-a034-f01629975382/attach
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd/private-networks/487c2354-24bb-4b17-bf88-0d918610cea9/attach
     method: POST
   response:
-    body: '{"created_at":"2023-07-12T09:44:00.213237117Z","dhcp_config":{},"lb":{"backend_count":0,"created_at":"2023-07-12T09:43:29.715899Z","description":"","frontend_count":0,"id":"4f821d84-b13a-4832-883e-40a68bbc437c","instances":[{"created_at":"2023-07-12T09:41:33.586562Z","id":"5a3b33d2-5ce4-4fe6-964d-df63ac0f7513","ip_address":"10.74.54.85","region":"fr-par","status":"ready","updated_at":"2023-07-12T09:43:31.137205Z","zone":"fr-par-1"}],"ip":[{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":"4f821d84-b13a-4832-883e-40a68bbc437c","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-07-12T09:43:32.553631Z","zone":"fr-par-1"},"private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","status":"pending","updated_at":"2023-07-12T09:44:00.213237117Z"}'
+    body: '{"created_at":"2023-10-20T14:19:03.015447949Z","dhcp_config":{"ip_id":null},"ipam_ids":[],"lb":{"backend_count":0,"created_at":"2023-10-20T14:18:32.564371Z","description":"","frontend_count":0,"id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","instances":[{"created_at":"2023-10-20T14:12:52.137043Z","id":"a45718f6-ab56-425b-800c-bc95edaa18b0","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-20T14:18:38.756490Z","zone":"fr-par-1"}],"ip":[{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-20T14:18:40.121254Z","zone":"fr-par-1"},"private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","status":"pending","updated_at":"2023-10-20T14:19:03.015447949Z"}'
     headers:
       Content-Length:
-      - "1283"
+      - "1334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:00 GMT
+      - Fri, 20 Oct 2023 14:19:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1535,7 +1486,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de71dc99-1d93-42ec-b99e-561f722cc44f
+      - 718475b1-3da4-41a8-8bc7-973d3ae66e70
     status: 200 OK
     code: 200
     duration: ""
@@ -1544,21 +1495,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c/private-networks?order_by=created_at_asc
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd/private-networks?order_by=created_at_asc
     method: GET
   response:
-    body: '{"private_network":[{"created_at":"2023-07-12T09:44:00.213237Z","dhcp_config":{},"lb":{"backend_count":0,"created_at":"2023-07-12T09:43:29.715899Z","description":"","frontend_count":0,"id":"4f821d84-b13a-4832-883e-40a68bbc437c","instances":[],"ip":[{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":"4f821d84-b13a-4832-883e-40a68bbc437c","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-07-12T09:43:32.553631Z","zone":"fr-par-1"},"private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","status":"pending","updated_at":"2023-07-12T09:44:00.213237Z"}],"total_count":1}'
+    body: '{"private_network":[{"created_at":"2023-10-20T14:19:03.015448Z","dhcp_config":{"ip_id":null},"ipam_ids":[],"lb":{"backend_count":0,"created_at":"2023-10-20T14:18:32.564371Z","description":"","frontend_count":0,"id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","instances":[],"ip":[{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-20T14:18:40.121254Z","zone":"fr-par-1"},"private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","status":"pending","updated_at":"2023-10-20T14:19:03.015448Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1104"
+      - "1161"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:00 GMT
+      - Fri, 20 Oct 2023 14:19:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1568,7 +1519,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82aa9289-2b5b-46ae-a54e-cb995bb80e86
+      - 092e05bc-aaa6-4c19-b82d-58ccf6a3b22e
     status: 200 OK
     code: 200
     duration: ""
@@ -1577,45 +1528,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4/private_nics/420f112b-c0c7-4bf7-ac6c-9b92e0e895c2
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/private_nics/d30911b2-df1e-4160-9363-3872d4594224
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:43:52.089648+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"syncing","tags":[],"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "376"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bcb8bc7f-64e1-4670-aedf-6eee773a6c2c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4/private_nics/420f112b-c0c7-4bf7-ac6c-9b92e0e895c2
-    method: GET
-  response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:43:52.089648+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:18:46.789669+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1624,7 +1542,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:07 GMT
+      - Fri, 20 Oct 2023 14:19:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1634,7 +1552,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 056a26b2-9b34-4cf1-9f63-a179d1cd4264
+      - 08f0ad27-2dc7-4b96-9837-8929e3ee591d
     status: 200 OK
     code: 200
     duration: ""
@@ -1643,12 +1561,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4/private_nics/420f112b-c0c7-4bf7-ac6c-9b92e0e895c2
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/private_nics/d30911b2-df1e-4160-9363-3872d4594224
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:43:52.089648+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:18:46.789669+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1657,7 +1575,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:12 GMT
+      - Fri, 20 Oct 2023 14:19:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1667,7 +1585,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c02f2230-a1a9-426d-aa27-9e8a22f22f7e
+      - 0174be2d-b0d0-4e11-a349-fb29eb4c82b3
     status: 200 OK
     code: 200
     duration: ""
@@ -1676,12 +1594,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4/private_nics/420f112b-c0c7-4bf7-ac6c-9b92e0e895c2
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/private_nics/d30911b2-df1e-4160-9363-3872d4594224
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:43:52.089648+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:18:46.789669+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1690,7 +1608,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:17 GMT
+      - Fri, 20 Oct 2023 14:19:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1700,7 +1618,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58bc25d8-05b4-47d6-b314-36eade9b2565
+      - 6755bca4-1de4-4ca6-b9d4-727f6c43add6
     status: 200 OK
     code: 200
     duration: ""
@@ -1709,45 +1627,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4/private_nics/420f112b-c0c7-4bf7-ac6c-9b92e0e895c2
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/private_nics/d30911b2-df1e-4160-9363-3872d4594224
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:43:52.089648+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"syncing","tags":[],"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "376"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1eaa3a59-5d0a-4c03-b14e-c9353e8ccc83
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4/private_nics/420f112b-c0c7-4bf7-ac6c-9b92e0e895c2
-    method: GET
-  response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:44:22.378336+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:19:17.636021+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1756,7 +1641,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:27 GMT
+      - Fri, 20 Oct 2023 14:19:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1766,7 +1651,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37998be5-6083-4ecb-9d76-8a802d0a5a55
+      - a86522e0-bf17-4360-895f-851f49e5061f
     status: 200 OK
     code: 200
     duration: ""
@@ -1775,12 +1660,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4/private_nics/420f112b-c0c7-4bf7-ac6c-9b92e0e895c2
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/private_nics/d30911b2-df1e-4160-9363-3872d4594224
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:44:22.378336+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:19:17.636021+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1789,7 +1674,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:27 GMT
+      - Fri, 20 Oct 2023 14:19:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1799,7 +1684,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d0536cb-bceb-4b6c-b43a-33c7f3eb273b
+      - 72de9c18-460d-4ba8-b6a5-7012aca98e83
     status: 200 OK
     code: 200
     duration: ""
@@ -1808,29 +1693,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:43:24.129491+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"204","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:0d","maintenances":[],"modification_date":"2023-07-12T09:43:46.223503+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.78.55","private_nics":[{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:44:22.378336+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:43:24.129491+00:00","export_uri":null,"id":"45fdaa44-3af7-4bf4-a09c-e6d7d065ee0c","modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.142624+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"601","node_id":"8","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:73","maintenances":[],"modification_date":"2023-10-20T14:18:45.082650+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.100.15","private_nics":[{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:19:17.636021+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.142624+00:00","export_uri":null,"id":"b60cee5c-b097-4855-a3ce-407f0bca70cc","modification_date":"2023-10-20T14:18:28.142624+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3130"
+      - "3150"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:27 GMT
+      - Fri, 20 Oct 2023 14:19:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1840,7 +1725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6f1a4a4-f00e-46d6-be99-9caf5c72000c
+      - 866198bc-0a40-4cf8-ab48-0f6abe401540
     status: 200 OK
     code: 200
     duration: ""
@@ -1849,9 +1734,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1863,7 +1748,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:27 GMT
+      - Fri, 20 Oct 2023 14:19:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1873,7 +1758,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2777552-8113-4646-bfbd-70efde15e816
+      - 9e6ea21c-ade5-42bd-8032-bacedeed0554
     status: 200 OK
     code: 200
     duration: ""
@@ -1882,12 +1767,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:44:22.378336+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:19:17.636021+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -1896,9 +1781,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:28 GMT
+      - Fri, 20 Oct 2023 14:19:22 GMT
       Link:
-      - </servers/b236a23b-93ac-41a8-88db-6043fc5a2be4/private_nics?page=1&per_page=50&>;
+      - </servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -1909,7 +1794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4dfafd7c-f086-4dea-9b07-9deef63aa285
+      - f3afb13b-3fbe-4f5a-8dba-668a0e0e1a86
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -1920,21 +1805,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c/private-networks?order_by=created_at_asc
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd/private-networks?order_by=created_at_asc
     method: GET
   response:
-    body: '{"private_network":[{"created_at":"2023-07-12T09:44:00.213237Z","dhcp_config":{},"lb":{"backend_count":0,"created_at":"2023-07-12T09:43:29.715899Z","description":"","frontend_count":0,"id":"4f821d84-b13a-4832-883e-40a68bbc437c","instances":[],"ip":[{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":"4f821d84-b13a-4832-883e-40a68bbc437c","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-07-12T09:43:32.553631Z","zone":"fr-par-1"},"private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","status":"ready","updated_at":"2023-07-12T09:44:08.290457Z"}],"total_count":1}'
+    body: '{"private_network":[{"created_at":"2023-10-20T14:19:03.015448Z","dhcp_config":{"ip_id":"f1a92c22-e3cb-4d69-99d4-b915cc2287e6"},"ipam_ids":["f1a92c22-e3cb-4d69-99d4-b915cc2287e6"],"lb":{"backend_count":0,"created_at":"2023-10-20T14:18:32.564371Z","description":"","frontend_count":0,"id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","instances":[],"ip":[{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-20T14:18:40.121254Z","zone":"fr-par-1"},"private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","status":"ready","updated_at":"2023-10-20T14:19:12.067191Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1102"
+      - "1231"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:30 GMT
+      - Fri, 20 Oct 2023 14:19:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1944,7 +1829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3ceb436-2832-49fb-8d0e-51899de39b7c
+      - 20cc9491-69bc-4f4f-a76a-c1f964499884
     status: 200 OK
     code: 200
     duration: ""
@@ -1953,21 +1838,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2023-07-12T09:43:29.715899Z","description":"","frontend_count":0,"id":"4f821d84-b13a-4832-883e-40a68bbc437c","instances":[{"created_at":"2023-07-12T09:41:33.586562Z","id":"5a3b33d2-5ce4-4fe6-964d-df63ac0f7513","ip_address":"10.74.54.85","region":"fr-par","status":"ready","updated_at":"2023-07-12T09:43:31.137205Z","zone":"fr-par-1"}],"ip":[{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":"4f821d84-b13a-4832-883e-40a68bbc437c","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-07-12T09:43:32.553631Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2023-10-20T14:18:32.564371Z","description":"","frontend_count":0,"id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","instances":[{"created_at":"2023-10-20T14:12:52.137043Z","id":"a45718f6-ab56-425b-800c-bc95edaa18b0","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-20T14:19:11.776181Z","zone":"fr-par-1"}],"ip":[{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-20T14:18:40.121254Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1088"
+      - "1107"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:30 GMT
+      - Fri, 20 Oct 2023 14:19:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1977,7 +1862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc79a2fe-6734-4076-97d2-fcd04a4152c5
+      - 465cf360-c7b3-4ebf-a2c5-df565387bb90
     status: 200 OK
     code: 200
     duration: ""
@@ -1986,21 +1871,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2023-07-12T09:43:29.715899Z","description":"","frontend_count":0,"id":"4f821d84-b13a-4832-883e-40a68bbc437c","instances":[{"created_at":"2023-07-12T09:41:33.586562Z","id":"5a3b33d2-5ce4-4fe6-964d-df63ac0f7513","ip_address":"10.74.54.85","region":"fr-par","status":"ready","updated_at":"2023-07-12T09:43:31.137205Z","zone":"fr-par-1"}],"ip":[{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":"4f821d84-b13a-4832-883e-40a68bbc437c","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-07-12T09:43:32.553631Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2023-10-20T14:18:32.564371Z","description":"","frontend_count":0,"id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","instances":[{"created_at":"2023-10-20T14:12:52.137043Z","id":"a45718f6-ab56-425b-800c-bc95edaa18b0","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-20T14:19:11.776181Z","zone":"fr-par-1"}],"ip":[{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-20T14:18:40.121254Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1088"
+      - "1107"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:30 GMT
+      - Fri, 20 Oct 2023 14:19:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2010,7 +1895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa16c8c5-5ed6-4e13-ad1b-198129002854
+      - d4df94a4-b219-4bd9-b346-d0589ac99557
     status: 200 OK
     code: 200
     duration: ""
@@ -2019,21 +1904,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c/private-networks?order_by=created_at_asc
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd/private-networks?order_by=created_at_asc
     method: GET
   response:
-    body: '{"private_network":[{"created_at":"2023-07-12T09:44:00.213237Z","dhcp_config":{},"lb":{"backend_count":0,"created_at":"2023-07-12T09:43:29.715899Z","description":"","frontend_count":0,"id":"4f821d84-b13a-4832-883e-40a68bbc437c","instances":[],"ip":[{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":"4f821d84-b13a-4832-883e-40a68bbc437c","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-07-12T09:43:32.553631Z","zone":"fr-par-1"},"private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","status":"ready","updated_at":"2023-07-12T09:44:08.290457Z"}],"total_count":1}'
+    body: '{"private_network":[{"created_at":"2023-10-20T14:19:03.015448Z","dhcp_config":{"ip_id":"f1a92c22-e3cb-4d69-99d4-b915cc2287e6"},"ipam_ids":["f1a92c22-e3cb-4d69-99d4-b915cc2287e6"],"lb":{"backend_count":0,"created_at":"2023-10-20T14:18:32.564371Z","description":"","frontend_count":0,"id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","instances":[],"ip":[{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-20T14:18:40.121254Z","zone":"fr-par-1"},"private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","status":"ready","updated_at":"2023-10-20T14:19:12.067191Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1102"
+      - "1231"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:30 GMT
+      - Fri, 20 Oct 2023 14:19:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2043,7 +1928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88cd91dd-12bc-4a33-8946-20face39ae2d
+      - 68984136-8b0d-4722-9f55-183a7a7d6def
     status: 200 OK
     code: 200
     duration: ""
@@ -2052,21 +1937,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2023-07-12T09:43:29.715899Z","description":"","frontend_count":0,"id":"4f821d84-b13a-4832-883e-40a68bbc437c","instances":[{"created_at":"2023-07-12T09:41:33.586562Z","id":"5a3b33d2-5ce4-4fe6-964d-df63ac0f7513","ip_address":"10.74.54.85","region":"fr-par","status":"ready","updated_at":"2023-07-12T09:43:31.137205Z","zone":"fr-par-1"}],"ip":[{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":"4f821d84-b13a-4832-883e-40a68bbc437c","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-07-12T09:43:32.553631Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2023-10-20T14:18:32.564371Z","description":"","frontend_count":0,"id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","instances":[{"created_at":"2023-10-20T14:12:52.137043Z","id":"a45718f6-ab56-425b-800c-bc95edaa18b0","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-20T14:19:11.776181Z","zone":"fr-par-1"}],"ip":[{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-20T14:18:40.121254Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1088"
+      - "1107"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:31 GMT
+      - Fri, 20 Oct 2023 14:19:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2076,7 +1961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd5adac0-a6e7-4a57-972d-4376395e40c2
+      - a16d7417-1eac-47a9-9d54-75ea0a76d872
     status: 200 OK
     code: 200
     duration: ""
@@ -2085,793 +1970,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/36097131-88b0-4e6b-9baf-6d1e304e81da
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/f8576741-b282-4830-9813-a6b028e3f0ca
     method: GET
   response:
-    body: '{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":"4f821d84-b13a-4832-883e-40a68bbc437c","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "312"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e2ead83e-bdf8-40e6-a54d-1aeeff2b03c8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/f7ffb21f-b279-4b49-a10e-ba7ac7b58d99
-    method: GET
-  response:
-    body: '{"address":"163.172.142.90","created_at":"2023-07-12T09:43:23.969335Z","gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"f7ffb21f-b279-4b49-a10e-ba7ac7b58d99","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"90-142-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:43:23.969335Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "394"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 501980b7-b261-44f2-848a-41c6d787c5b6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/36097131-88b0-4e6b-9baf-6d1e304e81da
-    method: GET
-  response:
-    body: '{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":"4f821d84-b13a-4832-883e-40a68bbc437c","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "312"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 96017d6b-6fba-4873-9a06-a3241b15c6dd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/4ac59b75-000a-4fd7-be45-a33eb2287983
-    method: GET
-  response:
-    body: '{"address":"10.0.0.1","created_at":"2023-07-12T09:43:23.360057Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4ac59b75-000a-4fd7-be45-a33eb2287983","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:43:23.360057Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "556"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d5b6ed0a-5881-4d86-8078-f8a85bec77dc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a32b2fda-5143-40eb-a034-f01629975382
-    method: GET
-  response:
-    body: '{"created_at":"2023-07-12T09:43:23.395931Z","dhcp_enabled":false,"id":"a32b2fda-5143-40eb-a034-f01629975382","name":"private
-      network with a DHCP config","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-07-12T09:43:23.395931Z","id":"25525de3-cbf9-4727-894d-2cca49ebf678","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:43:29.826706Z"},{"created_at":"2023-07-12T09:43:23.395931Z","id":"2e3e5d5e-3c76-42d4-8b63-4e98bb1985c6","subnet":"fd46:78ab:30b8:1151::/64","updated_at":"2023-07-12T09:43:29.826706Z"}],"tags":[],"updated_at":"2023-07-12T09:43:36.621944Z","vpc_id":"7abd38de-d34e-4f86-877b-c97f3e0f073a"}'
-    headers:
-      Content-Length:
-      - "716"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 975077d3-08be-4350-b8b3-a16f31772a2f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/98be913f-45a8-4870-ac7e-f41c5c59b906
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:43:24.390741Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:43:30.019601Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:43:23.360057Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4ac59b75-000a-4fd7-be45-a33eb2287983","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:43:23.360057Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"b03f0edc-4729-4771-b167-2b3850a14688","mac_address":"02:00:00:13:5D:B8","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","status":"ready","updated_at":"2023-07-12T09:43:37.144523Z","zone":"fr-par-1"}],"id":"98be913f-45a8-4870-ac7e-f41c5c59b906","ip":{"address":"163.172.142.90","created_at":"2023-07-12T09:43:23.969335Z","gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"f7ffb21f-b279-4b49-a10e-ba7ac7b58d99","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"90-142-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:43:23.969335Z","zone":"fr-par-1"},"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:43:37.273762Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1870"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2a3630b3-fc52-41ae-ba09-754a006c5eb5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c
-    method: GET
-  response:
-    body: '{"backend_count":0,"created_at":"2023-07-12T09:43:29.715899Z","description":"","frontend_count":0,"id":"4f821d84-b13a-4832-883e-40a68bbc437c","instances":[{"created_at":"2023-07-12T09:41:33.586562Z","id":"5a3b33d2-5ce4-4fe6-964d-df63ac0f7513","ip_address":"10.74.54.85","region":"fr-par","status":"ready","updated_at":"2023-07-12T09:43:31.137205Z","zone":"fr-par-1"}],"ip":[{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":"4f821d84-b13a-4832-883e-40a68bbc437c","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-07-12T09:43:32.553631Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1088"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ef734b05-0569-45c6-beca-cbc46aa5c139
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c
-    method: GET
-  response:
-    body: '{"backend_count":0,"created_at":"2023-07-12T09:43:29.715899Z","description":"","frontend_count":0,"id":"4f821d84-b13a-4832-883e-40a68bbc437c","instances":[{"created_at":"2023-07-12T09:41:33.586562Z","id":"5a3b33d2-5ce4-4fe6-964d-df63ac0f7513","ip_address":"10.74.54.85","region":"fr-par","status":"ready","updated_at":"2023-07-12T09:43:31.137205Z","zone":"fr-par-1"}],"ip":[{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":"4f821d84-b13a-4832-883e-40a68bbc437c","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-07-12T09:43:32.553631Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1088"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ef607ef9-d9c7-4b77-97dd-f6e64c2d6bb8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:43:24.129491+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"204","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:0d","maintenances":[],"modification_date":"2023-07-12T09:43:46.223503+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.78.55","private_nics":[{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:44:22.378336+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:43:24.129491+00:00","export_uri":null,"id":"45fdaa44-3af7-4bf4-a09c-e6d7d065ee0c","modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","name":"Scaleway
-      Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3130"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 438d5ced-648a-4add-bc5d-851399877ea9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b03f0edc-4729-4771-b167-2b3850a14688
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-07-12T09:43:30.019601Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:43:23.360057Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4ac59b75-000a-4fd7-be45-a33eb2287983","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:43:23.360057Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"b03f0edc-4729-4771-b167-2b3850a14688","mac_address":"02:00:00:13:5D:B8","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","status":"ready","updated_at":"2023-07-12T09:43:37.144523Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "935"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dfdc97e1-659b-4d12-952a-fb90a8cb791d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/98be913f-45a8-4870-ac7e-f41c5c59b906
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:43:24.390741Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:43:30.019601Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:43:23.360057Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4ac59b75-000a-4fd7-be45-a33eb2287983","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:43:23.360057Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"b03f0edc-4729-4771-b167-2b3850a14688","mac_address":"02:00:00:13:5D:B8","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","status":"ready","updated_at":"2023-07-12T09:43:37.144523Z","zone":"fr-par-1"}],"id":"98be913f-45a8-4870-ac7e-f41c5c59b906","ip":{"address":"163.172.142.90","created_at":"2023-07-12T09:43:23.969335Z","gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"f7ffb21f-b279-4b49-a10e-ba7ac7b58d99","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"90-142-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:43:23.969335Z","zone":"fr-par-1"},"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:43:37.273762Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1870"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 06e3c312-a46f-478b-bd31-fd02d2d91922
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c/private-networks?order_by=created_at_asc
-    method: GET
-  response:
-    body: '{"private_network":[{"created_at":"2023-07-12T09:44:00.213237Z","dhcp_config":{},"lb":{"backend_count":0,"created_at":"2023-07-12T09:43:29.715899Z","description":"","frontend_count":0,"id":"4f821d84-b13a-4832-883e-40a68bbc437c","instances":[],"ip":[{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":"4f821d84-b13a-4832-883e-40a68bbc437c","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-07-12T09:43:32.553631Z","zone":"fr-par-1"},"private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","status":"ready","updated_at":"2023-07-12T09:44:08.290457Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "1102"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 88e0b3a3-0893-49ca-b7ad-1c6071814dc7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4/user_data
-    method: GET
-  response:
-    body: '{"user_data":[]}'
-    headers:
-      Content-Length:
-      - "17"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 96a7b5d5-5143-4710-a2b5-922af3a0997d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b03f0edc-4729-4771-b167-2b3850a14688
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-07-12T09:43:30.019601Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:43:23.360057Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4ac59b75-000a-4fd7-be45-a33eb2287983","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:43:23.360057Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"b03f0edc-4729-4771-b167-2b3850a14688","mac_address":"02:00:00:13:5D:B8","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","status":"ready","updated_at":"2023-07-12T09:43:37.144523Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "935"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 15ab7f21-b158-4ef0-8637-64b1de94bc09
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4/private_nics
-    method: GET
-  response:
-    body: '{"private_nics":[{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:44:22.378336+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"available","tags":[],"zone":"fr-par-1"}]}'
-    headers:
-      Content-Length:
-      - "381"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:31 GMT
-      Link:
-      - </servers/b236a23b-93ac-41a8-88db-6043fc5a2be4/private_nics?page=1&per_page=50&>;
-        rel="last"
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ef51e94f-b94a-4f37-86d0-9c6d05730ad8
-      X-Total-Count:
-      - "1"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c
-    method: GET
-  response:
-    body: '{"backend_count":0,"created_at":"2023-07-12T09:43:29.715899Z","description":"","frontend_count":0,"id":"4f821d84-b13a-4832-883e-40a68bbc437c","instances":[{"created_at":"2023-07-12T09:41:33.586562Z","id":"5a3b33d2-5ce4-4fe6-964d-df63ac0f7513","ip_address":"10.74.54.85","region":"fr-par","status":"ready","updated_at":"2023-07-12T09:43:31.137205Z","zone":"fr-par-1"}],"ip":[{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":"4f821d84-b13a-4832-883e-40a68bbc437c","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-07-12T09:43:32.553631Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1088"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8c51a372-1978-42dc-b4cf-e0931ad077ed
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b03f0edc-4729-4771-b167-2b3850a14688
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-07-12T09:43:30.019601Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:43:23.360057Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4ac59b75-000a-4fd7-be45-a33eb2287983","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:43:23.360057Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"b03f0edc-4729-4771-b167-2b3850a14688","mac_address":"02:00:00:13:5D:B8","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","status":"ready","updated_at":"2023-07-12T09:43:37.144523Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "935"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d39c3aba-4c47-42df-bd47-4117d13f08be
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c/private-networks?order_by=created_at_asc
-    method: GET
-  response:
-    body: '{"private_network":[{"created_at":"2023-07-12T09:44:00.213237Z","dhcp_config":{},"lb":{"backend_count":0,"created_at":"2023-07-12T09:43:29.715899Z","description":"","frontend_count":0,"id":"4f821d84-b13a-4832-883e-40a68bbc437c","instances":[],"ip":[{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":"4f821d84-b13a-4832-883e-40a68bbc437c","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-07-12T09:43:32.553631Z","zone":"fr-par-1"},"private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","status":"ready","updated_at":"2023-07-12T09:44:08.290457Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "1102"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e34965d6-dbdb-40f4-8481-c8dcb5496eeb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:43:24.129491+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"204","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:0d","maintenances":[],"modification_date":"2023-07-12T09:43:46.223503+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.78.55","private_nics":[{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:44:22.378336+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:43:24.129491+00:00","export_uri":null,"id":"45fdaa44-3af7-4bf4-a09c-e6d7d065ee0c","modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","name":"Scaleway
-      Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3130"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6ea99273-778d-47cb-add0-df762eaffacb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b03f0edc-4729-4771-b167-2b3850a14688?cleanup_dhcp=true
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bbb2fa46-97e1-48a4-8f0a-0944792c8f5f
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b03f0edc-4729-4771-b167-2b3850a14688
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-07-12T09:43:30.019601Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:43:23.360057Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4ac59b75-000a-4fd7-be45-a33eb2287983","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:43:23.360057Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"b03f0edc-4729-4771-b167-2b3850a14688","mac_address":"02:00:00:13:5D:B8","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","status":"detaching","updated_at":"2023-07-12T09:44:32.655480Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "939"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b1f85bc7-fea1-4593-b1ce-b5a344edb26f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c/private-networks/a32b2fda-5143-40eb-a034-f01629975382/detach
-    method: POST
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 51b1ea2c-3dc6-4215-9849-647763c2ff93
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c
-    method: GET
-  response:
-    body: '{"backend_count":0,"created_at":"2023-07-12T09:43:29.715899Z","description":"","frontend_count":0,"id":"4f821d84-b13a-4832-883e-40a68bbc437c","instances":[{"created_at":"2023-07-12T09:41:33.586562Z","id":"5a3b33d2-5ce4-4fe6-964d-df63ac0f7513","ip_address":"10.74.54.85","region":"fr-par","status":"ready","updated_at":"2023-07-12T09:43:31.137205Z","zone":"fr-par-1"}],"ip":[{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":"4f821d84-b13a-4832-883e-40a68bbc437c","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-07-12T09:43:32.553631Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1088"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 89e85ae6-6171-4980-acf6-b06899d7cd36
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"action":"poweroff"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4/action
-    method: POST
-  response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4/action","href_result":"/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4","id":"01f0d7ff-85fe-4fd7-8fe5-c6a0d35b2d64","started_at":"2023-07-12T09:44:33.006328+00:00","status":"pending","terminated_at":null}}'
+    body: '{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "317"
@@ -2880,9 +1984,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:33 GMT
-      Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/01f0d7ff-85fe-4fd7-8fe5-c6a0d35b2d64
+      - Fri, 20 Oct 2023 14:19:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2892,7 +1994,757 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09ca0a5f-ebe7-42cf-8a6a-788e83d8f257
+      - 19be82e1-d0c8-40ed-a9be-9b51e6f31554
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/77bc134a-7df0-4cd8-beae-9bb95127fbff
+    method: GET
+  response:
+    body: '{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.307165Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"77bc134a-7df0-4cd8-beae-9bb95127fbff","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.307165Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "574"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 193f56bd-f059-460b-9ebd-d0947ed32570
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/f5ad4bfe-5f76-48e3-bfc9-fe61c59d6b56
+    method: GET
+  response:
+    body: '{"address":"51.15.139.125","created_at":"2023-10-20T14:18:26.967221Z","gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"f5ad4bfe-5f76-48e3-bfc9-fe61c59d6b56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"125-139-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.967221Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "401"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a444e3c6-1f1b-48a3-85cd-a363c5c164d7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/f8576741-b282-4830-9813-a6b028e3f0ca
+    method: GET
+  response:
+    body: '{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "317"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 79392822-7ebd-4d04-a87a-06505c5f13f4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.100301Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:18:34.664182Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.307165Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"77bc134a-7df0-4cd8-beae-9bb95127fbff","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.307165Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"538d6444-553e-46f3-9635-d08306cd5512","ipam_config":null,"mac_address":"02:00:00:14:57:CF","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","status":"ready","updated_at":"2023-10-20T14:18:37.880612Z","zone":"fr-par-1"}],"id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","ip":{"address":"51.15.139.125","created_at":"2023-10-20T14:18:26.967221Z","gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"f5ad4bfe-5f76-48e3-bfc9-fe61c59d6b56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"125-139-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.967221Z","zone":"fr-par-1"},"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:38.010140Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1963"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d5918e4d-e9ae-4712-bfc5-94153521a5ea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/487c2354-24bb-4b17-bf88-0d918610cea9
+    method: GET
+  response:
+    body: '{"created_at":"2023-10-20T14:18:26.405234Z","dhcp_enabled":true,"id":"487c2354-24bb-4b17-bf88-0d918610cea9","name":"private
+      network with a DHCP config","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T14:18:26.405234Z","id":"6204fe9b-7942-4693-96e7-973d31fd34e7","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:32.782740Z"},{"created_at":"2023-10-20T14:18:26.405234Z","id":"f3d6c0a6-b866-4e96-8981-01110c629b0e","subnet":"fd5f:519c:6d46:9931::/64","updated_at":"2023-10-20T14:18:32.801520Z"}],"tags":[],"updated_at":"2023-10-20T14:18:37.498750Z","vpc_id":"42c81a78-acb1-4c3f-b117-e6e9aa76c1f7"}'
+    headers:
+      Content-Length:
+      - "732"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 62f317a9-59ef-4fcb-9be7-788d0f614b2c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd
+    method: GET
+  response:
+    body: '{"backend_count":0,"created_at":"2023-10-20T14:18:32.564371Z","description":"","frontend_count":0,"id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","instances":[{"created_at":"2023-10-20T14:12:52.137043Z","id":"a45718f6-ab56-425b-800c-bc95edaa18b0","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-20T14:19:11.776181Z","zone":"fr-par-1"}],"ip":[{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-20T14:18:40.121254Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1107"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d32c3af7-a8cd-460f-afa9-2461f0485a1d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/538d6444-553e-46f3-9635-d08306cd5512
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-20T14:18:34.664182Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.307165Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"77bc134a-7df0-4cd8-beae-9bb95127fbff","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.307165Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"538d6444-553e-46f3-9635-d08306cd5512","ipam_config":null,"mac_address":"02:00:00:14:57:CF","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","status":"ready","updated_at":"2023-10-20T14:18:37.880612Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "984"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6219eff0-4c90-4a89-a74d-c1551d99b2d3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.100301Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:18:34.664182Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.307165Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"77bc134a-7df0-4cd8-beae-9bb95127fbff","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.307165Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"538d6444-553e-46f3-9635-d08306cd5512","ipam_config":null,"mac_address":"02:00:00:14:57:CF","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","status":"ready","updated_at":"2023-10-20T14:18:37.880612Z","zone":"fr-par-1"}],"id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","ip":{"address":"51.15.139.125","created_at":"2023-10-20T14:18:26.967221Z","gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"f5ad4bfe-5f76-48e3-bfc9-fe61c59d6b56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"125-139-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.967221Z","zone":"fr-par-1"},"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:38.010140Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1963"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 76409803-9214-43bf-862b-bf62d444a82e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd
+    method: GET
+  response:
+    body: '{"backend_count":0,"created_at":"2023-10-20T14:18:32.564371Z","description":"","frontend_count":0,"id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","instances":[{"created_at":"2023-10-20T14:12:52.137043Z","id":"a45718f6-ab56-425b-800c-bc95edaa18b0","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-20T14:19:11.776181Z","zone":"fr-par-1"}],"ip":[{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-20T14:18:40.121254Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1107"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e01a4b05-60aa-4db0-8e2f-608883cbf5c7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.142624+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"601","node_id":"8","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:73","maintenances":[],"modification_date":"2023-10-20T14:18:45.082650+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.100.15","private_nics":[{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:19:17.636021+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.142624+00:00","export_uri":null,"id":"b60cee5c-b097-4855-a3ce-407f0bca70cc","modification_date":"2023-10-20T14:18:28.142624+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","name":"Scaleway
+      Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3150"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3a11a99e-fbda-4196-93d6-93d6385a2e72
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/538d6444-553e-46f3-9635-d08306cd5512
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-20T14:18:34.664182Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.307165Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"77bc134a-7df0-4cd8-beae-9bb95127fbff","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.307165Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"538d6444-553e-46f3-9635-d08306cd5512","ipam_config":null,"mac_address":"02:00:00:14:57:CF","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","status":"ready","updated_at":"2023-10-20T14:18:37.880612Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "984"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bb2f82c5-83ae-45a3-a467-08af5d0d65ac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd/private-networks?order_by=created_at_asc
+    method: GET
+  response:
+    body: '{"private_network":[{"created_at":"2023-10-20T14:19:03.015448Z","dhcp_config":{"ip_id":"f1a92c22-e3cb-4d69-99d4-b915cc2287e6"},"ipam_ids":["f1a92c22-e3cb-4d69-99d4-b915cc2287e6"],"lb":{"backend_count":0,"created_at":"2023-10-20T14:18:32.564371Z","description":"","frontend_count":0,"id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","instances":[],"ip":[{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-20T14:18:40.121254Z","zone":"fr-par-1"},"private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","status":"ready","updated_at":"2023-10-20T14:19:12.067191Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "1231"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - af1a082b-6892-4896-998c-238a19c65e86
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/user_data
+    method: GET
+  response:
+    body: '{"user_data":[]}'
+    headers:
+      Content-Length:
+      - "17"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 16f83b63-675e-43c6-9880-6d278c8aeee6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/private_nics
+    method: GET
+  response:
+    body: '{"private_nics":[{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:19:17.636021+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:34 GMT
+      Link:
+      - </servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/private_nics?page=1&per_page=50&>;
+        rel="last"
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 006bf420-6fba-4d35-ad09-1716a882902c
+      X-Total-Count:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/538d6444-553e-46f3-9635-d08306cd5512
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-20T14:18:34.664182Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.307165Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"77bc134a-7df0-4cd8-beae-9bb95127fbff","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.307165Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"538d6444-553e-46f3-9635-d08306cd5512","ipam_config":null,"mac_address":"02:00:00:14:57:CF","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","status":"ready","updated_at":"2023-10-20T14:18:37.880612Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "984"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7a77275b-47df-41bf-a186-039b3aca214b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd
+    method: GET
+  response:
+    body: '{"backend_count":0,"created_at":"2023-10-20T14:18:32.564371Z","description":"","frontend_count":0,"id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","instances":[{"created_at":"2023-10-20T14:12:52.137043Z","id":"a45718f6-ab56-425b-800c-bc95edaa18b0","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-20T14:19:11.776181Z","zone":"fr-par-1"}],"ip":[{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-20T14:18:40.121254Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1107"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c59feb82-0783-4a98-9865-faa7e0711b02
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/538d6444-553e-46f3-9635-d08306cd5512?cleanup_dhcp=true
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 47cd4325-cd2c-4233-a826-6ee4e68816dc
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.142624+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"601","node_id":"8","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:73","maintenances":[],"modification_date":"2023-10-20T14:18:45.082650+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.100.15","private_nics":[{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:19:17.636021+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.142624+00:00","export_uri":null,"id":"b60cee5c-b097-4855-a3ce-407f0bca70cc","modification_date":"2023-10-20T14:18:28.142624+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","name":"Scaleway
+      Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3150"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a2c02e02-3b7b-40e0-bfed-5bb9a49c405b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd/private-networks?order_by=created_at_asc
+    method: GET
+  response:
+    body: '{"private_network":[{"created_at":"2023-10-20T14:19:03.015448Z","dhcp_config":{"ip_id":"f1a92c22-e3cb-4d69-99d4-b915cc2287e6"},"ipam_ids":["f1a92c22-e3cb-4d69-99d4-b915cc2287e6"],"lb":{"backend_count":0,"created_at":"2023-10-20T14:18:32.564371Z","description":"","frontend_count":0,"id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","instances":[],"ip":[{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-20T14:18:40.121254Z","zone":"fr-par-1"},"private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","status":"ready","updated_at":"2023-10-20T14:19:12.067191Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "1231"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ea3d2275-dc4c-43fa-8048-f8a7f5f08ce5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/538d6444-553e-46f3-9635-d08306cd5512
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-20T14:18:34.664182Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.307165Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"77bc134a-7df0-4cd8-beae-9bb95127fbff","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.307165Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"538d6444-553e-46f3-9635-d08306cd5512","ipam_config":null,"mac_address":"02:00:00:14:57:CF","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","status":"detaching","updated_at":"2023-10-20T14:19:35.618427Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "988"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b2171ca0-6aaa-4e91-841d-5f8ad90e449c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd/private-networks/487c2354-24bb-4b17-bf88-0d918610cea9/detach
+    method: POST
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bb2edfa1-1c9f-497a-99a8-0e5bc95df8d1
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"action":"poweroff"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/action
+    method: POST
+  response:
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/action","href_result":"/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7","id":"aca37943-2631-4c01-83ef-c2dbc195c170","started_at":"2023-10-20T14:19:35.987697+00:00","status":"pending","terminated_at":null}}'
+    headers:
+      Content-Length:
+      - "317"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:36 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/aca37943-2631-4c01-83ef-c2dbc195c170
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8e4068b8-1796-4633-8338-08b0f62ff60c
     status: 202 Accepted
     code: 202
     duration: ""
@@ -2901,9 +2753,83 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c?release_ip=false
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd
+    method: GET
+  response:
+    body: '{"backend_count":0,"created_at":"2023-10-20T14:18:32.564371Z","description":"","frontend_count":0,"id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","instances":[{"created_at":"2023-10-20T14:12:52.137043Z","id":"a45718f6-ab56-425b-800c-bc95edaa18b0","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-20T14:19:11.776181Z","zone":"fr-par-1"}],"ip":[{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-20T14:18:40.121254Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1107"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7a61814a-99f9-4d95-880d-7bba645e7d37
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.142624+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"601","node_id":"8","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:73","maintenances":[],"modification_date":"2023-10-20T14:19:35.685297+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.100.15","private_nics":[{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:19:17.636021+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.142624+00:00","export_uri":null,"id":"b60cee5c-b097-4855-a3ce-407f0bca70cc","modification_date":"2023-10-20T14:18:28.142624+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","name":"Scaleway
+      Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3118"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ca8a4609-89f8-48ec-a46a-727a66fe8128
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd?release_ip=false
     method: DELETE
   response:
     body: ""
@@ -2913,7 +2839,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:33 GMT
+      - Fri, 20 Oct 2023 14:19:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2923,7 +2849,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4025d09-b5c1-4775-b913-79cf2b61fe7f
+      - 27cb437b-2d31-4cdb-972b-60dcb644f52a
     status: 204 No Content
     code: 204
     duration: ""
@@ -2932,21 +2858,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2023-07-12T09:43:29.715899Z","description":"","frontend_count":0,"id":"4f821d84-b13a-4832-883e-40a68bbc437c","instances":[{"created_at":"2023-07-12T09:41:33.586562Z","id":"5a3b33d2-5ce4-4fe6-964d-df63ac0f7513","ip_address":"10.74.54.85","region":"fr-par","status":"ready","updated_at":"2023-07-12T09:43:31.137205Z","zone":"fr-par-1"}],"ip":[{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":"4f821d84-b13a-4832-883e-40a68bbc437c","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_delete","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-07-12T09:44:32.948103Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2023-10-20T14:18:32.564371Z","description":"","frontend_count":0,"id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","instances":[{"created_at":"2023-10-20T14:12:52.137043Z","id":"a45718f6-ab56-425b-800c-bc95edaa18b0","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-20T14:19:11.776181Z","zone":"fr-par-1"}],"ip":[{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":"a7fc3d66-e78d-4d61-ae45-7635df20d8cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_delete","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-20T14:19:36.157032Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1092"
+      - "1111"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:33 GMT
+      - Fri, 20 Oct 2023 14:19:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2956,7 +2882,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15ef80a6-a7a4-4717-844c-0a3018bc68e7
+      - c68cff1f-00c7-4dcf-97c0-06d7a8714788
     status: 200 OK
     code: 200
     duration: ""
@@ -2965,53 +2891,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/538d6444-553e-46f3-9635-d08306cd5512
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:43:24.129491+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"204","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:0d","maintenances":[],"modification_date":"2023-07-12T09:44:32.636321+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.78.55","private_nics":[{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:44:22.378336+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:43:24.129491+00:00","export_uri":null,"id":"45fdaa44-3af7-4bf4-a09c-e6d7d065ee0c","modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","name":"Scaleway
-      Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3098"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:44:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c8e70ff4-53a3-497f-a557-5da5fb9a5679
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b03f0edc-4729-4771-b167-2b3850a14688
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"b03f0edc-4729-4771-b167-2b3850a14688","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"538d6444-553e-46f3-9635-d08306cd5512","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3020,7 +2905,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:37 GMT
+      - Fri, 20 Oct 2023 14:19:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3030,7 +2915,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28c6a5a1-91b1-4ad6-a817-d81ed219b5c2
+      - 93601ed3-4a0c-4d67-93aa-dba809604e7d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3039,21 +2924,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/98be913f-45a8-4870-ac7e-f41c5c59b906
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:43:24.390741Z","gateway_networks":[],"id":"98be913f-45a8-4870-ac7e-f41c5c59b906","ip":{"address":"163.172.142.90","created_at":"2023-07-12T09:43:23.969335Z","gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"f7ffb21f-b279-4b49-a10e-ba7ac7b58d99","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"90-142-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:43:23.969335Z","zone":"fr-par-1"},"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:43:37.273762Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.100301Z","gateway_networks":[],"id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","ip":{"address":"51.15.139.125","created_at":"2023-10-20T14:18:26.967221Z","gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"f5ad4bfe-5f76-48e3-bfc9-fe61c59d6b56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"125-139-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.967221Z","zone":"fr-par-1"},"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:38.010140Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "935"
+      - "979"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:37 GMT
+      - Fri, 20 Oct 2023 14:19:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3063,7 +2948,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d47a456d-c55e-4d81-83a0-f107d7ec3244
+      - 7836d365-689e-467f-9b23-edfd0d3d2aa2
     status: 200 OK
     code: 200
     duration: ""
@@ -3072,12 +2957,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/4ac59b75-000a-4fd7-be45-a33eb2287983
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/77bc134a-7df0-4cd8-beae-9bb95127fbff
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"4ac59b75-000a-4fd7-be45-a33eb2287983","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"77bc134a-7df0-4cd8-beae-9bb95127fbff","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3086,7 +2971,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:37 GMT
+      - Fri, 20 Oct 2023 14:19:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3096,7 +2981,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65d976de-ea22-49a4-bad5-67952359be46
+      - 49da8e6f-e060-4235-9194-6f1230237050
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3105,29 +2990,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:43:24.129491+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"204","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:0d","maintenances":[],"modification_date":"2023-07-12T09:44:32.636321+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.78.55","private_nics":[{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:44:22.378336+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:43:24.129491+00:00","export_uri":null,"id":"45fdaa44-3af7-4bf4-a09c-e6d7d065ee0c","modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.142624+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"601","node_id":"8","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:73","maintenances":[],"modification_date":"2023-10-20T14:19:35.685297+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.100.15","private_nics":[{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:19:17.636021+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.142624+00:00","export_uri":null,"id":"b60cee5c-b097-4855-a3ce-407f0bca70cc","modification_date":"2023-10-20T14:18:28.142624+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3098"
+      - "3118"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:38 GMT
+      - Fri, 20 Oct 2023 14:19:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3137,7 +3022,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f3bea25-af50-4111-886d-a88e735e8ea3
+      - cd7ef84c-ce22-4138-a5ae-050eb8ce5b61
     status: 200 OK
     code: 200
     duration: ""
@@ -3146,29 +3031,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:43:24.129491+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"204","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:0d","maintenances":[],"modification_date":"2023-07-12T09:44:32.636321+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.78.55","private_nics":[{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:44:22.378336+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:43:24.129491+00:00","export_uri":null,"id":"45fdaa44-3af7-4bf4-a09c-e6d7d065ee0c","modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.142624+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"601","node_id":"8","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:73","maintenances":[],"modification_date":"2023-10-20T14:19:35.685297+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.100.15","private_nics":[{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:19:17.636021+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.142624+00:00","export_uri":null,"id":"b60cee5c-b097-4855-a3ce-407f0bca70cc","modification_date":"2023-10-20T14:18:28.142624+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3098"
+      - "3118"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:44 GMT
+      - Fri, 20 Oct 2023 14:19:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3178,7 +3063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 006d1ad3-833a-41a2-9448-289f6268bc89
+      - 9d7b9600-82b5-4df8-be60-ca452aecd103
     status: 200 OK
     code: 200
     duration: ""
@@ -3187,29 +3072,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:43:24.129491+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"204","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:0d","maintenances":[],"modification_date":"2023-07-12T09:44:32.636321+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.78.55","private_nics":[{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:44:22.378336+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:43:24.129491+00:00","export_uri":null,"id":"45fdaa44-3af7-4bf4-a09c-e6d7d065ee0c","modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.142624+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"601","node_id":"8","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:73","maintenances":[],"modification_date":"2023-10-20T14:19:35.685297+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.100.15","private_nics":[{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:19:17.636021+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.142624+00:00","export_uri":null,"id":"b60cee5c-b097-4855-a3ce-407f0bca70cc","modification_date":"2023-10-20T14:18:28.142624+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3098"
+      - "3118"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:49 GMT
+      - Fri, 20 Oct 2023 14:19:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3219,7 +3104,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e87182aa-7f79-4081-877d-ba3618dd061e
+      - 863a5adf-1c3d-4cac-b748-28a203fdcb6e
     status: 200 OK
     code: 200
     duration: ""
@@ -3228,29 +3113,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:43:24.129491+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"204","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:0d","maintenances":[],"modification_date":"2023-07-12T09:44:32.636321+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.78.55","private_nics":[{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:44:22.378336+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:43:24.129491+00:00","export_uri":null,"id":"45fdaa44-3af7-4bf4-a09c-e6d7d065ee0c","modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.142624+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"601","node_id":"8","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:73","maintenances":[],"modification_date":"2023-10-20T14:19:35.685297+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.100.15","private_nics":[{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:19:17.636021+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.142624+00:00","export_uri":null,"id":"b60cee5c-b097-4855-a3ce-407f0bca70cc","modification_date":"2023-10-20T14:18:28.142624+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3098"
+      - "3118"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:54 GMT
+      - Fri, 20 Oct 2023 14:19:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3260,7 +3145,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9cbb7e52-4749-4fdf-91da-a130b63e869c
+      - 29687dbb-1c8e-475b-99ae-70dbca1279c6
     status: 200 OK
     code: 200
     duration: ""
@@ -3269,29 +3154,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:43:24.129491+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:0d","maintenances":[],"modification_date":"2023-07-12T09:44:54.730504+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:44:22.378336+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:43:24.129491+00:00","export_uri":null,"id":"45fdaa44-3af7-4bf4-a09c-e6d7d065ee0c","modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.142624+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b1:73","maintenances":[],"modification_date":"2023-10-20T14:19:59.330190+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:19:17.636021+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.142624+00:00","export_uri":null,"id":"b60cee5c-b097-4855-a3ce-407f0bca70cc","modification_date":"2023-10-20T14:18:28.142624+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2977"
+      - "2997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:59 GMT
+      - Fri, 20 Oct 2023 14:20:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3301,7 +3186,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d8c6d1a-d149-4784-b7f1-16e3bac45163
+      - 3d2af6e5-5cdb-4890-b150-5bece9662d5c
     status: 200 OK
     code: 200
     duration: ""
@@ -3310,29 +3195,24 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/private_nics
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:43:24.129491+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:0d","maintenances":[],"modification_date":"2023-07-12T09:44:54.730504+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-07-12T09:43:51.150738+00:00","id":"420f112b-c0c7-4bf7-ac6c-9b92e0e895c2","mac_address":"02:00:00:13:5d:ba","modification_date":"2023-07-12T09:44:22.378336+00:00","private_network_id":"a32b2fda-5143-40eb-a034-f01629975382","server_id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:43:24.129491+00:00","export_uri":null,"id":"45fdaa44-3af7-4bf4-a09c-e6d7d065ee0c","modification_date":"2023-07-12T09:43:24.129491+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b236a23b-93ac-41a8-88db-6043fc5a2be4","name":"Scaleway
-      Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:19:17.636021+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
-      - "2977"
+      - "381"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:44:59 GMT
+      - Fri, 20 Oct 2023 14:20:02 GMT
+      Link:
+      - </servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/private_nics?page=1&per_page=50&>;
+        rel="last"
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3342,7 +3222,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7bda888-1544-431f-b7c8-7cdb3134869c
+      - f83ddb05-cec7-405d-8eca-eee6638963f6
+      X-Total-Count:
+      - "1"
     status: 200 OK
     code: 200
     duration: ""
@@ -3351,9 +3233,42 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/private_nics/d30911b2-df1e-4160-9363-3872d4594224
+    method: GET
+  response:
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:45.787475+00:00","id":"d30911b2-df1e-4160-9363-3872d4594224","mac_address":"02:00:00:14:57:d0","modification_date":"2023-10-20T14:19:17.636021+00:00","private_network_id":"487c2354-24bb-4b17-bf88-0d918610cea9","server_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","state":"available","tags":[],"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "378"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:20:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3a621255-3865-4e62-96de-58d17390bd2d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/private_nics/d30911b2-df1e-4160-9363-3872d4594224
     method: DELETE
   response:
     body: ""
@@ -3361,7 +3276,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Wed, 12 Jul 2023 09:45:00 GMT
+      - Fri, 20 Oct 2023 14:20:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3371,7 +3286,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b890f28-c9f1-4453-90ac-292b7eedf805
+      - 77edda28-7544-43a0-aa86-7c6db989720c
     status: 204 No Content
     code: 204
     duration: ""
@@ -3380,21 +3295,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7/private_nics/d30911b2-df1e-4160-9363-3872d4594224
     method: GET
   response:
-    body: '{"message":"\"b236a23b-93ac-41a8-88db-6043fc5a2be4\" not found","type":"unknown_resource"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"d30911b2-df1e-4160-9363-3872d4594224","type":"not_found"}'
     headers:
       Content-Length:
-      - "93"
+      - "148"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:00 GMT
+      - Fri, 20 Oct 2023 14:20:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3404,7 +3319,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8d2ea38-9272-4abf-bfde-1abbda26100d
+      - 80b3770e-a42d-452b-8380-af29d1ed7e16
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3413,17 +3328,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/45fdaa44-3af7-4bf4-a09c-e6d7d065ee0c
-    method: DELETE
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7
+    method: GET
   response:
-    body: ""
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.142624+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b1:73","maintenances":[],"modification_date":"2023-10-20T14:19:59.330190+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.142624+00:00","export_uri":null,"id":"b60cee5c-b097-4855-a3ce-407f0bca70cc","modification_date":"2023-10-20T14:18:28.142624+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","name":"Scaleway
+      Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
+      Content-Length:
+      - "2636"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:00 GMT
+      - Fri, 20 Oct 2023 14:20:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3433,7 +3360,36 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4cb4cf51-c48c-403c-b714-fd7d7b176bf7
+      - 3dd4fcae-3b8d-4d58-92aa-e72e76a45cc6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Fri, 20 Oct 2023 14:20:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b82e68b5-cf91-4ecf-b76c-0699ace22ee9
     status: 204 No Content
     code: 204
     duration: ""
@@ -3442,9 +3398,71 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:20:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 89b522a8-ebab-4876-bc6c-a4bdf1b82245
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b60cee5c-b097-4855-a3ce-407f0bca70cc
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Fri, 20 Oct 2023 14:20:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6b39d297-8f63-48b5-b24a-f09b675dd741
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd
     method: GET
   response:
     body: '{"message":"lbs not Found"}'
@@ -3456,7 +3474,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:03 GMT
+      - Fri, 20 Oct 2023 14:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3466,7 +3484,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01c48ab2-6c22-4039-9334-91dedf971351
+      - d4c75966-1fa6-42ef-bc79-565108f787ab
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3475,9 +3493,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd
     method: GET
   response:
     body: '{"message":"lbs not Found"}'
@@ -3489,7 +3507,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:03 GMT
+      - Fri, 20 Oct 2023 14:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3499,7 +3517,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e161e54-add4-4ede-a546-6fa4578d5a8e
+      - 8d698c91-7d77-4e18-84fb-cfe0b467e660
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3508,21 +3526,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/98be913f-45a8-4870-ac7e-f41c5c59b906
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:43:24.390741Z","gateway_networks":[],"id":"98be913f-45a8-4870-ac7e-f41c5c59b906","ip":{"address":"163.172.142.90","created_at":"2023-07-12T09:43:23.969335Z","gateway_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","id":"f7ffb21f-b279-4b49-a10e-ba7ac7b58d99","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"90-142-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:43:23.969335Z","zone":"fr-par-1"},"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:43:37.273762Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.100301Z","gateway_networks":[],"id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","ip":{"address":"51.15.139.125","created_at":"2023-10-20T14:18:26.967221Z","gateway_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","id":"f5ad4bfe-5f76-48e3-bfc9-fe61c59d6b56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"125-139-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.967221Z","zone":"fr-par-1"},"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:38.010140Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "935"
+      - "979"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:03 GMT
+      - Fri, 20 Oct 2023 14:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3532,7 +3550,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c2773b6-990e-42ca-b95f-11a33e749dba
+      - 0428fcc8-2d4f-408c-be8d-092c3454df7c
     status: 200 OK
     code: 200
     duration: ""
@@ -3541,21 +3559,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/36097131-88b0-4e6b-9baf-6d1e304e81da
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/f8576741-b282-4830-9813-a6b028e3f0ca
     method: GET
   response:
-    body: '{"id":"36097131-88b0-4e6b-9baf-6d1e304e81da","ip_address":"51.158.57.165","lb_id":null,"organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-57-165.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
+    body: '{"id":"f8576741-b282-4830-9813-a6b028e3f0ca","ip_address":"51.159.11.48","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-48.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "278"
+      - "283"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:03 GMT
+      - Fri, 20 Oct 2023 14:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3565,7 +3583,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02ac391b-024f-4083-9d12-6a47adcee988
+      - 90530e31-6c0c-493e-ba8e-8f593f47bebd
     status: 200 OK
     code: 200
     duration: ""
@@ -3574,9 +3592,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/98be913f-45a8-4870-ac7e-f41c5c59b906?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -3586,7 +3604,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:03 GMT
+      - Fri, 20 Oct 2023 14:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3596,7 +3614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0478f23-88ea-45a0-81b9-93aa8a1f9dd6
+      - d2776055-e076-458e-a00e-bdd5561c8f86
     status: 204 No Content
     code: 204
     duration: ""
@@ -3605,12 +3623,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/98be913f-45a8-4870-ac7e-f41c5c59b906
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3619,7 +3637,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:03 GMT
+      - Fri, 20 Oct 2023 14:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3629,7 +3647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf5c0008-5148-415c-b74d-4b93aee20a16
+      - b6cacd2c-26df-40fc-b621-671fee73de69
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3638,9 +3656,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a32b2fda-5143-40eb-a034-f01629975382
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/f5ad4bfe-5f76-48e3-bfc9-fe61c59d6b56
     method: DELETE
   response:
     body: ""
@@ -3650,7 +3668,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:03 GMT
+      - Fri, 20 Oct 2023 14:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3660,7 +3678,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - accffeb9-865d-4675-b806-7bc83c8a78a5
+      - 6f969c6d-82a1-42dc-bca7-dd6605e5a044
     status: 204 No Content
     code: 204
     duration: ""
@@ -3669,9 +3687,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/f7ffb21f-b279-4b49-a10e-ba7ac7b58d99
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/f8576741-b282-4830-9813-a6b028e3f0ca
     method: DELETE
   response:
     body: ""
@@ -3681,7 +3699,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:03 GMT
+      - Fri, 20 Oct 2023 14:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3691,7 +3709,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0aee3e99-14aa-427f-95e9-d885dcbd4a3a
+      - 8c124e6b-8f6e-4971-bee3-25b654fb27a7
     status: 204 No Content
     code: 204
     duration: ""
@@ -3700,9 +3718,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/36097131-88b0-4e6b-9baf-6d1e304e81da
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/487c2354-24bb-4b17-bf88-0d918610cea9
     method: DELETE
   response:
     body: ""
@@ -3712,7 +3730,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:05 GMT
+      - Fri, 20 Oct 2023 14:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3722,7 +3740,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d4832f2-399a-48fb-a1eb-0b4bacccf87f
+      - 4fc3b11e-d819-428b-86cf-a80b15a8b3e7
     status: 204 No Content
     code: 204
     duration: ""
@@ -3731,21 +3749,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b236a23b-93ac-41a8-88db-6043fc5a2be4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c8146d64-b475-4a8d-a443-e01e6deb21c7
     method: GET
   response:
-    body: '{"message":"\"b236a23b-93ac-41a8-88db-6043fc5a2be4\" not found","type":"unknown_resource"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"c8146d64-b475-4a8d-a443-e01e6deb21c7","type":"not_found"}'
     headers:
       Content-Length:
-      - "93"
+      - "143"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:05 GMT
+      - Fri, 20 Oct 2023 14:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3755,7 +3773,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2261e625-5ed2-4eb2-ab94-b8c4a4c9f340
+      - fe9f43d7-5ed4-41ec-a5b6-4512fda38845
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3764,42 +3782,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c
-    method: GET
-  response:
-    body: '{"message":"lbs not Found"}'
-    headers:
-      Content-Length:
-      - "27"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:45:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 261b675c-2cb4-4dca-92c6-f1f739999c3f
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/4f821d84-b13a-4832-883e-40a68bbc437c
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd
     method: GET
   response:
     body: '{"message":"lbs not Found"}'
@@ -3811,7 +3796,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:05 GMT
+      - Fri, 20 Oct 2023 14:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3821,7 +3806,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8f086fa-3512-47d8-b962-3178df56c4c3
+      - b5d741da-eab3-4912-ade9-0ab0471a61d5
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3830,9 +3815,42 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/36097131-88b0-4e6b-9baf-6d1e304e81da
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a7fc3d66-e78d-4d61-ae45-7635df20d8cd
+    method: GET
+  response:
+    body: '{"message":"lbs not Found"}'
+    headers:
+      Content-Length:
+      - "27"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:20:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1504ee79-712e-49d7-807d-166f4b6aa494
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/f8576741-b282-4830-9813-a6b028e3f0ca
     method: GET
   response:
     body: '{"message":"ips not Found"}'
@@ -3844,7 +3862,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:05 GMT
+      - Fri, 20 Oct 2023 14:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3854,7 +3872,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45390dc4-0f73-4a90-9db9-b117f7d0444e
+      - efc8011a-4366-427f-be8e-9997c3893792
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3863,12 +3881,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b03f0edc-4729-4771-b167-2b3850a14688
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/538d6444-553e-46f3-9635-d08306cd5512
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"b03f0edc-4729-4771-b167-2b3850a14688","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"538d6444-553e-46f3-9635-d08306cd5512","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3877,7 +3895,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:05 GMT
+      - Fri, 20 Oct 2023 14:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3887,7 +3905,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f03fb114-80a8-4e58-a864-a285ae5876f2
+      - 65edf39b-c0ab-4dff-920d-dd181be80c47
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3896,12 +3914,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a32b2fda-5143-40eb-a034-f01629975382
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/487c2354-24bb-4b17-bf88-0d918610cea9
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"a32b2fda-5143-40eb-a034-f01629975382","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"487c2354-24bb-4b17-bf88-0d918610cea9","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3910,7 +3928,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:05 GMT
+      - Fri, 20 Oct 2023 14:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3920,7 +3938,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32ba272d-8e20-4dcc-9dfb-e730434339f7
+      - 8c1ee570-57d9-4263-b902-fc5cde5d2775
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3929,12 +3947,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/4ac59b75-000a-4fd7-be45-a33eb2287983
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/77bc134a-7df0-4cd8-beae-9bb95127fbff
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"4ac59b75-000a-4fd7-be45-a33eb2287983","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"77bc134a-7df0-4cd8-beae-9bb95127fbff","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3943,7 +3961,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:05 GMT
+      - Fri, 20 Oct 2023 14:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3953,7 +3971,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 874aa07b-e414-4112-86f9-8b6fa57ae50c
+      - 2b5b68d4-43df-49f8-8165-71534a314bb3
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3962,12 +3980,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/98be913f-45a8-4870-ac7e-f41c5c59b906
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"98be913f-45a8-4870-ac7e-f41c5c59b906","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"4edd7529-3f3f-4cb2-8f09-6e9fef5a5d56","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3976,7 +3994,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:05 GMT
+      - Fri, 20 Oct 2023 14:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3986,7 +4004,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc876691-9f37-4ccf-bfb1-fc7147ddb245
+      - 73068d2b-816f-4c40-9fae-230b82b2779a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3995,12 +4013,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/f7ffb21f-b279-4b49-a10e-ba7ac7b58d99
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/f5ad4bfe-5f76-48e3-bfc9-fe61c59d6b56
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"ip","resource_id":"f7ffb21f-b279-4b49-a10e-ba7ac7b58d99","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"ip","resource_id":"f5ad4bfe-5f76-48e3-bfc9-fe61c59d6b56","type":"not_found"}'
     headers:
       Content-Length:
       - "123"
@@ -4009,7 +4027,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:05 GMT
+      - Fri, 20 Oct 2023 14:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4019,7 +4037,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6d03967-aa21-4c80-883b-b0f3e85d01a1
+      - 36de4dd8-58bb-4120-9ca9-31ca2c76b2e7
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/vpc-public-gateway-dhcp-entry-basic.cassette.yaml
+++ b/scaleway/testdata/vpc-public-gateway-dhcp-entry-basic.cassette.yaml
@@ -2,27 +2,27 @@
 version: 1
 interactions:
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","subnet":"192.168.1.0/24","address":null,"pool_low":null,"pool_high":null,"enable_dynamic":null,"valid_lifetime":null,"renew_timer":null,"rebind_timer":null,"push_default_route":null,"push_dns_server":null,"dns_servers_override":null,"dns_search":null,"dns_local_name":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","address":null,"pool_low":null,"pool_high":null,"enable_dynamic":null,"valid_lifetime":null,"renew_timer":null,"rebind_timer":null,"push_default_route":null,"push_dns_server":null,"dns_servers_override":null,"dns_search":null,"dns_local_name":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
     method: POST
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:57 GMT
+      - Fri, 20 Oct 2023 14:54:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5480cbc7-946a-4f3d-972f-fb36532761b2
+      - 4619d9cf-ba11-46a2-94bb-3626ad37d1c1
     status: 200 OK
     code: 200
     duration: ""
@@ -41,21 +41,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/872ade8e-2702-41b5-be01-0c10ef43401a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/4a889438-daf1-417e-aee4-996c8b27ccfc
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:58 GMT
+      - Fri, 20 Oct 2023 14:54:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,32 +65,168 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68b630d3-736a-4b02-8d6e-0861dcef1e26
+      - cc768a7b-2265-440f-8d1a-cf6f83bd1e7e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"pn_test_network","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
+    method: POST
+  response:
+    body: '{"address":"51.158.65.159","created_at":"2023-10-20T14:54:49.962464Z","gateway_id":null,"id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"159-65-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:54:49.962464Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "367"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:54:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 93813c1c-d75a-4c47-b07f-cdae2b2d59c5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/f5a1fd31-4400-4fa1-8432-b312cfd012cd
+    method: GET
+  response:
+    body: '{"address":"51.158.65.159","created_at":"2023-10-20T14:54:49.962464Z","gateway_id":null,"id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"159-65-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:54:49.962464Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "367"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:54:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0102eb80-500a-4ccd-9480-f1d6f055cd59
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","enable_smtp":false,"enable_bastion":false,"bastion_port":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
+    method: POST
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:54:50.160667Z","gateway_networks":[],"id":"86efc927-4816-4b90-b1b0-b184079e15ed","ip":{"address":"51.158.65.159","created_at":"2023-10-20T14:54:49.962464Z","gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"159-65-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:54:49.962464Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:54:50.160667Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "969"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:54:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 65ef88f3-21bc-412b-a6dc-42889b3b2803
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/86efc927-4816-4b90-b1b0-b184079e15ed
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:54:50.160667Z","gateway_networks":[],"id":"86efc927-4816-4b90-b1b0-b184079e15ed","ip":{"address":"51.158.65.159","created_at":"2023-10-20T14:54:49.962464Z","gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"159-65-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:54:49.962464Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:54:50.160667Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "969"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:54:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3fd9b426-0017-4df4-8101-5b1baad9513d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"pn_test_network","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null,"vpc_id":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-07-12T09:46:57.988609Z","dhcp_enabled":false,"id":"a475898a-5097-40bb-8171-9f8d07d52d5c","name":"pn_test_network","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-07-12T09:46:57.988609Z","id":"7f34c9c2-4702-4ca1-959c-74a236503303","subnet":"172.16.8.0/22","updated_at":"2023-07-12T09:46:57.988609Z"},{"created_at":"2023-07-12T09:46:57.988609Z","id":"025f7334-13c1-4b7c-b120-007e421ababf","subnet":"fd46:78ab:30b8:fd6c::/64","updated_at":"2023-07-12T09:46:57.988609Z"}],"tags":[],"updated_at":"2023-07-12T09:46:57.988609Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2023-10-20T14:54:49.394486Z","dhcp_enabled":true,"id":"4acd338e-6465-4dc3-a997-5e31625a283c","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T14:54:49.394486Z","id":"3c7b7e99-01e2-40cd-84b1-cf707f6d207c","subnet":"172.16.80.0/22","updated_at":"2023-10-20T14:54:49.394486Z"},{"created_at":"2023-10-20T14:54:49.394486Z","id":"2dc34e55-fd33-4619-bbb1-295b32ad4c9f","subnet":"fd5f:519c:6d46:b485::/64","updated_at":"2023-10-20T14:54:49.394486Z"}],"tags":[],"updated_at":"2023-10-20T14:54:49.394486Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "699"
+      - "716"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:58 GMT
+      - Fri, 20 Oct 2023 14:54:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -100,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d8563c1-a96f-4876-bf95-7294bf2a7bc5
+      - 419cb614-ac33-4943-bd22-02ca6540136d
     status: 200 OK
     code: 200
     duration: ""
@@ -109,21 +245,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a475898a-5097-40bb-8171-9f8d07d52d5c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4acd338e-6465-4dc3-a997-5e31625a283c
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:46:57.988609Z","dhcp_enabled":false,"id":"a475898a-5097-40bb-8171-9f8d07d52d5c","name":"pn_test_network","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-07-12T09:46:57.988609Z","id":"7f34c9c2-4702-4ca1-959c-74a236503303","subnet":"172.16.8.0/22","updated_at":"2023-07-12T09:46:57.988609Z"},{"created_at":"2023-07-12T09:46:57.988609Z","id":"025f7334-13c1-4b7c-b120-007e421ababf","subnet":"fd46:78ab:30b8:fd6c::/64","updated_at":"2023-07-12T09:46:57.988609Z"}],"tags":[],"updated_at":"2023-07-12T09:46:57.988609Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2023-10-20T14:54:49.394486Z","dhcp_enabled":true,"id":"4acd338e-6465-4dc3-a997-5e31625a283c","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T14:54:49.394486Z","id":"3c7b7e99-01e2-40cd-84b1-cf707f6d207c","subnet":"172.16.80.0/22","updated_at":"2023-10-20T14:54:49.394486Z"},{"created_at":"2023-10-20T14:54:49.394486Z","id":"2dc34e55-fd33-4619-bbb1-295b32ad4c9f","subnet":"fd5f:519c:6d46:b485::/64","updated_at":"2023-10-20T14:54:49.394486Z"}],"tags":[],"updated_at":"2023-10-20T14:54:49.394486Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "699"
+      - "716"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:58 GMT
+      - Fri, 20 Oct 2023 14:54:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -133,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3e2b5a9-3e17-4390-9c61-5eabc019bdfb
+      - 4794dc92-2454-4bfb-be66-8755e18c8bd6
     status: 200 OK
     code: 200
     duration: ""
@@ -142,21 +278,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60"],"id":"5b51710c-e543-47b5-92d2-a68a83cefbe9","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"10b2d3c3-bfa7-42d4-910b-389e95f95ccb","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1092"
+      - "1256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:58 GMT
+      - Fri, 20 Oct 2023 14:54:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -166,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1561e5b-8852-46cc-954d-e6b79a99410e
+      - 1bfd559a-a9b6-47ad-9f39-40b444a8d7a6
     status: 200 OK
     code: 200
     duration: ""
@@ -175,21 +311,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
+    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
     headers:
       Content-Length:
-      - "37931"
+      - "38421"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:58 GMT
+      - Fri, 20 Oct 2023 14:54:50 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
@@ -202,7 +338,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06a01602-26eb-44ec-bb35-304514dace43
+      - 683003b4-5e3f-4f9d-9b82-c20b1e9ad121
       X-Total-Count:
       - "56"
     status: 200 OK
@@ -213,21 +349,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
     headers:
       Content-Length:
-      - "4489"
+      - "4865"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:58 GMT
+      - Fri, 20 Oct 2023 14:54:50 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
@@ -240,110 +376,42 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b5a1861-466a-484b-9337-34a2fd835748
+      - 5504035b-a13a-4cf0-b86b-3169b3b05cae
       X-Total-Count:
       - "56"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null}'
+    body: '{"name":"tf-srv-competent-herschel","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
-    method: POST
-  response:
-    body: '{"address":"163.172.185.229","created_at":"2023-07-12T09:46:58.725645Z","gateway_id":null,"id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-185-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:46:58.725645Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "362"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:46:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c8f4a70c-093b-423f-8a8e-5ead1ff47a92
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/98cd880f-da4f-4c67-8857-32c89bf2bea1
-    method: GET
-  response:
-    body: '{"address":"163.172.185.229","created_at":"2023-07-12T09:46:58.725645Z","gateway_id":null,"id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-185-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:46:58.725645Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "362"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:46:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 70667328-d85e-4b6f-b653-ae41ceb379e5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"tf-srv-mystifying-mahavira","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:46:58.580506+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:54:51.156669+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2640"
+      - "2657"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:58 GMT
+      - Fri, 20 Oct 2023 14:54:51 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -353,7 +421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5fa57a9f-0532-4044-83ed-99a84278c1ec
+      - 91f769cf-ccd9-4e06-b7e9-3eb4c9906a99
     status: 201 Created
     code: 201
     duration: ""
@@ -362,27 +430,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:46:58.580506+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:54:51.156669+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2640"
+      - "2657"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:59 GMT
+      - Fri, 20 Oct 2023 14:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -392,7 +460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd57aedf-e8aa-4c73-92be-d9f825a85333
+      - 6510e521-a6d7-471b-9142-d4328ecc8f85
     status: 200 OK
     code: 200
     duration: ""
@@ -401,27 +469,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:46:58.580506+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:54:51.156669+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2640"
+      - "2657"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:59 GMT
+      - Fri, 20 Oct 2023 14:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -431,75 +499,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab12663d-93ef-4270-9ae7-95b38bd2e367
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","enable_smtp":false,"enable_bastion":false,"bastion_port":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
-    method: POST
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:46:59.262468Z","gateway_networks":[],"id":"36396eae-68c3-4778-813d-88f8c1860f25","ip":{"address":"163.172.185.229","created_at":"2023-07-12T09:46:58.725645Z","gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-185-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:46:58.725645Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:46:59.262468Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "926"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:46:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 14fa8bb0-d9b2-47c5-a326-45e9b99af4d8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/36396eae-68c3-4778-813d-88f8c1860f25
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:46:59.262468Z","gateway_networks":[],"id":"36396eae-68c3-4778-813d-88f8c1860f25","ip":{"address":"163.172.185.229","created_at":"2023-07-12T09:46:58.725645Z","gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-185-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:46:58.725645Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:46:59.323894Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "929"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:46:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7f9e708a-bbea-4ed4-92f3-b9ebd223e1d9
+      - f14579b2-99d6-49db-a8ab-814e1ad39f8e
     status: 200 OK
     code: 200
     duration: ""
@@ -510,12 +510,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/6696f912-abb5-4922-adc7-46441e3bc005/action","href_result":"/servers/6696f912-abb5-4922-adc7-46441e3bc005","id":"b0f62adb-ebe9-4197-86b1-95d2d4a727e0","started_at":"2023-07-12T09:46:59.510449+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/action","href_result":"/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","id":"f3f127b8-ef99-4d84-a848-c5f5e11a22c2","started_at":"2023-10-20T14:54:52.928112+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -524,9 +524,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:59 GMT
+      - Fri, 20 Oct 2023 14:54:52 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/b0f62adb-ebe9-4197-86b1-95d2d4a727e0
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/f3f127b8-ef99-4d84-a848-c5f5e11a22c2
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -536,7 +536,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9aa4724-6fff-4fee-8a43-aa39bd8de0f8
+      - c42347b8-971b-4e95-8ace-a50163b9fd48
     status: 202 Accepted
     code: 202
     duration: ""
@@ -545,27 +545,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:46:59.181634+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:54:52.272439+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2662"
+      - "2679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:59 GMT
+      - Fri, 20 Oct 2023 14:54:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -575,7 +575,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b931e99-12d1-423b-8887-094f50b02326
+      - bf92eca0-5065-49ec-b318-c25ba144be69
     status: 200 OK
     code: 200
     duration: ""
@@ -584,21 +584,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/36396eae-68c3-4778-813d-88f8c1860f25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/86efc927-4816-4b90-b1b0-b184079e15ed
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:46:59.262468Z","gateway_networks":[],"id":"36396eae-68c3-4778-813d-88f8c1860f25","ip":{"address":"163.172.185.229","created_at":"2023-07-12T09:46:58.725645Z","gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-185-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:46:58.725645Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:46:59.812860Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:54:50.160667Z","gateway_networks":[],"id":"86efc927-4816-4b90-b1b0-b184079e15ed","ip":{"address":"51.158.65.159","created_at":"2023-10-20T14:54:49.962464Z","gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"159-65-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:54:49.962464Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:54:50.944006Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "926"
+      - "969"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:04 GMT
+      - Fri, 20 Oct 2023 14:54:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -608,7 +608,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a75d8c2-78e6-4198-8c73-d9381faa15ba
+      - 71054ee0-248f-4dbd-8397-e58a241a88f5
     status: 200 OK
     code: 200
     duration: ""
@@ -617,21 +617,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/36396eae-68c3-4778-813d-88f8c1860f25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/86efc927-4816-4b90-b1b0-b184079e15ed
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:46:59.262468Z","gateway_networks":[],"id":"36396eae-68c3-4778-813d-88f8c1860f25","ip":{"address":"163.172.185.229","created_at":"2023-07-12T09:46:58.725645Z","gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-185-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:46:58.725645Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:46:59.812860Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:54:50.160667Z","gateway_networks":[],"id":"86efc927-4816-4b90-b1b0-b184079e15ed","ip":{"address":"51.158.65.159","created_at":"2023-10-20T14:54:49.962464Z","gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"159-65-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:54:49.962464Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:54:50.944006Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "926"
+      - "969"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:04 GMT
+      - Fri, 20 Oct 2023 14:54:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -641,7 +641,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c111c2d-8d0e-4d79-87e0-b3b0138cc040
+      - 108030e5-1c61-4f58-9388-e31bc0d42e6e
     status: 200 OK
     code: 200
     duration: ""
@@ -650,21 +650,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/36396eae-68c3-4778-813d-88f8c1860f25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/86efc927-4816-4b90-b1b0-b184079e15ed
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:46:59.262468Z","gateway_networks":[],"id":"36396eae-68c3-4778-813d-88f8c1860f25","ip":{"address":"163.172.185.229","created_at":"2023-07-12T09:46:58.725645Z","gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-185-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:46:58.725645Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:46:59.812860Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:54:50.160667Z","gateway_networks":[],"id":"86efc927-4816-4b90-b1b0-b184079e15ed","ip":{"address":"51.158.65.159","created_at":"2023-10-20T14:54:49.962464Z","gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"159-65-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:54:49.962464Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:54:50.944006Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "926"
+      - "969"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:04 GMT
+      - Fri, 20 Oct 2023 14:54:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -674,7 +674,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b7a0b81-0513-4eeb-9dc7-4c16ee408ce5
+      - 044b4841-018e-4583-9afd-3b11672f091a
     status: 200 OK
     code: 200
     duration: ""
@@ -683,27 +683,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1801","node_id":"39","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:46:59.181634+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.148.77","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1902","node_id":"12","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:54:52.272439+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.154.23","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2772"
+      - "2789"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:04 GMT
+      - Fri, 20 Oct 2023 14:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -713,32 +713,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36785384-9064-4d83-af73-f65ea98a5b7b
+      - bae3cffc-414c-429e-8dd1-0f534a7ea7dd
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","enable_masquerade":true,"dhcp_id":"872ade8e-2702-41b5-be01-0c10ef43401a","enable_dhcp":true}'
+    body: '{"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"4a889438-daf1-417e-aee4-996c8b27ccfc"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":null,"private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"created","updated_at":"2023-07-12T09:47:04.900086Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":null,"private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"created","updated_at":"2023-10-20T14:54:58.970489Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "934"
+      - "983"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:04 GMT
+      - Fri, 20 Oct 2023 14:54:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -748,7 +748,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68613a3b-2656-4e6a-9361-ffba642a809b
+      - 51bd77ef-120c-450f-be1d-1ee2fb2a79d8
     status: 200 OK
     code: 200
     duration: ""
@@ -757,21 +757,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/36396eae-68c3-4778-813d-88f8c1860f25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/86efc927-4816-4b90-b1b0-b184079e15ed
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:46:59.262468Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":null,"private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"created","updated_at":"2023-07-12T09:47:04.900086Z","zone":"fr-par-1"}],"id":"36396eae-68c3-4778-813d-88f8c1860f25","ip":{"address":"163.172.185.229","created_at":"2023-07-12T09:46:58.725645Z","gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-185-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:46:58.725645Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:47:04.998721Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:54:50.160667Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":null,"private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"created","updated_at":"2023-10-20T14:54:58.970489Z","zone":"fr-par-1"}],"id":"86efc927-4816-4b90-b1b0-b184079e15ed","ip":{"address":"51.158.65.159","created_at":"2023-10-20T14:54:49.962464Z","gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"159-65-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:54:49.962464Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:54:59.412186Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1864"
+      - "1955"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:05 GMT
+      - Fri, 20 Oct 2023 14:54:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -781,7 +781,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3847f8a9-5cb5-44a0-ba1b-d43f02bb758d
+      - 53aa37ca-389c-489c-b35b-93fa55a033ee
     status: 200 OK
     code: 200
     duration: ""
@@ -790,27 +790,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1801","node_id":"39","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:46:59.181634+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.148.77","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1902","node_id":"12","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:54:52.272439+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.154.23","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2772"
+      - "2789"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:10 GMT
+      - Fri, 20 Oct 2023 14:55:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -820,7 +820,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf790b78-003b-4ac2-92ee-843ae87129cc
+      - 82c9d4bd-097e-432c-ad79-9b60da0566e8
     status: 200 OK
     code: 200
     duration: ""
@@ -829,21 +829,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/36396eae-68c3-4778-813d-88f8c1860f25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/86efc927-4816-4b90-b1b0-b184079e15ed
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:46:59.262468Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:06.738183Z","zone":"fr-par-1"}],"id":"36396eae-68c3-4778-813d-88f8c1860f25","ip":{"address":"163.172.185.229","created_at":"2023-07-12T09:46:58.725645Z","gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-185-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:46:58.725645Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:47:06.863197Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:54:50.160667Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}],"id":"86efc927-4816-4b90-b1b0-b184079e15ed","ip":{"address":"51.158.65.159","created_at":"2023-10-20T14:54:49.962464Z","gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"159-65-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:54:49.962464Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:55:01.868988Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1873"
+      - "1964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:10 GMT
+      - Fri, 20 Oct 2023 14:55:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -853,7 +853,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d73f7005-b2e3-45fb-a076-091063ad4486
+      - afa982b1-8f0e-4635-97da-03472c377006
     status: 200 OK
     code: 200
     duration: ""
@@ -862,21 +862,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6dfcb4c0-93b6-42e8-89ab-4fca45bb6640
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/49ebf11f-e3d8-4a04-ab76-3e1d78bde62c
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:06.738183Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:10 GMT
+      - Fri, 20 Oct 2023 14:55:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -886,7 +886,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82b402b0-c124-4543-807d-5e81498fcd4e
+      - b00dbb8b-a4f5-424d-a598-8a7f15891d37
     status: 200 OK
     code: 200
     duration: ""
@@ -895,21 +895,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6dfcb4c0-93b6-42e8-89ab-4fca45bb6640
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/49ebf11f-e3d8-4a04-ab76-3e1d78bde62c
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:06.738183Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:10 GMT
+      - Fri, 20 Oct 2023 14:55:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -919,7 +919,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afd9ff8f-d5fd-4433-a9cb-c49535d85d9b
+      - 22286160-0e79-433c-95f1-88ced51b8115
     status: 200 OK
     code: 200
     duration: ""
@@ -928,21 +928,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/36396eae-68c3-4778-813d-88f8c1860f25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/86efc927-4816-4b90-b1b0-b184079e15ed
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:46:59.262468Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:06.738183Z","zone":"fr-par-1"}],"id":"36396eae-68c3-4778-813d-88f8c1860f25","ip":{"address":"163.172.185.229","created_at":"2023-07-12T09:46:58.725645Z","gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-185-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:46:58.725645Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:47:06.863197Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:54:50.160667Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}],"id":"86efc927-4816-4b90-b1b0-b184079e15ed","ip":{"address":"51.158.65.159","created_at":"2023-10-20T14:54:49.962464Z","gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"159-65-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:54:49.962464Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:55:01.868988Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1873"
+      - "1964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:10 GMT
+      - Fri, 20 Oct 2023 14:55:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -952,7 +952,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0650e19-37d4-4c44-bee8-6d7190988a00
+      - 0fb40e6e-b7dd-4c96-a1ce-a09a4a573843
     status: 200 OK
     code: 200
     duration: ""
@@ -961,21 +961,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6dfcb4c0-93b6-42e8-89ab-4fca45bb6640
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/49ebf11f-e3d8-4a04-ab76-3e1d78bde62c
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:06.738183Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:10 GMT
+      - Fri, 20 Oct 2023 14:55:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -985,7 +985,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe87297a-d687-4f2b-9dca-ead27e9eb41e
+      - 235ed7b8-5382-4d73-9464-baf257ec74d8
     status: 200 OK
     code: 200
     duration: ""
@@ -994,27 +994,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1801","node_id":"39","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:47:14.506781+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.148.77","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1902","node_id":"12","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:54:52.272439+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.154.23","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2803"
+      - "2789"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:15 GMT
+      - Fri, 20 Oct 2023 14:55:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1024,7 +1024,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 224b2f17-48a5-4a6b-afe1-649a5f02e870
+      - ae414c2c-98d0-4fe5-a382-5420d2db95f9
     status: 200 OK
     code: 200
     duration: ""
@@ -1033,60 +1033,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/a475898a-5097-40bb-8171-9f8d07d52d5c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:46:57.988609Z","id":"a475898a-5097-40bb-8171-9f8d07d52d5c","name":"pn_test_network","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","subnets":["192.168.1.0/24","fd46:78ab:30b8:fd6c::/64"],"tags":[],"updated_at":"2023-07-12T09:47:06.429751Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "349"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:47:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b266d36e-07e7-465c-92dc-821123a84419
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1801","node_id":"39","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:47:14.506781+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.148.77","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1902","node_id":"12","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:55:09.626445+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.154.23","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2803"
+      - "2820"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:15 GMT
+      - Fri, 20 Oct 2023 14:55:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,23 +1063,95 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edd2a387-33a8-4cc9-b44b-7d1e894a07ea
+      - aa161a7f-a750-4a89-b24f-a638a23443db
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c"}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/4acd338e-6465-4dc3-a997-5e31625a283c
+    method: GET
+  response:
+    body: '{"created_at":"2023-10-20T14:54:49.394486Z","id":"4acd338e-6465-4dc3-a997-5e31625a283c","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnets":["192.168.1.0/24","fd5f:519c:6d46:b485::/64"],"tags":[],"updated_at":"2023-10-20T14:55:01.186016Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "358"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:55:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6a606309-8554-42d9-a069-34df8ccb2e95
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1902","node_id":"12","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:55:09.626445+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.154.23","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2820"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:55:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 542150db-018b-42d7-b7c1-2cf429ffe8f7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:15.409426+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:14.592601+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1121,7 +1160,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:16 GMT
+      - Fri, 20 Oct 2023 14:55:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1131,7 +1170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 322e15b5-b7d8-4b8c-b133-16ce6ca47aad
+      - 23217241-01fc-4eec-a82e-a765eef6487d
     status: 201 Created
     code: 201
     duration: ""
@@ -1140,12 +1179,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005/private_nics/33f072e0-750f-4f67-871e-b3ba294f7cf0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics/2ec5400d-73fa-4bbd-8672-f73c95eafab8
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:15.409426+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:14.592601+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1154,7 +1193,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:16 GMT
+      - Fri, 20 Oct 2023 14:55:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1164,7 +1203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7df8359f-7462-4302-ae43-8a9c516340d5
+      - 0c348a74-451d-4b7d-bafd-8aefa2f8cca3
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,12 +1212,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005/private_nics/33f072e0-750f-4f67-871e-b3ba294f7cf0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics/2ec5400d-73fa-4bbd-8672-f73c95eafab8
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:16.341618+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:15.410989+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1187,7 +1226,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:21 GMT
+      - Fri, 20 Oct 2023 14:55:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1197,7 +1236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 310910cd-87b3-4227-aa94-d34aee7d313f
+      - 1f472468-b87f-42c9-803d-9178203d70ab
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,12 +1245,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005/private_nics/33f072e0-750f-4f67-871e-b3ba294f7cf0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics/2ec5400d-73fa-4bbd-8672-f73c95eafab8
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:16.341618+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:15.410989+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1220,7 +1259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:26 GMT
+      - Fri, 20 Oct 2023 14:55:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1230,7 +1269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1d0e1c3-427e-4f7a-af30-9f9944e490a1
+      - cb206e83-ac9b-45a9-81c4-bcb5d046c306
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,12 +1278,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005/private_nics/33f072e0-750f-4f67-871e-b3ba294f7cf0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics/2ec5400d-73fa-4bbd-8672-f73c95eafab8
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:16.341618+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:15.410989+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1253,7 +1292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:31 GMT
+      - Fri, 20 Oct 2023 14:55:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1263,7 +1302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ecf9bb01-16ed-415f-9c21-67f9e890cfd1
+      - d900ddae-c59c-4df3-80e3-1749c4f2689d
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,12 +1311,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005/private_nics/33f072e0-750f-4f67-871e-b3ba294f7cf0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics/2ec5400d-73fa-4bbd-8672-f73c95eafab8
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:16.341618+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:15.410989+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1286,7 +1325,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:36 GMT
+      - Fri, 20 Oct 2023 14:55:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1296,7 +1335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38d92651-3851-4798-b847-c399332df2e6
+      - aebd6713-2c42-4888-aaee-84577542461e
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,12 +1344,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005/private_nics/33f072e0-750f-4f67-871e-b3ba294f7cf0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics/2ec5400d-73fa-4bbd-8672-f73c95eafab8
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:16.341618+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:15.410989+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1319,7 +1358,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:41 GMT
+      - Fri, 20 Oct 2023 14:55:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1329,7 +1368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d22048c4-2fa2-422b-adb8-96db9e50fc7d
+      - 3ad4b1f8-6a36-41cd-917b-6dfc44e5b96a
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,12 +1377,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005/private_nics/33f072e0-750f-4f67-871e-b3ba294f7cf0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics/2ec5400d-73fa-4bbd-8672-f73c95eafab8
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:16.341618+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:15.410989+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1352,7 +1391,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:46 GMT
+      - Fri, 20 Oct 2023 14:55:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1362,7 +1401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aeb869ad-b90f-46ce-b962-9684cdd758c5
+      - a60d0db9-2d4c-4e09-9099-61dbe1b1572b
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,12 +1410,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005/private_nics/33f072e0-750f-4f67-871e-b3ba294f7cf0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics/2ec5400d-73fa-4bbd-8672-f73c95eafab8
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:45.815313+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1385,7 +1424,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:51 GMT
+      - Fri, 20 Oct 2023 14:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1395,7 +1434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15553a6b-8322-4f11-954f-d07404292b47
+      - ffbcc244-4a6f-41cd-a513-529097f083cc
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,12 +1443,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005/private_nics/33f072e0-750f-4f67-871e-b3ba294f7cf0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics/2ec5400d-73fa-4bbd-8672-f73c95eafab8
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:45.815313+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1418,7 +1457,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:51 GMT
+      - Fri, 20 Oct 2023 14:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1428,7 +1467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6170925-d157-45e0-bee3-13621dd5dd8f
+      - 563c403f-821b-4bc0-be06-235b6d49bab6
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,27 +1476,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1801","node_id":"39","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:47:14.506781+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.148.77","private_nics":[{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1902","node_id":"12","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:55:09.626445+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.154.23","private_nics":[{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:45.815313+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3156"
+      - "3173"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:52 GMT
+      - Fri, 20 Oct 2023 14:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1467,7 +1506,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a70374c4-e919-4ae7-b08f-0cd209f1e4a5
+      - 79060ecc-1887-4ea5-921e-d44a65835296
     status: 200 OK
     code: 200
     duration: ""
@@ -1476,9 +1515,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1490,7 +1529,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:52 GMT
+      - Fri, 20 Oct 2023 14:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1500,7 +1539,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbc88e24-5c5b-44a9-962c-8fbcca513c2e
+      - 77a166dd-95e3-41e3-bd2d-456ed57f2c9f
     status: 200 OK
     code: 200
     duration: ""
@@ -1509,12 +1548,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:45.815313+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -1523,9 +1562,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:52 GMT
+      - Fri, 20 Oct 2023 14:55:51 GMT
       Link:
-      - </servers/6696f912-abb5-4922-adc7-46441e3bc005/private_nics?page=1&per_page=50&>;
+      - </servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -1536,7 +1575,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39d36e59-71ef-4f8c-b3db-d3667a37c31e
+      - ec54ee89-fb8e-4605-ac57-9ba166c545ce
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -1547,21 +1586,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6dfcb4c0-93b6-42e8-89ab-4fca45bb6640
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/49ebf11f-e3d8-4a04-ab76-3e1d78bde62c
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:06.738183Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:52 GMT
+      - Fri, 20 Oct 2023 14:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1571,32 +1610,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b119e322-43be-4f17-a291-5c78b1351f0a
+      - 030a45cc-ec1f-4162-9e7d-0c841c9dec84
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_network_id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5d:c1","ip_address":"192.168.1.1"}'
+    body: '{"gateway_network_id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","mac_address":"02:00:00:14:58:21","ip_address":"192.168.1.1"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries
     method: POST
   response:
-    body: '{"created_at":"2023-07-12T09:47:52.318001Z","gateway_network_id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","hostname":"","id":"51124f8a-c7ab-4ae1-8f3b-a42946775830","ip_address":"192.168.1.1","mac_address":"02:00:00:13:5d:c1","type":"reservation","updated_at":"2023-07-12T09:47:52.318001Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T14:55:15.312988Z","gateway_network_id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","hostname":"tf-srv-competent-herschel","id":"9689c9d4-1a46-4877-b567-bbf4965806f9","ip_address":"192.168.1.1","mac_address":"02:00:00:14:58:21","type":"reservation","updated_at":"2023-10-20T14:55:51.736094Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "305"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:52 GMT
+      - Fri, 20 Oct 2023 14:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1606,7 +1645,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10886994-533a-43e7-bc00-5f9d8b483902
+      - 22e27cc5-2008-49d0-bdbf-a23a4ab8e98f
     status: 200 OK
     code: 200
     duration: ""
@@ -1615,21 +1654,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6dfcb4c0-93b6-42e8-89ab-4fca45bb6640
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/49ebf11f-e3d8-4a04-ab76-3e1d78bde62c
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:06.738183Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:52 GMT
+      - Fri, 20 Oct 2023 14:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1639,7 +1678,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 291355dc-78b8-4179-84e1-260ff6017131
+      - 11fe237c-980f-42b9-98b5-f010e272b2f5
     status: 200 OK
     code: 200
     duration: ""
@@ -1648,21 +1687,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/51124f8a-c7ab-4ae1-8f3b-a42946775830
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/9689c9d4-1a46-4877-b567-bbf4965806f9
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:47:52.318001Z","gateway_network_id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","hostname":"","id":"51124f8a-c7ab-4ae1-8f3b-a42946775830","ip_address":"192.168.1.1","mac_address":"02:00:00:13:5d:c1","type":"reservation","updated_at":"2023-07-12T09:47:52.318001Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T14:55:15.312988Z","gateway_network_id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","hostname":"tf-srv-competent-herschel","id":"9689c9d4-1a46-4877-b567-bbf4965806f9","ip_address":"192.168.1.1","mac_address":"02:00:00:14:58:21","type":"reservation","updated_at":"2023-10-20T14:55:51.736094Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "305"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:52 GMT
+      - Fri, 20 Oct 2023 14:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1672,7 +1711,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f818dac9-d6e0-4ce7-90fb-c0c22dfb9e4f
+      - c2762d91-79aa-4997-9aa8-2e7f0d721f9c
     status: 200 OK
     code: 200
     duration: ""
@@ -1681,21 +1720,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/51124f8a-c7ab-4ae1-8f3b-a42946775830
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/9689c9d4-1a46-4877-b567-bbf4965806f9
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:47:52.318001Z","gateway_network_id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","hostname":"","id":"51124f8a-c7ab-4ae1-8f3b-a42946775830","ip_address":"192.168.1.1","mac_address":"02:00:00:13:5d:c1","type":"reservation","updated_at":"2023-07-12T09:47:52.318001Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T14:55:15.312988Z","gateway_network_id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","hostname":"tf-srv-competent-herschel","id":"9689c9d4-1a46-4877-b567-bbf4965806f9","ip_address":"192.168.1.1","mac_address":"02:00:00:14:58:21","type":"reservation","updated_at":"2023-10-20T14:55:51.736094Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "305"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:52 GMT
+      - Fri, 20 Oct 2023 14:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1705,7 +1744,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 116a0c0a-b63a-474b-a8ad-e03077232252
+      - c0993bec-7d68-4a3f-9237-7c69ebbdaa90
     status: 200 OK
     code: 200
     duration: ""
@@ -1714,21 +1753,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/98cd880f-da4f-4c67-8857-32c89bf2bea1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/4a889438-daf1-417e-aee4-996c8b27ccfc
     method: GET
   response:
-    body: '{"address":"163.172.185.229","created_at":"2023-07-12T09:46:58.725645Z","gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-185-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:46:58.725645Z","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "396"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:53 GMT
+      - Fri, 20 Oct 2023 14:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1738,7 +1777,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fab69da1-932e-4b96-8a99-ae99a75d087a
+      - 0327b4b0-0f12-401f-a2f0-280832adf275
     status: 200 OK
     code: 200
     duration: ""
@@ -1747,21 +1786,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/872ade8e-2702-41b5-be01-0c10ef43401a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/f5a1fd31-4400-4fa1-8432-b312cfd012cd
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"51.158.65.159","created_at":"2023-10-20T14:54:49.962464Z","gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"159-65-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:54:49.962464Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "401"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:53 GMT
+      - Fri, 20 Oct 2023 14:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1771,7 +1810,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a818cd65-f084-4ebd-9166-2fba5d1cfbcb
+      - 7ba4a005-2b2a-4116-93e7-0b370fb5d534
     status: 200 OK
     code: 200
     duration: ""
@@ -1780,21 +1819,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a475898a-5097-40bb-8171-9f8d07d52d5c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4acd338e-6465-4dc3-a997-5e31625a283c
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:46:57.988609Z","dhcp_enabled":false,"id":"a475898a-5097-40bb-8171-9f8d07d52d5c","name":"pn_test_network","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-07-12T09:46:57.988609Z","id":"7f34c9c2-4702-4ca1-959c-74a236503303","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:47:04.697889Z"},{"created_at":"2023-07-12T09:46:57.988609Z","id":"025f7334-13c1-4b7c-b120-007e421ababf","subnet":"fd46:78ab:30b8:fd6c::/64","updated_at":"2023-07-12T09:47:04.697889Z"}],"tags":[],"updated_at":"2023-07-12T09:47:52.471063Z","vpc_id":"bd54d65a-dcb0-43f6-a1fe-efd3be01848e"}'
+    body: '{"created_at":"2023-10-20T14:54:49.394486Z","dhcp_enabled":true,"id":"4acd338e-6465-4dc3-a997-5e31625a283c","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T14:54:49.394486Z","id":"3c7b7e99-01e2-40cd-84b1-cf707f6d207c","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:55.775503Z"},{"created_at":"2023-10-20T14:54:49.394486Z","id":"2dc34e55-fd33-4619-bbb1-295b32ad4c9f","subnet":"fd5f:519c:6d46:b485::/64","updated_at":"2023-10-20T14:54:55.778634Z"}],"tags":[],"updated_at":"2023-10-20T14:55:01.186016Z","vpc_id":"058bb8f6-e3fb-4d05-b99c-fab950078e66"}'
     headers:
       Content-Length:
-      - "700"
+      - "716"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:53 GMT
+      - Fri, 20 Oct 2023 14:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1804,7 +1843,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2cc4c5db-4f0a-490c-8a0f-bbbfba038d61
+      - 08defaa5-019b-4b9a-bf72-7d69a5a93e54
     status: 200 OK
     code: 200
     duration: ""
@@ -1813,21 +1852,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/36396eae-68c3-4778-813d-88f8c1860f25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/86efc927-4816-4b90-b1b0-b184079e15ed
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:46:59.262468Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:52.606592Z","zone":"fr-par-1"}],"id":"36396eae-68c3-4778-813d-88f8c1860f25","ip":{"address":"163.172.185.229","created_at":"2023-07-12T09:46:58.725645Z","gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-185-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:46:58.725645Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:47:06.863197Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:54:50.160667Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}],"id":"86efc927-4816-4b90-b1b0-b184079e15ed","ip":{"address":"51.158.65.159","created_at":"2023-10-20T14:54:49.962464Z","gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"159-65-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:54:49.962464Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:55:01.868988Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1873"
+      - "1964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:53 GMT
+      - Fri, 20 Oct 2023 14:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1837,7 +1876,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4ab1594-4de9-4ab0-b893-f9126e2165b1
+      - 3893b6d7-7461-4067-ae14-b8a9e2613503
     status: 200 OK
     code: 200
     duration: ""
@@ -1846,27 +1885,60 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/49ebf11f-e3d8-4a04-ab76-3e1d78bde62c
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:55:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e90e43b8-3a38-4c7a-bb43-311d84ec1124
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1801","node_id":"39","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:47:14.506781+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.148.77","private_nics":[{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1902","node_id":"12","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:55:09.626445+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.154.23","private_nics":[{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:45.815313+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3156"
+      - "3173"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:53 GMT
+      - Fri, 20 Oct 2023 14:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1876,7 +1948,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15e3320b-053f-4635-9fb1-203250ce0c77
+      - 3ba281f9-88b3-4e9f-ba76-47762f40f93e
     status: 200 OK
     code: 200
     duration: ""
@@ -1885,21 +1957,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6dfcb4c0-93b6-42e8-89ab-4fca45bb6640
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/86efc927-4816-4b90-b1b0-b184079e15ed
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:52.606592Z","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:54:50.160667Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}],"id":"86efc927-4816-4b90-b1b0-b184079e15ed","ip":{"address":"51.158.65.159","created_at":"2023-10-20T14:54:49.962464Z","gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"159-65-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:54:49.962464Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:55:01.868988Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "1964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:53 GMT
+      - Fri, 20 Oct 2023 14:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1909,7 +1981,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c11646e0-463c-4c09-9a19-21cbbdc2616f
+      - 02b351f1-d7fe-4551-a458-01a3a506cb5b
     status: 200 OK
     code: 200
     duration: ""
@@ -1918,9 +1990,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1932,7 +2004,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:53 GMT
+      - Fri, 20 Oct 2023 14:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1942,7 +2014,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d073520-2f44-42e0-8209-b0f605ca4163
+      - 4c6af287-6811-4b8e-b0b6-4661207abed0
     status: 200 OK
     code: 200
     duration: ""
@@ -1951,21 +2023,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/36396eae-68c3-4778-813d-88f8c1860f25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/49ebf11f-e3d8-4a04-ab76-3e1d78bde62c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:46:59.262468Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:52.606592Z","zone":"fr-par-1"}],"id":"36396eae-68c3-4778-813d-88f8c1860f25","ip":{"address":"163.172.185.229","created_at":"2023-07-12T09:46:58.725645Z","gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-185-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:46:58.725645Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:47:06.863197Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1873"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:53 GMT
+      - Fri, 20 Oct 2023 14:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1975,7 +2047,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91f3b84c-df0a-4aa6-8534-58b20c962f2c
+      - c802b216-724e-452d-bdb2-d496298b3705
     status: 200 OK
     code: 200
     duration: ""
@@ -1984,12 +2056,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:45.815313+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -1998,9 +2070,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:53 GMT
+      - Fri, 20 Oct 2023 14:55:53 GMT
       Link:
-      - </servers/6696f912-abb5-4922-adc7-46441e3bc005/private_nics?page=1&per_page=50&>;
+      - </servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -2011,7 +2083,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fcd79101-8fc7-4a7e-a456-a88b0d1510a4
+      - d73f5560-6ed3-46e1-9899-f6c51d07398f
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -2022,21 +2094,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6dfcb4c0-93b6-42e8-89ab-4fca45bb6640
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/9689c9d4-1a46-4877-b567-bbf4965806f9
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:52.606592Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T14:55:15.312988Z","gateway_network_id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","hostname":"tf-srv-competent-herschel","id":"9689c9d4-1a46-4877-b567-bbf4965806f9","ip_address":"192.168.1.1","mac_address":"02:00:00:14:58:21","type":"reservation","updated_at":"2023-10-20T14:55:51.736094Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:53 GMT
+      - Fri, 20 Oct 2023 14:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2046,7 +2118,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4264cd4-0762-4393-a221-d209d19458dd
+      - e3acbcb6-fe35-44d0-ae3a-a92cc93ad568
     status: 200 OK
     code: 200
     duration: ""
@@ -2055,21 +2127,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/51124f8a-c7ab-4ae1-8f3b-a42946775830
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/f5a1fd31-4400-4fa1-8432-b312cfd012cd
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:47:52.318001Z","gateway_network_id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","hostname":"","id":"51124f8a-c7ab-4ae1-8f3b-a42946775830","ip_address":"192.168.1.1","mac_address":"02:00:00:13:5d:c1","type":"reservation","updated_at":"2023-07-12T09:47:52.318001Z","zone":"fr-par-1"}'
+    body: '{"address":"51.158.65.159","created_at":"2023-10-20T14:54:49.962464Z","gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"159-65-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:54:49.962464Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "305"
+      - "401"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:53 GMT
+      - Fri, 20 Oct 2023 14:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2079,7 +2151,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00131eec-e910-463f-83aa-e9304c1c800b
+      - 703269d3-afba-4335-a8eb-b5e5552721ba
     status: 200 OK
     code: 200
     duration: ""
@@ -2088,21 +2160,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/872ade8e-2702-41b5-be01-0c10ef43401a
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4acd338e-6465-4dc3-a997-5e31625a283c
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T14:54:49.394486Z","dhcp_enabled":true,"id":"4acd338e-6465-4dc3-a997-5e31625a283c","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T14:54:49.394486Z","id":"3c7b7e99-01e2-40cd-84b1-cf707f6d207c","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:55.775503Z"},{"created_at":"2023-10-20T14:54:49.394486Z","id":"2dc34e55-fd33-4619-bbb1-295b32ad4c9f","subnet":"fd5f:519c:6d46:b485::/64","updated_at":"2023-10-20T14:54:55.778634Z"}],"tags":[],"updated_at":"2023-10-20T14:55:01.186016Z","vpc_id":"058bb8f6-e3fb-4d05-b99c-fab950078e66"}'
     headers:
       Content-Length:
-      - "568"
+      - "716"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:53 GMT
+      - Fri, 20 Oct 2023 14:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2112,7 +2184,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1704b12-c36e-40b1-b64b-7dffa5bf32a4
+      - 1c59dc84-0fb9-4af0-b334-e7a9c872cda0
     status: 200 OK
     code: 200
     duration: ""
@@ -2121,21 +2193,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/98cd880f-da4f-4c67-8857-32c89bf2bea1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/4a889438-daf1-417e-aee4-996c8b27ccfc
     method: GET
   response:
-    body: '{"address":"163.172.185.229","created_at":"2023-07-12T09:46:58.725645Z","gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-185-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:46:58.725645Z","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "396"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:53 GMT
+      - Fri, 20 Oct 2023 14:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2145,7 +2217,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16e65760-5363-41ba-bcca-f50ad0501257
+      - 400e2097-1ef3-41b9-a16e-75c7f58a4ab4
     status: 200 OK
     code: 200
     duration: ""
@@ -2154,21 +2226,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a475898a-5097-40bb-8171-9f8d07d52d5c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/86efc927-4816-4b90-b1b0-b184079e15ed
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:46:57.988609Z","dhcp_enabled":false,"id":"a475898a-5097-40bb-8171-9f8d07d52d5c","name":"pn_test_network","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-07-12T09:46:57.988609Z","id":"7f34c9c2-4702-4ca1-959c-74a236503303","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:47:04.697889Z"},{"created_at":"2023-07-12T09:46:57.988609Z","id":"025f7334-13c1-4b7c-b120-007e421ababf","subnet":"fd46:78ab:30b8:fd6c::/64","updated_at":"2023-07-12T09:47:04.697889Z"}],"tags":[],"updated_at":"2023-07-12T09:47:52.471063Z","vpc_id":"bd54d65a-dcb0-43f6-a1fe-efd3be01848e"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:54:50.160667Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}],"id":"86efc927-4816-4b90-b1b0-b184079e15ed","ip":{"address":"51.158.65.159","created_at":"2023-10-20T14:54:49.962464Z","gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"159-65-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:54:49.962464Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:55:01.868988Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "700"
+      - "1964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:53 GMT
+      - Fri, 20 Oct 2023 14:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2178,7 +2250,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43aa0645-83f1-405f-bcb8-6f1884b252e5
+      - 75d37909-45bb-4d19-bcac-ca55a991bfc7
     status: 200 OK
     code: 200
     duration: ""
@@ -2187,21 +2259,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/36396eae-68c3-4778-813d-88f8c1860f25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/49ebf11f-e3d8-4a04-ab76-3e1d78bde62c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:46:59.262468Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:52.606592Z","zone":"fr-par-1"}],"id":"36396eae-68c3-4778-813d-88f8c1860f25","ip":{"address":"163.172.185.229","created_at":"2023-07-12T09:46:58.725645Z","gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-185-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:46:58.725645Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:47:06.863197Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1873"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:53 GMT
+      - Fri, 20 Oct 2023 14:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2211,7 +2283,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31d7be5a-1ea5-47a0-a7e8-65ead5660d13
+      - 97c41ddb-5a4b-4411-8466-64660b793d3b
     status: 200 OK
     code: 200
     duration: ""
@@ -2220,21 +2292,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6dfcb4c0-93b6-42e8-89ab-4fca45bb6640
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/86efc927-4816-4b90-b1b0-b184079e15ed
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:52.606592Z","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:54:50.160667Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}],"id":"86efc927-4816-4b90-b1b0-b184079e15ed","ip":{"address":"51.158.65.159","created_at":"2023-10-20T14:54:49.962464Z","gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"159-65-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:54:49.962464Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:55:01.868988Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "1964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:53 GMT
+      - Fri, 20 Oct 2023 14:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2244,7 +2316,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c573156d-21a2-496d-bb1d-5b21b40afff4
+      - 30e16414-d7ed-44aa-bd8b-73961776aac9
     status: 200 OK
     code: 200
     duration: ""
@@ -2253,60 +2325,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/36396eae-68c3-4778-813d-88f8c1860f25
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:46:59.262468Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:52.606592Z","zone":"fr-par-1"}],"id":"36396eae-68c3-4778-813d-88f8c1860f25","ip":{"address":"163.172.185.229","created_at":"2023-07-12T09:46:58.725645Z","gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-185-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:46:58.725645Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:47:06.863197Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1873"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:47:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 60ef4683-8734-4be0-a1c6-86af1246577d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1801","node_id":"39","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:47:14.506781+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.148.77","private_nics":[{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1902","node_id":"12","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:55:09.626445+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.154.23","private_nics":[{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:45.815313+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3156"
+      - "3173"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:54 GMT
+      - Fri, 20 Oct 2023 14:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2316,7 +2355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ffbd37a-be0f-4ff9-8f13-d5df196576bb
+      - 733306e1-d8cb-4fd8-86cf-6168156a5003
     status: 200 OK
     code: 200
     duration: ""
@@ -2325,21 +2364,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6dfcb4c0-93b6-42e8-89ab-4fca45bb6640
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/49ebf11f-e3d8-4a04-ab76-3e1d78bde62c
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:52.606592Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:54 GMT
+      - Fri, 20 Oct 2023 14:55:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2349,7 +2388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 275ae92b-98ef-4afc-bae2-012b13094742
+      - f5b2ce1a-f069-4bb8-a4ff-96f71d2f4ddc
     status: 200 OK
     code: 200
     duration: ""
@@ -2358,9 +2397,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2372,7 +2411,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:54 GMT
+      - Fri, 20 Oct 2023 14:55:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2382,7 +2421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3bab436e-3a5b-466e-a167-3206b53ca519
+      - 38c1ea0f-8a32-4847-a3ee-5f5a494357c9
     status: 200 OK
     code: 200
     duration: ""
@@ -2391,12 +2430,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:45.815313+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -2405,9 +2444,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:54 GMT
+      - Fri, 20 Oct 2023 14:55:54 GMT
       Link:
-      - </servers/6696f912-abb5-4922-adc7-46441e3bc005/private_nics?page=1&per_page=50&>;
+      - </servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -2418,7 +2457,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 970e308d-33dc-4a25-9964-eefe0ecd1c5d
+      - 4a13e5e8-adeb-44d8-973a-b61efb485345
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -2429,21 +2468,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/51124f8a-c7ab-4ae1-8f3b-a42946775830
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/9689c9d4-1a46-4877-b567-bbf4965806f9
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:47:52.318001Z","gateway_network_id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","hostname":"","id":"51124f8a-c7ab-4ae1-8f3b-a42946775830","ip_address":"192.168.1.1","mac_address":"02:00:00:13:5d:c1","type":"reservation","updated_at":"2023-07-12T09:47:52.318001Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T14:55:15.312988Z","gateway_network_id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","hostname":"tf-srv-competent-herschel","id":"9689c9d4-1a46-4877-b567-bbf4965806f9","ip_address":"192.168.1.1","mac_address":"02:00:00:14:58:21","type":"reservation","updated_at":"2023-10-20T14:55:51.736094Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "305"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:54 GMT
+      - Fri, 20 Oct 2023 14:55:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2453,7 +2492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52769b17-bcd3-4708-9874-e99839f27b65
+      - 6473f3fd-2e3a-4c71-8741-6c05267568b4
     status: 200 OK
     code: 200
     duration: ""
@@ -2462,21 +2501,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6dfcb4c0-93b6-42e8-89ab-4fca45bb6640
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/49ebf11f-e3d8-4a04-ab76-3e1d78bde62c
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:52.606592Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:54 GMT
+      - Fri, 20 Oct 2023 14:55:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2486,7 +2525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8931edf3-00d6-42c2-8ee3-2ef295450a26
+      - 15742ef0-5a4a-4ee5-b8bd-391b7847c7ec
     status: 200 OK
     code: 200
     duration: ""
@@ -2497,21 +2536,21 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/51124f8a-c7ab-4ae1-8f3b-a42946775830
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/9689c9d4-1a46-4877-b567-bbf4965806f9
     method: PATCH
   response:
-    body: '{"created_at":"2023-07-12T09:47:52.318001Z","gateway_network_id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","hostname":"","id":"51124f8a-c7ab-4ae1-8f3b-a42946775830","ip_address":"192.168.1.2","mac_address":"02:00:00:13:5d:c1","type":"reservation","updated_at":"2023-07-12T09:47:54.766039Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T14:55:15.312988Z","gateway_network_id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","hostname":"tf-srv-competent-herschel","id":"9689c9d4-1a46-4877-b567-bbf4965806f9","ip_address":"192.168.1.2","mac_address":"02:00:00:14:58:21","type":"reservation","updated_at":"2023-10-20T14:55:55.119017Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "305"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:54 GMT
+      - Fri, 20 Oct 2023 14:55:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2521,7 +2560,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4be78bf-b9e4-447a-b5e2-97d2103cf209
+      - 083b52dd-679a-45b3-9f36-67865019afab
     status: 200 OK
     code: 200
     duration: ""
@@ -2530,21 +2569,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6dfcb4c0-93b6-42e8-89ab-4fca45bb6640
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/49ebf11f-e3d8-4a04-ab76-3e1d78bde62c
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:52.606592Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:54 GMT
+      - Fri, 20 Oct 2023 14:55:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2554,7 +2593,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbdbf7ae-95cb-417b-b345-35add2d5ce4d
+      - e6e2c21f-714c-4f6b-9d1f-b2fd7a990f77
     status: 200 OK
     code: 200
     duration: ""
@@ -2563,21 +2602,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/51124f8a-c7ab-4ae1-8f3b-a42946775830
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/9689c9d4-1a46-4877-b567-bbf4965806f9
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:47:52.318001Z","gateway_network_id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","hostname":"","id":"51124f8a-c7ab-4ae1-8f3b-a42946775830","ip_address":"192.168.1.2","mac_address":"02:00:00:13:5d:c1","type":"reservation","updated_at":"2023-07-12T09:47:54.766039Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T14:55:15.312988Z","gateway_network_id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","hostname":"tf-srv-competent-herschel","id":"9689c9d4-1a46-4877-b567-bbf4965806f9","ip_address":"192.168.1.2","mac_address":"02:00:00:14:58:21","type":"reservation","updated_at":"2023-10-20T14:55:55.119017Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "305"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:54 GMT
+      - Fri, 20 Oct 2023 14:55:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2587,7 +2626,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a9cef5c-50cf-4ece-9d18-c20bb249cfaf
+      - c6bd1416-d6e0-4e19-af42-e980748aefbf
     status: 200 OK
     code: 200
     duration: ""
@@ -2596,21 +2635,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/51124f8a-c7ab-4ae1-8f3b-a42946775830
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/9689c9d4-1a46-4877-b567-bbf4965806f9
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:47:52.318001Z","gateway_network_id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","hostname":"","id":"51124f8a-c7ab-4ae1-8f3b-a42946775830","ip_address":"192.168.1.2","mac_address":"02:00:00:13:5d:c1","type":"reservation","updated_at":"2023-07-12T09:47:54.766039Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T14:55:15.312988Z","gateway_network_id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","hostname":"tf-srv-competent-herschel","id":"9689c9d4-1a46-4877-b567-bbf4965806f9","ip_address":"192.168.1.2","mac_address":"02:00:00:14:58:21","type":"reservation","updated_at":"2023-10-20T14:55:55.119017Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "305"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:55 GMT
+      - Fri, 20 Oct 2023 14:55:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2620,7 +2659,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db007d34-c026-4f0a-a5de-f87380034d5d
+      - 1f5f2b21-37a7-47ca-ba48-8d1cd135e2dd
     status: 200 OK
     code: 200
     duration: ""
@@ -2629,21 +2668,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/98cd880f-da4f-4c67-8857-32c89bf2bea1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/4a889438-daf1-417e-aee4-996c8b27ccfc
     method: GET
   response:
-    body: '{"address":"163.172.185.229","created_at":"2023-07-12T09:46:58.725645Z","gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-185-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:46:58.725645Z","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "396"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:55 GMT
+      - Fri, 20 Oct 2023 14:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2653,7 +2692,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50fcab9c-d4b3-49a5-b31f-ee487b6c3b0e
+      - b70eb20f-c4ea-4b12-bd67-57bb3d73ae14
     status: 200 OK
     code: 200
     duration: ""
@@ -2662,21 +2701,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/872ade8e-2702-41b5-be01-0c10ef43401a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/f5a1fd31-4400-4fa1-8432-b312cfd012cd
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"51.158.65.159","created_at":"2023-10-20T14:54:49.962464Z","gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"159-65-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:54:49.962464Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "401"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:55 GMT
+      - Fri, 20 Oct 2023 14:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2686,7 +2725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ff0977f-2220-4e03-ac98-ba0013744f66
+      - 1454caeb-85f4-4b6b-907e-64f5c61777a0
     status: 200 OK
     code: 200
     duration: ""
@@ -2695,21 +2734,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a475898a-5097-40bb-8171-9f8d07d52d5c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4acd338e-6465-4dc3-a997-5e31625a283c
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:46:57.988609Z","dhcp_enabled":false,"id":"a475898a-5097-40bb-8171-9f8d07d52d5c","name":"pn_test_network","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-07-12T09:46:57.988609Z","id":"7f34c9c2-4702-4ca1-959c-74a236503303","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:47:04.697889Z"},{"created_at":"2023-07-12T09:46:57.988609Z","id":"025f7334-13c1-4b7c-b120-007e421ababf","subnet":"fd46:78ab:30b8:fd6c::/64","updated_at":"2023-07-12T09:47:04.697889Z"}],"tags":[],"updated_at":"2023-07-12T09:47:54.886746Z","vpc_id":"bd54d65a-dcb0-43f6-a1fe-efd3be01848e"}'
+    body: '{"created_at":"2023-10-20T14:54:49.394486Z","dhcp_enabled":true,"id":"4acd338e-6465-4dc3-a997-5e31625a283c","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T14:54:49.394486Z","id":"3c7b7e99-01e2-40cd-84b1-cf707f6d207c","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:55.775503Z"},{"created_at":"2023-10-20T14:54:49.394486Z","id":"2dc34e55-fd33-4619-bbb1-295b32ad4c9f","subnet":"fd5f:519c:6d46:b485::/64","updated_at":"2023-10-20T14:54:55.778634Z"}],"tags":[],"updated_at":"2023-10-20T14:55:01.186016Z","vpc_id":"058bb8f6-e3fb-4d05-b99c-fab950078e66"}'
     headers:
       Content-Length:
-      - "700"
+      - "716"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:55 GMT
+      - Fri, 20 Oct 2023 14:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2719,7 +2758,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7510705-16c9-4671-8111-6e28b229f920
+      - ecd28eaa-90d1-4cb3-9425-dd10c41d9445
     status: 200 OK
     code: 200
     duration: ""
@@ -2728,21 +2767,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/36396eae-68c3-4778-813d-88f8c1860f25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/86efc927-4816-4b90-b1b0-b184079e15ed
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:46:59.262468Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:54.957669Z","zone":"fr-par-1"}],"id":"36396eae-68c3-4778-813d-88f8c1860f25","ip":{"address":"163.172.185.229","created_at":"2023-07-12T09:46:58.725645Z","gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-185-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:46:58.725645Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:47:06.863197Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:54:50.160667Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}],"id":"86efc927-4816-4b90-b1b0-b184079e15ed","ip":{"address":"51.158.65.159","created_at":"2023-10-20T14:54:49.962464Z","gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"159-65-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:54:49.962464Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:55:01.868988Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1873"
+      - "1964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:55 GMT
+      - Fri, 20 Oct 2023 14:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2752,7 +2791,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62ce0ef2-a44b-4e1c-bdfb-ab809e5bde1d
+      - 4e35ac0a-811c-407d-9fcc-012c0a89bb8c
     status: 200 OK
     code: 200
     duration: ""
@@ -2761,21 +2800,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6dfcb4c0-93b6-42e8-89ab-4fca45bb6640
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/49ebf11f-e3d8-4a04-ab76-3e1d78bde62c
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:54.957669Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:55 GMT
+      - Fri, 20 Oct 2023 14:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2785,7 +2824,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06f75e55-95ae-421b-9c40-0bf3274cd2f5
+      - b0d677d5-e3c5-4eec-b1ca-3b695dc6a44e
     status: 200 OK
     code: 200
     duration: ""
@@ -2794,27 +2833,60 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/86efc927-4816-4b90-b1b0-b184079e15ed
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:54:50.160667Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}],"id":"86efc927-4816-4b90-b1b0-b184079e15ed","ip":{"address":"51.158.65.159","created_at":"2023-10-20T14:54:49.962464Z","gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"159-65-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:54:49.962464Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:55:01.868988Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1964"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:55:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1646fc99-e231-474e-b60c-6c6a5dd1ce3f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1801","node_id":"39","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:47:14.506781+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.148.77","private_nics":[{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1902","node_id":"12","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:55:09.626445+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.154.23","private_nics":[{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:45.815313+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3156"
+      - "3173"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:55 GMT
+      - Fri, 20 Oct 2023 14:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2824,7 +2896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac7f3e9a-ac90-4995-a10d-321d7b1a749c
+      - 60612a3f-0c12-4140-a9e5-07bffcbd3792
     status: 200 OK
     code: 200
     duration: ""
@@ -2833,21 +2905,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/36396eae-68c3-4778-813d-88f8c1860f25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/49ebf11f-e3d8-4a04-ab76-3e1d78bde62c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:46:59.262468Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:54.957669Z","zone":"fr-par-1"}],"id":"36396eae-68c3-4778-813d-88f8c1860f25","ip":{"address":"163.172.185.229","created_at":"2023-07-12T09:46:58.725645Z","gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-185-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:46:58.725645Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:47:06.863197Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1873"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:55 GMT
+      - Fri, 20 Oct 2023 14:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2857,7 +2929,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b947ecc7-a801-4332-8333-338e2db7ee78
+      - c7a0526b-949b-43c5-8b52-9649ef9d6305
     status: 200 OK
     code: 200
     duration: ""
@@ -2866,9 +2938,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2880,7 +2952,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:55 GMT
+      - Fri, 20 Oct 2023 14:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2890,7 +2962,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0262542-c7cf-45f8-b0a1-c45d1fc88d73
+      - d2d0901c-82d3-4baf-8c06-0d5bc6e30224
     status: 200 OK
     code: 200
     duration: ""
@@ -2899,12 +2971,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:45.815313+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -2913,9 +2985,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:55 GMT
+      - Fri, 20 Oct 2023 14:55:59 GMT
       Link:
-      - </servers/6696f912-abb5-4922-adc7-46441e3bc005/private_nics?page=1&per_page=50&>;
+      - </servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -2926,7 +2998,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e79e4d6-3c99-4405-99be-dbe928754c92
+      - 2b51c815-aafd-4472-a7eb-cb972bc58627
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -2937,21 +3009,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6dfcb4c0-93b6-42e8-89ab-4fca45bb6640
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/9689c9d4-1a46-4877-b567-bbf4965806f9
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:54.957669Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T14:55:15.312988Z","gateway_network_id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","hostname":"tf-srv-competent-herschel","id":"9689c9d4-1a46-4877-b567-bbf4965806f9","ip_address":"192.168.1.2","mac_address":"02:00:00:14:58:21","type":"reservation","updated_at":"2023-10-20T14:55:55.119017Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:55 GMT
+      - Fri, 20 Oct 2023 14:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2961,7 +3033,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 542ef8a7-f4f0-4f69-a33a-90b6054d0800
+      - 1cdc01e9-6179-4700-8076-79712ab1de3f
     status: 200 OK
     code: 200
     duration: ""
@@ -2970,21 +3042,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/51124f8a-c7ab-4ae1-8f3b-a42946775830
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/49ebf11f-e3d8-4a04-ab76-3e1d78bde62c
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:47:52.318001Z","gateway_network_id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","hostname":"","id":"51124f8a-c7ab-4ae1-8f3b-a42946775830","ip_address":"192.168.1.2","mac_address":"02:00:00:13:5d:c1","type":"reservation","updated_at":"2023-07-12T09:47:54.766039Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "305"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:55 GMT
+      - Fri, 20 Oct 2023 14:56:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2994,7 +3066,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d0a6445-a8dc-40cf-b921-7943377ea0b3
+      - 4e80062c-e4ba-4d25-ad66-a18cf2a1aaa3
     status: 200 OK
     code: 200
     duration: ""
@@ -3003,42 +3075,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6dfcb4c0-93b6-42e8-89ab-4fca45bb6640
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:54.957669Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "947"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:47:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8659f154-a117-403a-a6c9-7c1998e861d9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/51124f8a-c7ab-4ae1-8f3b-a42946775830
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/9689c9d4-1a46-4877-b567-bbf4965806f9
     method: DELETE
   response:
     body: ""
@@ -3048,7 +3087,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:56 GMT
+      - Fri, 20 Oct 2023 14:56:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3058,7 +3097,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1bfe09a4-ef2f-4f66-95a3-53ea46e71ed5
+      - 146f4b6a-a483-479d-aff0-f5c441afa4a8
     status: 204 No Content
     code: 204
     duration: ""
@@ -3067,21 +3106,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6dfcb4c0-93b6-42e8-89ab-4fca45bb6640
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/49ebf11f-e3d8-4a04-ab76-3e1d78bde62c
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:54.957669Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:56 GMT
+      - Fri, 20 Oct 2023 14:56:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3091,7 +3130,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 032b5d14-3897-4dc5-9146-8e165bc5bb61
+      - 61443688-0de0-4b20-9d43-73aaec152baf
     status: 200 OK
     code: 200
     duration: ""
@@ -3100,21 +3139,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6dfcb4c0-93b6-42e8-89ab-4fca45bb6640
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/49ebf11f-e3d8-4a04-ab76-3e1d78bde62c
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"ready","updated_at":"2023-07-12T09:47:56.767573Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"ready","updated_at":"2023-10-20T14:55:01.760066Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:56 GMT
+      - Fri, 20 Oct 2023 14:56:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3124,7 +3163,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac09088c-5ce2-4708-9a8e-7f22a2c03315
+      - 5ef00b43-5be8-4619-8469-15c3c5f2ddd8
     status: 200 OK
     code: 200
     duration: ""
@@ -3133,27 +3172,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1801","node_id":"39","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:47:14.506781+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.148.77","private_nics":[{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1902","node_id":"12","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:55:09.626445+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.154.23","private_nics":[{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:45.815313+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3156"
+      - "3173"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:56 GMT
+      - Fri, 20 Oct 2023 14:56:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3163,7 +3202,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 997a6d01-d314-4b9c-8104-b8391ee963d3
+      - 874d46af-f215-4978-8be0-aa1d3958c5e9
     status: 200 OK
     code: 200
     duration: ""
@@ -3172,9 +3211,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6dfcb4c0-93b6-42e8-89ab-4fca45bb6640?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/49ebf11f-e3d8-4a04-ab76-3e1d78bde62c?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -3184,7 +3223,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:56 GMT
+      - Fri, 20 Oct 2023 14:56:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3194,7 +3233,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d71b0afc-5583-4bd8-a067-7dc18fe4d739
+      - 249fec75-6128-4af4-ab6d-fdcf713528ad
     status: 204 No Content
     code: 204
     duration: ""
@@ -3203,21 +3242,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6dfcb4c0-93b6-42e8-89ab-4fca45bb6640
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/49ebf11f-e3d8-4a04-ab76-3e1d78bde62c
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:47:04.900086Z","dhcp":{"address":"192.168.1.1","created_at":"2023-07-12T09:46:57.945643Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"872ade8e-2702-41b5-be01-0c10ef43401a","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-07-12T09:46:57.945643Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","mac_address":"02:00:00:13:5D:C0","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","status":"detaching","updated_at":"2023-07-12T09:47:56.900877Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:54:58.970489Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T14:54:49.409070Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4a889438-daf1-417e-aee4-996c8b27ccfc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T14:54:49.409070Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","ipam_config":null,"mac_address":"02:00:00:14:58:1F","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","status":"detaching","updated_at":"2023-10-20T14:56:00.780173Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "951"
+      - "1000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:57 GMT
+      - Fri, 20 Oct 2023 14:56:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3227,7 +3266,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90b252a2-e20a-4296-9e73-535a5d02086e
+      - 8cb2a49a-9484-42d0-be13-a5548a09b82a
     status: 200 OK
     code: 200
     duration: ""
@@ -3238,12 +3277,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/6696f912-abb5-4922-adc7-46441e3bc005/action","href_result":"/servers/6696f912-abb5-4922-adc7-46441e3bc005","id":"0b416387-1869-4d7a-8baa-ff2b6198dd1b","started_at":"2023-07-12T09:47:57.218190+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/action","href_result":"/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","id":"ca93efe0-c3bc-4c6d-bdb1-dd7cb4bde85c","started_at":"2023-10-20T14:56:01.398710+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -3252,9 +3291,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:57 GMT
+      - Fri, 20 Oct 2023 14:56:01 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/0b416387-1869-4d7a-8baa-ff2b6198dd1b
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/ca93efe0-c3bc-4c6d-bdb1-dd7cb4bde85c
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3264,7 +3303,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a38e2196-e610-497c-a7a7-ed1af8fbf21f
+      - 9ca75df6-4ed1-45f3-9e60-d995ae44ae38
     status: 202 Accepted
     code: 202
     duration: ""
@@ -3273,27 +3312,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1801","node_id":"39","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:47:56.879253+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.148.77","private_nics":[{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1902","node_id":"12","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:56:00.838902+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.154.23","private_nics":[{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:45.815313+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3124"
+      - "3141"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:47:57 GMT
+      - Fri, 20 Oct 2023 14:56:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3303,7 +3342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b112a8aa-104f-4dde-8093-c174046d0c86
+      - 7efcc704-dbdc-4956-b963-b1f8d1de8925
     status: 200 OK
     code: 200
     duration: ""
@@ -3312,12 +3351,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6dfcb4c0-93b6-42e8-89ab-4fca45bb6640
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/49ebf11f-e3d8-4a04-ab76-3e1d78bde62c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"6dfcb4c0-93b6-42e8-89ab-4fca45bb6640","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"49ebf11f-e3d8-4a04-ab76-3e1d78bde62c","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3326,7 +3365,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:48:02 GMT
+      - Fri, 20 Oct 2023 14:56:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3336,7 +3375,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31e3565d-cb86-4718-9f57-90d3f1afac72
+      - 0f072dfe-1984-4052-b884-c199da5de262
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3345,21 +3384,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/36396eae-68c3-4778-813d-88f8c1860f25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/86efc927-4816-4b90-b1b0-b184079e15ed
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:46:59.262468Z","gateway_networks":[],"id":"36396eae-68c3-4778-813d-88f8c1860f25","ip":{"address":"163.172.185.229","created_at":"2023-07-12T09:46:58.725645Z","gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-185-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:46:58.725645Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:47:06.863197Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:54:50.160667Z","gateway_networks":[],"id":"86efc927-4816-4b90-b1b0-b184079e15ed","ip":{"address":"51.158.65.159","created_at":"2023-10-20T14:54:49.962464Z","gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"159-65-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:54:49.962464Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:55:01.868988Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "926"
+      - "968"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:48:02 GMT
+      - Fri, 20 Oct 2023 14:56:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3369,7 +3408,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e26d1a95-6565-47f2-8eb7-3e0a03d9ee46
+      - babd5d56-f586-4165-b2a2-7b566c022a86
     status: 200 OK
     code: 200
     duration: ""
@@ -3378,12 +3417,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/872ade8e-2702-41b5-be01-0c10ef43401a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/4a889438-daf1-417e-aee4-996c8b27ccfc
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"872ade8e-2702-41b5-be01-0c10ef43401a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"4a889438-daf1-417e-aee4-996c8b27ccfc","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3392,7 +3431,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:48:02 GMT
+      - Fri, 20 Oct 2023 14:56:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3402,7 +3441,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - decd23d6-4ca2-443a-b84f-758408249961
+      - c6770cde-f58c-4f5a-8fac-1f06b4f703be
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3411,21 +3450,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/36396eae-68c3-4778-813d-88f8c1860f25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/86efc927-4816-4b90-b1b0-b184079e15ed
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:46:59.262468Z","gateway_networks":[],"id":"36396eae-68c3-4778-813d-88f8c1860f25","ip":{"address":"163.172.185.229","created_at":"2023-07-12T09:46:58.725645Z","gateway_id":"36396eae-68c3-4778-813d-88f8c1860f25","id":"98cd880f-da4f-4c67-8857-32c89bf2bea1","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-185-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:46:58.725645Z","zone":"fr-par-1"},"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:47:06.863197Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:54:50.160667Z","gateway_networks":[],"id":"86efc927-4816-4b90-b1b0-b184079e15ed","ip":{"address":"51.158.65.159","created_at":"2023-10-20T14:54:49.962464Z","gateway_id":"86efc927-4816-4b90-b1b0-b184079e15ed","id":"f5a1fd31-4400-4fa1-8432-b312cfd012cd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"159-65-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:54:49.962464Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:55:01.868988Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "926"
+      - "968"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:48:02 GMT
+      - Fri, 20 Oct 2023 14:56:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3435,7 +3474,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f23bb210-2a94-4453-bcfb-ee658e6f2400
+      - 23965f72-40ec-444b-96ea-4de7a7fdb912
     status: 200 OK
     code: 200
     duration: ""
@@ -3444,9 +3483,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/36396eae-68c3-4778-813d-88f8c1860f25?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/86efc927-4816-4b90-b1b0-b184079e15ed?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -3456,7 +3495,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:48:02 GMT
+      - Fri, 20 Oct 2023 14:56:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3466,7 +3505,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5cda5955-31c0-492e-b612-18a4f9b3188f
+      - 9c792467-8d88-44cd-835c-ea91e12e31cf
     status: 204 No Content
     code: 204
     duration: ""
@@ -3475,12 +3514,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/36396eae-68c3-4778-813d-88f8c1860f25
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/86efc927-4816-4b90-b1b0-b184079e15ed
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"36396eae-68c3-4778-813d-88f8c1860f25","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"86efc927-4816-4b90-b1b0-b184079e15ed","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3489,7 +3528,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:48:02 GMT
+      - Fri, 20 Oct 2023 14:56:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3499,7 +3538,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f5372d8-8a02-472b-8617-fecb43b3e03f
+      - 9a0e8b69-8021-4a8b-841e-867e08cd5d52
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3508,9 +3547,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/98cd880f-da4f-4c67-8857-32c89bf2bea1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/f5a1fd31-4400-4fa1-8432-b312cfd012cd
     method: DELETE
   response:
     body: ""
@@ -3520,7 +3559,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:48:02 GMT
+      - Fri, 20 Oct 2023 14:56:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3530,7 +3569,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c8939ad-34e6-41ce-addc-d247efe905b0
+      - 9a7b6340-9882-429e-9cf4-32937ca04801
     status: 204 No Content
     code: 204
     duration: ""
@@ -3539,27 +3578,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1801","node_id":"39","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:47:56.879253+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.148.77","private_nics":[{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1902","node_id":"12","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:56:00.838902+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.154.23","private_nics":[{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:45.815313+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3124"
+      - "3141"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:48:02 GMT
+      - Fri, 20 Oct 2023 14:56:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3569,7 +3608,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0827e3fe-e955-4c5d-8bc8-0092b3dbfa28
+      - dc2f096c-7979-4c7a-9b5b-ab59e2493dbb
     status: 200 OK
     code: 200
     duration: ""
@@ -3578,27 +3617,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1801","node_id":"39","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:47:56.879253+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.148.77","private_nics":[{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1902","node_id":"12","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:56:00.838902+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.154.23","private_nics":[{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:45.815313+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3124"
+      - "3141"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:48:07 GMT
+      - Fri, 20 Oct 2023 14:56:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3608,7 +3647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8344907-f400-44bc-a537-1d0fbaadb326
+      - da3587f5-379c-4417-adc2-ec7ec3d7543b
     status: 200 OK
     code: 200
     duration: ""
@@ -3617,27 +3656,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1801","node_id":"39","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:47:56.879253+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.148.77","private_nics":[{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1902","node_id":"12","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:56:00.838902+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.154.23","private_nics":[{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:45.815313+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3124"
+      - "3141"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:48:13 GMT
+      - Fri, 20 Oct 2023 14:56:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3647,7 +3686,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7da06856-3f60-4c3e-9427-5021f77ff998
+      - c5546201-54a0-46fc-99c0-0810a7aa2b63
     status: 200 OK
     code: 200
     duration: ""
@@ -3656,27 +3695,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1801","node_id":"39","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:47:56.879253+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.148.77","private_nics":[{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1902","node_id":"12","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:56:00.838902+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.154.23","private_nics":[{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:45.815313+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3124"
+      - "3141"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:48:18 GMT
+      - Fri, 20 Oct 2023 14:56:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3686,7 +3725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7a61b39-d241-4758-b478-2c538bdb0c10
+      - 75a06122-7a72-4b9f-a198-c275f49ceeb6
     status: 200 OK
     code: 200
     duration: ""
@@ -3695,27 +3734,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1801","node_id":"39","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:47:56.879253+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.148.77","private_nics":[{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1902","node_id":"12","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:56:00.838902+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.154.23","private_nics":[{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:45.815313+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3124"
+      - "3141"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:48:23 GMT
+      - Fri, 20 Oct 2023 14:56:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3725,7 +3764,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0879046d-f0bf-450c-a1ee-8c24d5733b45
+      - fe5f2c19-2c05-467a-a7f7-a10475d10421
     status: 200 OK
     code: 200
     duration: ""
@@ -3734,27 +3773,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1801","node_id":"39","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:47:56.879253+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.148.77","private_nics":[{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1902","node_id":"12","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:56:00.838902+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.154.23","private_nics":[{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:45.815313+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3124"
+      - "3141"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:48:28 GMT
+      - Fri, 20 Oct 2023 14:56:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3764,7 +3803,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80b4fa1d-6985-45e3-a2ef-2c45ae853fb3
+      - be65138f-6cef-4d27-a498-4814ffd7d428
     status: 200 OK
     code: 200
     duration: ""
@@ -3773,27 +3812,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1801","node_id":"39","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:47:56.879253+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.148.77","private_nics":[{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:56:34.170552+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:45.815313+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3124"
+      - "3018"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:48:33 GMT
+      - Fri, 20 Oct 2023 14:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3803,7 +3842,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e8e1de1-8bc8-4a8a-ab20-2f5da22641ff
+      - 28746826-f6db-4529-8e27-dd6c3de9e6e0
     status: 200 OK
     code: 200
     duration: ""
@@ -3812,27 +3851,24 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1801","node_id":"39","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:47:56.879253+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.148.77","private_nics":[{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:45.815313+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
-      - "3124"
+      - "381"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:48:38 GMT
+      - Fri, 20 Oct 2023 14:56:38 GMT
+      Link:
+      - </servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics?page=1&per_page=50&>;
+        rel="last"
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3842,7 +3878,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eed675d6-bcc0-4106-8255-47de3a6e3245
+      - 9f05e100-01ce-4282-a0e1-732fd8fccd73
+      X-Total-Count:
+      - "1"
     status: 200 OK
     code: 200
     duration: ""
@@ -3851,27 +3889,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics/2ec5400d-73fa-4bbd-8672-f73c95eafab8
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1801","node_id":"39","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:47:56.879253+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.148.77","private_nics":[{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:55:14.592601+00:00","id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","mac_address":"02:00:00:14:58:21","modification_date":"2023-10-20T14:55:45.815313+00:00","private_network_id":"4acd338e-6465-4dc3-a997-5e31625a283c","server_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3124"
+      - "378"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:48:44 GMT
+      - Fri, 20 Oct 2023 14:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3881,7 +3913,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fdeeebd7-6750-4091-b221-82ffc978c18f
+      - b073ea8c-8d2d-4872-afd2-726c044459c8
     status: 200 OK
     code: 200
     duration: ""
@@ -3890,87 +3922,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:48:49.060765+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3001"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:48:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c742c05f-46d4-460b-97ce-b045d25f838a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:46:58.580506+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-mahavira","id":"6696f912-abb5-4922-adc7-46441e3bc005","image":{"arch":"x86_64","creation_date":"2023-06-28T12:44:51.423515+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"aef2a64e-d6d8-4b39-b00d-61ce2ddce2c8","modification_date":"2023-06-28T12:44:51.423515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"3cd60412-e478-4f16-ad7c-8290c6e1e8c8","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:3d","maintenances":[],"modification_date":"2023-07-12T09:48:49.060765+00:00","name":"tf-srv-mystifying-mahavira","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-07-12T09:47:15.409426+00:00","id":"33f072e0-750f-4f67-871e-b3ba294f7cf0","mac_address":"02:00:00:13:5d:c1","modification_date":"2023-07-12T09:47:46.855956+00:00","private_network_id":"a475898a-5097-40bb-8171-9f8d07d52d5c","server_id":"6696f912-abb5-4922-adc7-46441e3bc005","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:46:58.580506+00:00","export_uri":null,"id":"68ff1498-7be0-451c-9906-636a26a6c936","modification_date":"2023-07-12T09:46:58.580506+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6696f912-abb5-4922-adc7-46441e3bc005","name":"tf-srv-mystifying-mahavira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3001"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:48:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 20e644a9-af96-4e7d-91cf-645403c16756
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics/2ec5400d-73fa-4bbd-8672-f73c95eafab8
     method: DELETE
   response:
     body: ""
@@ -3978,7 +3932,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Wed, 12 Jul 2023 09:48:50 GMT
+      - Fri, 20 Oct 2023 14:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3988,7 +3942,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 180ad1e4-74c9-4900-b4d1-2fc9b752d80b
+      - f002cf67-5ae0-4a3e-9c50-4ae9984047bf
     status: 204 No Content
     code: 204
     duration: ""
@@ -3997,21 +3951,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6696f912-abb5-4922-adc7-46441e3bc005
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23/private_nics/2ec5400d-73fa-4bbd-8672-f73c95eafab8
     method: GET
   response:
-    body: '{"message":"\"6696f912-abb5-4922-adc7-46441e3bc005\" not found","type":"unknown_resource"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"2ec5400d-73fa-4bbd-8672-f73c95eafab8","type":"not_found"}'
     headers:
       Content-Length:
-      - "93"
+      - "148"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:48:50 GMT
+      - Fri, 20 Oct 2023 14:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4021,7 +3975,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 809ddf9f-9cef-4c7c-bc43-98bc2383c33d
+      - 21d13c86-4620-4bb6-b0c4-e7ef77ac19ac
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4030,17 +3984,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/68ff1498-7be0-451c-9906-636a26a6c936
-    method: DELETE
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
+    method: GET
   response:
-    body: ""
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:54:51.156669+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-competent-herschel","id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b3:83","maintenances":[],"modification_date":"2023-10-20T14:56:34.170552+00:00","name":"tf-srv-competent-herschel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:54:51.156669+00:00","export_uri":null,"id":"b1e88085-dd63-4615-bd5e-e0290130a466","modification_date":"2023-10-20T14:54:51.156669+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","name":"tf-srv-competent-herschel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
+      Content-Length:
+      - "2657"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
       Date:
-      - Wed, 12 Jul 2023 09:48:50 GMT
+      - Fri, 20 Oct 2023 14:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4050,7 +4014,36 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 965901a4-a6cc-451e-a724-dbf49e92ccc1
+      - c881b20c-ccb4-4b0a-9992-49f89fd26836
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Fri, 20 Oct 2023 14:56:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 04e67d05-d6ee-406f-a203-f07cfb47c61d
     status: 204 No Content
     code: 204
     duration: ""
@@ -4059,9 +4052,71 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a475898a-5097-40bb-8171-9f8d07d52d5c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"1b4cdcb9-fe4e-4132-aa04-39b4a93a4d23","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:56:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4f80cd1b-0626-4bce-a033-303056b565a3
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b1e88085-dd63-4615-bd5e-e0290130a466
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Fri, 20 Oct 2023 14:56:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2ff25fe3-3d02-4ee4-80a6-005004776fba
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4acd338e-6465-4dc3-a997-5e31625a283c
     method: DELETE
   response:
     body: ""
@@ -4071,7 +4126,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:48:50 GMT
+      - Fri, 20 Oct 2023 14:56:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4081,7 +4136,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d26b5d9c-088e-4ee8-9922-f06e1258fd1e
+      - e2b1be0a-f260-48d6-8a61-7f2a5c968af9
     status: 204 No Content
     code: 204
     duration: ""
@@ -4090,12 +4145,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/51124f8a-c7ab-4ae1-8f3b-a42946775830
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/9689c9d4-1a46-4877-b567-bbf4965806f9
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"dhcp_entry","resource_id":"51124f8a-c7ab-4ae1-8f3b-a42946775830","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp_entry","resource_id":"9689c9d4-1a46-4877-b567-bbf4965806f9","type":"not_found"}'
     headers:
       Content-Length:
       - "131"
@@ -4104,7 +4159,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:48:50 GMT
+      - Fri, 20 Oct 2023 14:56:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4114,7 +4169,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d265ac3-c6f3-483c-a860-284ee413f7d1
+      - f275d451-a59f-4364-8143-417050f9f686
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/vpc-public-gateway-pat-rule-with-instance.cassette.yaml
+++ b/scaleway/testdata/vpc-public-gateway-pat-rule-with-instance.cassette.yaml
@@ -2,27 +2,27 @@
 version: 1
 interactions:
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","subnet":"10.0.0.0/24","address":null,"pool_low":null,"pool_high":null,"enable_dynamic":null,"valid_lifetime":null,"renew_timer":null,"rebind_timer":null,"push_default_route":null,"push_dns_server":null,"dns_servers_override":null,"dns_search":null,"dns_local_name":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"10.0.0.0/24","address":null,"pool_low":null,"pool_high":null,"enable_dynamic":null,"valid_lifetime":null,"renew_timer":null,"rebind_timer":null,"push_default_route":null,"push_dns_server":null,"dns_servers_override":null,"dns_search":null,"dns_local_name":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
     method: POST
   response:
-    body: '{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "556"
+      - "574"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:28 GMT
+      - Fri, 20 Oct 2023 14:18:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37b4e1d7-32ca-42b6-8d56-7f44deb493a0
+      - 1a28597e-d2c4-442a-b262-704938f95365
     status: 200 OK
     code: 200
     duration: ""
@@ -41,21 +41,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/eefd7a68-9adb-4b1f-bd37-6320aaab5cb8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/32426185-49c2-4047-a113-32594639fbf2
     method: GET
   response:
-    body: '{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "556"
+      - "574"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:28 GMT
+      - Fri, 20 Oct 2023 14:18:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,33 +65,172 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17bad09b-dc86-4ba4-a761-37d4970f449a
+      - 2383a875-6929-446e-b047-d84b7cfc389f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"My Private Network","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
+    method: POST
+  response:
+    body: '{"address":"51.15.245.191","created_at":"2023-10-20T14:18:26.936140Z","gateway_id":null,"id":"52b38e88-8e0b-4580-8776-8b524fc7aca3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"191-245-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.936140Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "367"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:18:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 191ef71a-a283-47f3-8f9a-8f3dbfccc017
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/52b38e88-8e0b-4580-8776-8b524fc7aca3
+    method: GET
+  response:
+    body: '{"address":"51.15.245.191","created_at":"2023-10-20T14:18:26.936140Z","gateway_id":null,"id":"52b38e88-8e0b-4580-8776-8b524fc7aca3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"191-245-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.936140Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "367"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:18:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 17dda731-8fa3-4051-a6f2-fac42e46cc97
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"The Public
+      Gateway","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"52b38e88-8e0b-4580-8776-8b524fc7aca3","enable_smtp":false,"enable_bastion":false,"bastion_port":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
+    method: POST
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.035978Z","gateway_networks":[],"id":"38056808-01b1-40cd-9c29-0ef6cd790859","ip":{"address":"51.15.245.191","created_at":"2023-10-20T14:18:26.936140Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"52b38e88-8e0b-4580-8776-8b524fc7aca3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"191-245-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.936140Z","zone":"fr-par-1"},"is_legacy":false,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:27.035978Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "981"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:18:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cd661a2c-71fc-4d62-9c0a-d37e87de54ee
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/38056808-01b1-40cd-9c29-0ef6cd790859
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.035978Z","gateway_networks":[],"id":"38056808-01b1-40cd-9c29-0ef6cd790859","ip":{"address":"51.15.245.191","created_at":"2023-10-20T14:18:26.936140Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"52b38e88-8e0b-4580-8776-8b524fc7aca3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"191-245-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.936140Z","zone":"fr-par-1"},"is_legacy":false,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:27.079216Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "984"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:18:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 638d61e1-ebc0-47f7-b021-c9189e0158ea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"My Private Network","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null,"vpc_id":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-07-12T09:45:28.388263Z","dhcp_enabled":false,"id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","name":"My
-      Private Network","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-07-12T09:45:28.388263Z","id":"444af6ff-d09e-4cec-bb65-2cde61767ebe","subnet":"172.16.16.0/22","updated_at":"2023-07-12T09:45:28.388263Z"},{"created_at":"2023-07-12T09:45:28.388263Z","id":"5a16f223-4aa2-4cf5-bc0f-0615076b962a","subnet":"fd46:78ab:30b8:fc50::/64","updated_at":"2023-07-12T09:45:28.388263Z"}],"tags":[],"updated_at":"2023-07-12T09:45:28.388263Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2023-10-20T14:18:26.291733Z","dhcp_enabled":true,"id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","name":"My
+      Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T14:18:26.291733Z","id":"52cf5211-72fc-4c11-920a-ace8324198f1","subnet":"172.16.92.0/22","updated_at":"2023-10-20T14:18:26.291733Z"},{"created_at":"2023-10-20T14:18:26.291733Z","id":"e81a0a9b-9573-4a40-a27a-712a7f43ec84","subnet":"fd5f:519c:6d46:40e3::/64","updated_at":"2023-10-20T14:18:26.291733Z"}],"tags":[],"updated_at":"2023-10-20T14:18:26.291733Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "703"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:28 GMT
+      - Fri, 20 Oct 2023 14:18:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -101,7 +240,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c73506ef-5ebd-4d95-80e9-44fb5a79badc
+      - e3b98f0f-d5bf-4d01-bb50-56b2bebf4e89
     status: 200 OK
     code: 200
     duration: ""
@@ -110,22 +249,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/951d085f-c13a-4075-b56c-7b566cc7d0e8
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:45:28.388263Z","dhcp_enabled":false,"id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","name":"My
-      Private Network","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-07-12T09:45:28.388263Z","id":"444af6ff-d09e-4cec-bb65-2cde61767ebe","subnet":"172.16.16.0/22","updated_at":"2023-07-12T09:45:28.388263Z"},{"created_at":"2023-07-12T09:45:28.388263Z","id":"5a16f223-4aa2-4cf5-bc0f-0615076b962a","subnet":"fd46:78ab:30b8:fc50::/64","updated_at":"2023-07-12T09:45:28.388263Z"}],"tags":[],"updated_at":"2023-07-12T09:45:28.388263Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2023-10-20T14:18:26.291733Z","dhcp_enabled":true,"id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","name":"My
+      Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T14:18:26.291733Z","id":"52cf5211-72fc-4c11-920a-ace8324198f1","subnet":"172.16.92.0/22","updated_at":"2023-10-20T14:18:26.291733Z"},{"created_at":"2023-10-20T14:18:26.291733Z","id":"e81a0a9b-9573-4a40-a27a-712a7f43ec84","subnet":"fd5f:519c:6d46:40e3::/64","updated_at":"2023-10-20T14:18:26.291733Z"}],"tags":[],"updated_at":"2023-10-20T14:18:26.291733Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "703"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:28 GMT
+      - Fri, 20 Oct 2023 14:18:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -135,7 +274,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 667e1b96-75c8-4336-a559-5bf2a482b005
+      - 92da7b02-3da0-415d-8d0b-bddd0ba16b63
     status: 200 OK
     code: 200
     duration: ""
@@ -144,21 +283,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=debian_bullseye&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","label":"debian_bullseye","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60"],"id":"92de05f7-7bfa-4920-8fb6-035764ba1792","label":"debian_bullseye","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","label":"debian_bullseye","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"7691a260-ab4a-4692-8c54-862e08826deb","label":"debian_bullseye","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1098"
+      - "1262"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:28 GMT
+      - Fri, 20 Oct 2023 14:18:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -168,7 +307,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58fb9517-bfd3-4120-80b7-2bd626e58393
+      - b8dd3616-245a-48ba-8d66-14c19433aba7
     status: 200 OK
     code: 200
     duration: ""
@@ -177,21 +316,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"local","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
+    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
     headers:
       Content-Length:
-      - "37931"
+      - "38421"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:28 GMT
+      - Fri, 20 Oct 2023 14:18:27 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
@@ -204,7 +343,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c594988-ca64-43d5-80e9-48238ccf2e61
+      - 1595b0df-56d4-4d85-a37a-bfc78f00a16d
       X-Total-Count:
       - "56"
     status: 200 OK
@@ -215,21 +354,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"default_boot_type":"bootscript","hot_snapshots_local_volume":true,"placement_groups":true,"private_network":0},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":104857600,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
     headers:
       Content-Length:
-      - "4489"
+      - "4865"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:28 GMT
+      - Fri, 20 Oct 2023 14:18:27 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
@@ -242,112 +381,44 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad961532-7d56-42d1-9552-546bc9368c13
+      - 3be25689-1c7c-4336-9f77-cbcae8e72295
       X-Total-Count:
       - "56"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null}'
+    body: '{"name":"Scaleway Instance","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"92e694e8-5f29-420f-b48d-c3cb88de283d","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
-    method: POST
-  response:
-    body: '{"address":"51.15.232.92","created_at":"2023-07-12T09:45:29.099151Z","gateway_id":null,"id":"1095bdd0-a080-4b52-9f66-f24bbde919db","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"92-232-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:45:29.099151Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "356"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:45:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 53f8f304-4d7b-492d-8b36-0bc36cbeb227
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/1095bdd0-a080-4b52-9f66-f24bbde919db
-    method: GET
-  response:
-    body: '{"address":"51.15.232.92","created_at":"2023-07-12T09:45:29.099151Z","gateway_id":null,"id":"1095bdd0-a080-4b52-9f66-f24bbde919db","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"92-232-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:45:29.099151Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "356"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:45:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bb43e0dc-0d8f-435f-a15a-7f78f844dbb3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"Scaleway Instance","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:45:29.214963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"4de6e031-267e-4d5f-a940-d3558bb481f0","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:2d","maintenances":[],"modification_date":"2023-07-12T09:45:29.214963+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:45:29.214963+00:00","export_uri":null,"id":"84d27cb0-679a-4cf2-826f-0c30d887ba25","modification_date":"2023-07-12T09:45:29.214963+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4de6e031-267e-4d5f-a940-d3558bb481f0","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.472674+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e6c098b1-27fb-4122-a199-67a4b10a2860","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b1:77","maintenances":[],"modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.472674+00:00","export_uri":null,"id":"87f51bef-dd4c-4d60-a2ca-fb33696ef6b0","modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e6c098b1-27fb-4122-a199-67a4b10a2860","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2586"
+      - "2606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:29 GMT
+      - Fri, 20 Oct 2023 14:18:29 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -357,75 +428,38 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b909d4c1-7231-42fa-be44-ce81a1dc405d
+      - 3805f581-2a0b-4d51-8d01-9f9ab400e639
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","name":"The Public
-      Gateway","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"1095bdd0-a080-4b52-9f66-f24bbde919db","enable_smtp":false,"enable_bastion":false,"bastion_port":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
-    method: POST
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:45:29.601163Z","gateway_networks":[],"id":"184afad5-9d19-4bb6-916a-95bbff5b9461","ip":{"address":"51.15.232.92","created_at":"2023-07-12T09:45:29.099151Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"1095bdd0-a080-4b52-9f66-f24bbde919db","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"92-232-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:45:29.099151Z","zone":"fr-par-1"},"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:45:29.601163Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "932"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:45:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1e9775fa-594e-439f-8be8-aa337a19b65b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
     body: ""
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:45:29.214963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"4de6e031-267e-4d5f-a940-d3558bb481f0","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:2d","maintenances":[],"modification_date":"2023-07-12T09:45:29.214963+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:45:29.214963+00:00","export_uri":null,"id":"84d27cb0-679a-4cf2-826f-0c30d887ba25","modification_date":"2023-07-12T09:45:29.214963+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4de6e031-267e-4d5f-a940-d3558bb481f0","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.472674+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e6c098b1-27fb-4122-a199-67a4b10a2860","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b1:77","maintenances":[],"modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.472674+00:00","export_uri":null,"id":"87f51bef-dd4c-4d60-a2ca-fb33696ef6b0","modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e6c098b1-27fb-4122-a199-67a4b10a2860","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2586"
+      - "2606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:29 GMT
+      - Fri, 20 Oct 2023 14:18:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -435,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9001f130-6997-4de6-994e-19e07a1e53b9
+      - ebe43f74-467f-4dfa-a129-0eb7fc778cf0
     status: 200 OK
     code: 200
     duration: ""
@@ -444,63 +478,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/184afad5-9d19-4bb6-916a-95bbff5b9461
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:45:29.601163Z","gateway_networks":[],"id":"184afad5-9d19-4bb6-916a-95bbff5b9461","ip":{"address":"51.15.232.92","created_at":"2023-07-12T09:45:29.099151Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"1095bdd0-a080-4b52-9f66-f24bbde919db","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"92-232-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:45:29.099151Z","zone":"fr-par-1"},"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:45:29.650193Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "935"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:45:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a23cc550-383e-4e8b-9e71-b9a2abd0ac0e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:45:29.214963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"4de6e031-267e-4d5f-a940-d3558bb481f0","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:2d","maintenances":[],"modification_date":"2023-07-12T09:45:29.214963+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:45:29.214963+00:00","export_uri":null,"id":"84d27cb0-679a-4cf2-826f-0c30d887ba25","modification_date":"2023-07-12T09:45:29.214963+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4de6e031-267e-4d5f-a940-d3558bb481f0","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.472674+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e6c098b1-27fb-4122-a199-67a4b10a2860","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b1:77","maintenances":[],"modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.472674+00:00","export_uri":null,"id":"87f51bef-dd4c-4d60-a2ca-fb33696ef6b0","modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e6c098b1-27fb-4122-a199-67a4b10a2860","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2586"
+      - "2606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:29 GMT
+      - Fri, 20 Oct 2023 14:18:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -510,7 +510,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41cbb346-d88f-410e-a762-82a6494a4f09
+      - 99d629d2-79b7-4775-9bfb-691cabda4ca7
     status: 200 OK
     code: 200
     duration: ""
@@ -521,12 +521,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/4de6e031-267e-4d5f-a940-d3558bb481f0/action","href_result":"/servers/4de6e031-267e-4d5f-a940-d3558bb481f0","id":"3d15b79b-6efb-46a0-b089-7ea9e5c5f494","started_at":"2023-07-12T09:45:30.129798+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/action","href_result":"/servers/e6c098b1-27fb-4122-a199-67a4b10a2860","id":"1fc783e4-d358-4be5-8d97-a6fed602cfa4","started_at":"2023-10-20T14:18:29.893360+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -535,9 +535,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:30 GMT
+      - Fri, 20 Oct 2023 14:18:29 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/3d15b79b-6efb-46a0-b089-7ea9e5c5f494
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/1fc783e4-d358-4be5-8d97-a6fed602cfa4
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -547,7 +547,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 397f884e-16b5-4818-a644-2e238f53fd28
+      - dbd20e42-fbb4-4f4c-ab77-1a1d5be45321
     status: 202 Accepted
     code: 202
     duration: ""
@@ -556,29 +556,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:45:29.214963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"4de6e031-267e-4d5f-a940-d3558bb481f0","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:2d","maintenances":[],"modification_date":"2023-07-12T09:45:29.819942+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:45:29.214963+00:00","export_uri":null,"id":"84d27cb0-679a-4cf2-826f-0c30d887ba25","modification_date":"2023-07-12T09:45:29.214963+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4de6e031-267e-4d5f-a940-d3558bb481f0","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.472674+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e6c098b1-27fb-4122-a199-67a4b10a2860","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b1:77","maintenances":[],"modification_date":"2023-10-20T14:18:29.472857+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.472674+00:00","export_uri":null,"id":"87f51bef-dd4c-4d60-a2ca-fb33696ef6b0","modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e6c098b1-27fb-4122-a199-67a4b10a2860","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2608"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:30 GMT
+      - Fri, 20 Oct 2023 14:18:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -588,7 +588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9142a790-a1f2-409e-ba9b-497092284792
+      - 6a030b9f-4520-4aaf-ae69-4b72691d289d
     status: 200 OK
     code: 200
     duration: ""
@@ -597,22 +597,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/184afad5-9d19-4bb6-916a-95bbff5b9461
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/38056808-01b1-40cd-9c29-0ef6cd790859
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:45:29.601163Z","gateway_networks":[],"id":"184afad5-9d19-4bb6-916a-95bbff5b9461","ip":{"address":"51.15.232.92","created_at":"2023-07-12T09:45:29.099151Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"1095bdd0-a080-4b52-9f66-f24bbde919db","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"92-232-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:45:29.099151Z","zone":"fr-par-1"},"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:45:30.152061Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.035978Z","gateway_networks":[],"id":"38056808-01b1-40cd-9c29-0ef6cd790859","ip":{"address":"51.15.245.191","created_at":"2023-10-20T14:18:26.936140Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"52b38e88-8e0b-4580-8776-8b524fc7aca3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"191-245-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.936140Z","zone":"fr-par-1"},"is_legacy":false,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:27.803599Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "932"
+      - "981"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:34 GMT
+      - Fri, 20 Oct 2023 14:18:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -622,7 +622,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe1d4248-50fe-4747-a0bf-e7a49b047e55
+      - c856d165-14e5-4281-bace-e76349169ac0
     status: 200 OK
     code: 200
     duration: ""
@@ -631,22 +631,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/184afad5-9d19-4bb6-916a-95bbff5b9461
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/38056808-01b1-40cd-9c29-0ef6cd790859
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:45:29.601163Z","gateway_networks":[],"id":"184afad5-9d19-4bb6-916a-95bbff5b9461","ip":{"address":"51.15.232.92","created_at":"2023-07-12T09:45:29.099151Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"1095bdd0-a080-4b52-9f66-f24bbde919db","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"92-232-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:45:29.099151Z","zone":"fr-par-1"},"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:45:30.152061Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.035978Z","gateway_networks":[],"id":"38056808-01b1-40cd-9c29-0ef6cd790859","ip":{"address":"51.15.245.191","created_at":"2023-10-20T14:18:26.936140Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"52b38e88-8e0b-4580-8776-8b524fc7aca3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"191-245-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.936140Z","zone":"fr-par-1"},"is_legacy":false,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:27.803599Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "932"
+      - "981"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:34 GMT
+      - Fri, 20 Oct 2023 14:18:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -656,7 +656,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b732f86d-ca33-43ca-8bf0-f651f0b345a8
+      - dbc654dd-79c1-4786-9b04-5f0fc6aa30d9
     status: 200 OK
     code: 200
     duration: ""
@@ -665,22 +665,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/184afad5-9d19-4bb6-916a-95bbff5b9461
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/38056808-01b1-40cd-9c29-0ef6cd790859
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:45:29.601163Z","gateway_networks":[],"id":"184afad5-9d19-4bb6-916a-95bbff5b9461","ip":{"address":"51.15.232.92","created_at":"2023-07-12T09:45:29.099151Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"1095bdd0-a080-4b52-9f66-f24bbde919db","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"92-232-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:45:29.099151Z","zone":"fr-par-1"},"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:45:30.152061Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.035978Z","gateway_networks":[],"id":"38056808-01b1-40cd-9c29-0ef6cd790859","ip":{"address":"51.15.245.191","created_at":"2023-10-20T14:18:26.936140Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"52b38e88-8e0b-4580-8776-8b524fc7aca3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"191-245-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.936140Z","zone":"fr-par-1"},"is_legacy":false,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:27.803599Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "932"
+      - "981"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:34 GMT
+      - Fri, 20 Oct 2023 14:18:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -690,32 +690,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51aadb1c-d9f7-4128-adcc-d65e0ab79cd0
+      - b3a35d03-4df9-4ff5-ae2b-c765ac57a7d8
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","enable_masquerade":true,"dhcp_id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","enable_dhcp":true}'
+    body: '{"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"32426185-49c2-4047-a113-32594639fbf2"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":null,"private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"created","updated_at":"2023-07-12T09:45:35.309213Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":null,"private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"created","updated_at":"2023-10-20T14:18:34.046806Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "922"
+      - "971"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:35 GMT
+      - Fri, 20 Oct 2023 14:18:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -725,7 +725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8366d2c8-fed1-4c94-bbcb-63d76c3b7af1
+      - 123b05ee-7b5d-4470-be7b-1085ef5d8cda
     status: 200 OK
     code: 200
     duration: ""
@@ -734,29 +734,63 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/38056808-01b1-40cd-9c29-0ef6cd790859
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.035978Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":null,"private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"created","updated_at":"2023-10-20T14:18:34.046806Z","zone":"fr-par-1"}],"id":"38056808-01b1-40cd-9c29-0ef6cd790859","ip":{"address":"51.15.245.191","created_at":"2023-10-20T14:18:26.936140Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"52b38e88-8e0b-4580-8776-8b524fc7aca3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"191-245-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.936140Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:34.211742Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1955"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:18:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 518ffc4d-1d91-44e1-bc50-d3be6036d487
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:45:29.214963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"4de6e031-267e-4d5f-a940-d3558bb481f0","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"603","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:2d","maintenances":[],"modification_date":"2023-07-12T09:45:29.819942+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.194.160.55","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:45:29.214963+00:00","export_uri":null,"id":"84d27cb0-679a-4cf2-826f-0c30d887ba25","modification_date":"2023-07-12T09:45:29.214963+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4de6e031-267e-4d5f-a940-d3558bb481f0","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.472674+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e6c098b1-27fb-4122-a199-67a4b10a2860","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"901","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:77","maintenances":[],"modification_date":"2023-10-20T14:18:29.472857+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.32.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.472674+00:00","export_uri":null,"id":"87f51bef-dd4c-4d60-a2ca-fb33696ef6b0","modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e6c098b1-27fb-4122-a199-67a4b10a2860","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2718"
+      - "2735"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:35 GMT
+      - Fri, 20 Oct 2023 14:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +800,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 856e1d0d-5e88-4470-83f7-c84afd1e63d6
+      - 30721daf-6c56-4b2c-8b42-b76465f77bf1
     status: 200 OK
     code: 200
     duration: ""
@@ -775,22 +809,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/184afad5-9d19-4bb6-916a-95bbff5b9461
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/38056808-01b1-40cd-9c29-0ef6cd790859
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:45:29.601163Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":null,"private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"created","updated_at":"2023-07-12T09:45:35.309213Z","zone":"fr-par-1"}],"id":"184afad5-9d19-4bb6-916a-95bbff5b9461","ip":{"address":"51.15.232.92","created_at":"2023-07-12T09:45:29.099151Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"1095bdd0-a080-4b52-9f66-f24bbde919db","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"92-232-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:45:29.099151Z","zone":"fr-par-1"},"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:45:35.445331Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.035978Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":"02:00:00:14:57:CE","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"ready","updated_at":"2023-10-20T14:18:36.984154Z","zone":"fr-par-1"}],"id":"38056808-01b1-40cd-9c29-0ef6cd790859","ip":{"address":"51.15.245.191","created_at":"2023-10-20T14:18:26.936140Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"52b38e88-8e0b-4580-8776-8b524fc7aca3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"191-245-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.936140Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:37.102467Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1858"
+      - "1964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:35 GMT
+      - Fri, 20 Oct 2023 14:18:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -800,7 +834,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78b2f64c-1702-4b23-b10d-63e9cefecab3
+      - 988670f5-966b-4247-a46a-93aacdc3120c
     status: 200 OK
     code: 200
     duration: ""
@@ -809,22 +843,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/184afad5-9d19-4bb6-916a-95bbff5b9461
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d6afbf3f-19c9-4b30-af0c-776d2871e1bb
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:45:29.601163Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":"02:00:00:13:5D:BD","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"ready","updated_at":"2023-07-12T09:45:37.116881Z","zone":"fr-par-1"}],"id":"184afad5-9d19-4bb6-916a-95bbff5b9461","ip":{"address":"51.15.232.92","created_at":"2023-07-12T09:45:29.099151Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"1095bdd0-a080-4b52-9f66-f24bbde919db","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"92-232-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:45:29.099151Z","zone":"fr-par-1"},"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:45:37.224400Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":"02:00:00:14:57:CE","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"ready","updated_at":"2023-10-20T14:18:36.984154Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1867"
+      - "984"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:40 GMT
+      - Fri, 20 Oct 2023 14:18:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -834,7 +867,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - adac9355-e245-453c-ae1a-ef38f491a695
+      - 56ca0fc1-781b-4ed1-bd3d-4e19e488f1e1
     status: 200 OK
     code: 200
     duration: ""
@@ -843,29 +876,129 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d6afbf3f-19c9-4b30-af0c-776d2871e1bb
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":"02:00:00:14:57:CE","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"ready","updated_at":"2023-10-20T14:18:36.984154Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "984"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:18:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b1a92242-879c-4af1-a330-7f2960770678
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/38056808-01b1-40cd-9c29-0ef6cd790859
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.035978Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":"02:00:00:14:57:CE","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"ready","updated_at":"2023-10-20T14:18:36.984154Z","zone":"fr-par-1"}],"id":"38056808-01b1-40cd-9c29-0ef6cd790859","ip":{"address":"51.15.245.191","created_at":"2023-10-20T14:18:26.936140Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"52b38e88-8e0b-4580-8776-8b524fc7aca3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"191-245-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.936140Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:37.102467Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1964"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:18:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 11a691d5-d38d-4df7-9b91-be3fb60a1e48
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d6afbf3f-19c9-4b30-af0c-776d2871e1bb
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":"02:00:00:14:57:CE","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"ready","updated_at":"2023-10-20T14:18:36.984154Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "984"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:18:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 38d4e991-927f-4beb-98c4-874c78a503c1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:45:29.214963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"4de6e031-267e-4d5f-a940-d3558bb481f0","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"603","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:2d","maintenances":[],"modification_date":"2023-07-12T09:45:29.819942+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.194.160.55","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:45:29.214963+00:00","export_uri":null,"id":"84d27cb0-679a-4cf2-826f-0c30d887ba25","modification_date":"2023-07-12T09:45:29.214963+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4de6e031-267e-4d5f-a940-d3558bb481f0","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.472674+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e6c098b1-27fb-4122-a199-67a4b10a2860","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"901","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:77","maintenances":[],"modification_date":"2023-10-20T14:18:29.472857+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.32.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.472674+00:00","export_uri":null,"id":"87f51bef-dd4c-4d60-a2ca-fb33696ef6b0","modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e6c098b1-27fb-4122-a199-67a4b10a2860","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2718"
+      - "2735"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:40 GMT
+      - Fri, 20 Oct 2023 14:18:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -875,7 +1008,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96453afe-71f8-4e51-b37e-0d071a14f192
+      - 702e49ca-4e2d-43f2-b776-cab49d8e7e9a
     status: 200 OK
     code: 200
     duration: ""
@@ -884,162 +1017,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4043f415-6786-40ee-a9cf-ec99e4afb5bf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":"02:00:00:13:5D:BD","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"ready","updated_at":"2023-07-12T09:45:37.116881Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "935"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:45:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2d353d90-fce5-4f71-a141-4802546c228c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4043f415-6786-40ee-a9cf-ec99e4afb5bf
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":"02:00:00:13:5D:BD","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"ready","updated_at":"2023-07-12T09:45:37.116881Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "935"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:45:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0db70d42-245e-4eeb-a1fa-55521101b53f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/184afad5-9d19-4bb6-916a-95bbff5b9461
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:45:29.601163Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":"02:00:00:13:5D:BD","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"ready","updated_at":"2023-07-12T09:45:37.116881Z","zone":"fr-par-1"}],"id":"184afad5-9d19-4bb6-916a-95bbff5b9461","ip":{"address":"51.15.232.92","created_at":"2023-07-12T09:45:29.099151Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"1095bdd0-a080-4b52-9f66-f24bbde919db","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"92-232-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:45:29.099151Z","zone":"fr-par-1"},"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:45:37.224400Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1867"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:45:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d536cb72-e48d-45de-9abd-e43b63e7d9ab
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4043f415-6786-40ee-a9cf-ec99e4afb5bf
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":"02:00:00:13:5D:BD","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"ready","updated_at":"2023-07-12T09:45:37.116881Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "935"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:45:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ee25ca86-7f7e-4cfc-9314-ac1927d1f20a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:45:29.214963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"4de6e031-267e-4d5f-a940-d3558bb481f0","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"603","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:2d","maintenances":[],"modification_date":"2023-07-12T09:45:40.689784+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.194.160.55","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:45:29.214963+00:00","export_uri":null,"id":"84d27cb0-679a-4cf2-826f-0c30d887ba25","modification_date":"2023-07-12T09:45:29.214963+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4de6e031-267e-4d5f-a940-d3558bb481f0","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.472674+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e6c098b1-27fb-4122-a199-67a4b10a2860","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"901","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:77","maintenances":[],"modification_date":"2023-10-20T14:18:29.472857+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.32.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.472674+00:00","export_uri":null,"id":"87f51bef-dd4c-4d60-a2ca-fb33696ef6b0","modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e6c098b1-27fb-4122-a199-67a4b10a2860","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2749"
+      - "2735"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:45 GMT
+      - Fri, 20 Oct 2023 14:18:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1049,7 +1049,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4087988f-981d-4e10-ac84-90821c284278
+      - acb43b48-90e2-4e16-b3ff-1506f51b4aeb
     status: 200 OK
     code: 200
     duration: ""
@@ -1058,63 +1058,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:45:28.388263Z","id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","name":"My
-      Private Network","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","subnets":["10.0.0.0/24","fd46:78ab:30b8:fc50::/64"],"tags":[],"updated_at":"2023-07-12T09:45:36.825475Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "349"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:45:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2b4d0e31-0044-4178-ad43-288db017bcd0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:45:29.214963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"4de6e031-267e-4d5f-a940-d3558bb481f0","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"603","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:2d","maintenances":[],"modification_date":"2023-07-12T09:45:40.689784+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.194.160.55","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:45:29.214963+00:00","export_uri":null,"id":"84d27cb0-679a-4cf2-826f-0c30d887ba25","modification_date":"2023-07-12T09:45:29.214963+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4de6e031-267e-4d5f-a940-d3558bb481f0","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.472674+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e6c098b1-27fb-4122-a199-67a4b10a2860","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"901","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:77","maintenances":[],"modification_date":"2023-10-20T14:18:45.667855+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.32.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.472674+00:00","export_uri":null,"id":"87f51bef-dd4c-4d60-a2ca-fb33696ef6b0","modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e6c098b1-27fb-4122-a199-67a4b10a2860","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2749"
+      - "2766"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:45 GMT
+      - Fri, 20 Oct 2023 14:18:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1124,23 +1090,98 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f4209de-4e5c-40c8-90dc-f8a9724f3f6b
+      - 7e7a1e00-6150-4153-bf4e-b1cd71bff4c6
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737"}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/951d085f-c13a-4075-b56c-7b566cc7d0e8
+    method: GET
+  response:
+    body: '{"created_at":"2023-10-20T14:18:26.291733Z","id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","name":"My
+      Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnets":["10.0.0.0/24","fd5f:519c:6d46:40e3::/64"],"tags":[],"updated_at":"2023-10-20T14:18:36.675179Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "358"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:18:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e3f1997f-609b-4ea9-8be7-869fb6f1ee4b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.472674+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e6c098b1-27fb-4122-a199-67a4b10a2860","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"901","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:77","maintenances":[],"modification_date":"2023-10-20T14:18:45.667855+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.32.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.472674+00:00","export_uri":null,"id":"87f51bef-dd4c-4d60-a2ca-fb33696ef6b0","modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e6c098b1-27fb-4122-a199-67a4b10a2860","name":"Scaleway
+      Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2766"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:18:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - aa93f94f-9e5e-4a3f-9cac-9ff2fc5925dc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:45:45.911135+00:00","id":"ca5b5ac5-c55b-441c-8973-4dce5b318a50","mac_address":"02:00:00:13:5d:bf","modification_date":"2023-07-12T09:45:45.911135+00:00","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","server_id":"4de6e031-267e-4d5f-a940-d3558bb481f0","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:18:51.027324+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1149,7 +1190,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:46 GMT
+      - Fri, 20 Oct 2023 14:18:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1200,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42f2e8ed-0123-4bb3-8332-04ddcf812351
+      - 4d4eba5f-1c9a-4c7d-b1bf-2ecb92671cd0
     status: 201 Created
     code: 201
     duration: ""
@@ -1168,12 +1209,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0/private_nics/ca5b5ac5-c55b-441c-8973-4dce5b318a50
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/private_nics/c99d3bd0-86cc-4a85-9591-4bb630c9fd39
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:45:45.911135+00:00","id":"ca5b5ac5-c55b-441c-8973-4dce5b318a50","mac_address":"02:00:00:13:5d:bf","modification_date":"2023-07-12T09:45:45.911135+00:00","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","server_id":"4de6e031-267e-4d5f-a940-d3558bb481f0","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:18:51.027324+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1182,7 +1223,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:46 GMT
+      - Fri, 20 Oct 2023 14:18:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1233,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bba11cb0-63b4-4d12-807c-48eb61d9c5e7
+      - 84d78543-c3c5-410d-a3db-5481ce70a4c0
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,12 +1242,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0/private_nics/ca5b5ac5-c55b-441c-8973-4dce5b318a50
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/private_nics/c99d3bd0-86cc-4a85-9591-4bb630c9fd39
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:45:45.911135+00:00","id":"ca5b5ac5-c55b-441c-8973-4dce5b318a50","mac_address":"02:00:00:13:5d:bf","modification_date":"2023-07-12T09:45:46.824057+00:00","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","server_id":"4de6e031-267e-4d5f-a940-d3558bb481f0","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:18:51.895193+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1215,7 +1256,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:51 GMT
+      - Fri, 20 Oct 2023 14:18:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1266,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4bc3b3a9-2e7a-4dc9-9b18-89e34a698347
+      - 25cc7c4e-7c35-4820-a3f4-d051aa97b578
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,12 +1275,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0/private_nics/ca5b5ac5-c55b-441c-8973-4dce5b318a50
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/private_nics/c99d3bd0-86cc-4a85-9591-4bb630c9fd39
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:45:45.911135+00:00","id":"ca5b5ac5-c55b-441c-8973-4dce5b318a50","mac_address":"02:00:00:13:5d:bf","modification_date":"2023-07-12T09:45:46.824057+00:00","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","server_id":"4de6e031-267e-4d5f-a940-d3558bb481f0","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:18:51.895193+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1248,7 +1289,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:45:56 GMT
+      - Fri, 20 Oct 2023 14:19:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1299,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 715cf40b-df7d-4f4c-bd89-29f09b347172
+      - 6883b882-3b8e-4d5f-92f1-24df8390f91c
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,12 +1308,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0/private_nics/ca5b5ac5-c55b-441c-8973-4dce5b318a50
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/private_nics/c99d3bd0-86cc-4a85-9591-4bb630c9fd39
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:45:45.911135+00:00","id":"ca5b5ac5-c55b-441c-8973-4dce5b318a50","mac_address":"02:00:00:13:5d:bf","modification_date":"2023-07-12T09:45:46.824057+00:00","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","server_id":"4de6e031-267e-4d5f-a940-d3558bb481f0","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:18:51.895193+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1281,7 +1322,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:01 GMT
+      - Fri, 20 Oct 2023 14:19:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1332,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7bcb49ce-5253-4959-902f-555c755ac4d5
+      - 783a6b8d-b5ff-4faf-90b0-72111498c72e
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,12 +1341,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0/private_nics/ca5b5ac5-c55b-441c-8973-4dce5b318a50
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/private_nics/c99d3bd0-86cc-4a85-9591-4bb630c9fd39
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:45:45.911135+00:00","id":"ca5b5ac5-c55b-441c-8973-4dce5b318a50","mac_address":"02:00:00:13:5d:bf","modification_date":"2023-07-12T09:45:46.824057+00:00","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","server_id":"4de6e031-267e-4d5f-a940-d3558bb481f0","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:18:51.895193+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1314,7 +1355,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:06 GMT
+      - Fri, 20 Oct 2023 14:19:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1365,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a575c92-47b8-432b-9864-300fb15c6d64
+      - c8f4ee64-0e2f-4231-9478-25def0bd3846
     status: 200 OK
     code: 200
     duration: ""
@@ -1333,12 +1374,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0/private_nics/ca5b5ac5-c55b-441c-8973-4dce5b318a50
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/private_nics/c99d3bd0-86cc-4a85-9591-4bb630c9fd39
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:45:45.911135+00:00","id":"ca5b5ac5-c55b-441c-8973-4dce5b318a50","mac_address":"02:00:00:13:5d:bf","modification_date":"2023-07-12T09:45:46.824057+00:00","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","server_id":"4de6e031-267e-4d5f-a940-d3558bb481f0","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:18:51.895193+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1347,7 +1388,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:12 GMT
+      - Fri, 20 Oct 2023 14:19:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1398,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0aafb9c5-43f7-4ce7-b4f8-9e12e6809260
+      - 20be1c2f-5295-4da2-a46c-0db06af56abf
     status: 200 OK
     code: 200
     duration: ""
@@ -1366,12 +1407,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0/private_nics/ca5b5ac5-c55b-441c-8973-4dce5b318a50
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/private_nics/c99d3bd0-86cc-4a85-9591-4bb630c9fd39
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:45:45.911135+00:00","id":"ca5b5ac5-c55b-441c-8973-4dce5b318a50","mac_address":"02:00:00:13:5d:bf","modification_date":"2023-07-12T09:45:46.824057+00:00","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","server_id":"4de6e031-267e-4d5f-a940-d3558bb481f0","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:18:51.895193+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1380,7 +1421,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:17 GMT
+      - Fri, 20 Oct 2023 14:19:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 183f2077-d594-43ae-96d5-3e6d21a99136
+      - 83594ad7-b71e-41c1-808d-e49cebd31b75
     status: 200 OK
     code: 200
     duration: ""
@@ -1399,12 +1440,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0/private_nics/ca5b5ac5-c55b-441c-8973-4dce5b318a50
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/private_nics/c99d3bd0-86cc-4a85-9591-4bb630c9fd39
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:45:45.911135+00:00","id":"ca5b5ac5-c55b-441c-8973-4dce5b318a50","mac_address":"02:00:00:13:5d:bf","modification_date":"2023-07-12T09:46:17.129745+00:00","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","server_id":"4de6e031-267e-4d5f-a940-d3558bb481f0","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:19:22.894671+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1413,7 +1454,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:22 GMT
+      - Fri, 20 Oct 2023 14:19:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9434d56-fbdd-4dfa-bc5f-0edd10878c2b
+      - 068fa53d-918e-4a45-9db4-85e2268146f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1432,12 +1473,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0/private_nics/ca5b5ac5-c55b-441c-8973-4dce5b318a50
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/private_nics/c99d3bd0-86cc-4a85-9591-4bb630c9fd39
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-07-12T09:45:45.911135+00:00","id":"ca5b5ac5-c55b-441c-8973-4dce5b318a50","mac_address":"02:00:00:13:5d:bf","modification_date":"2023-07-12T09:46:17.129745+00:00","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","server_id":"4de6e031-267e-4d5f-a940-d3558bb481f0","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:19:22.894671+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1446,7 +1487,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:22 GMT
+      - Fri, 20 Oct 2023 14:19:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - adf67f5c-33f4-4a81-bf29-06e715a07994
+      - b22d7f46-612d-4ff7-8662-453a1074e9c9
     status: 200 OK
     code: 200
     duration: ""
@@ -1465,29 +1506,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:45:29.214963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"4de6e031-267e-4d5f-a940-d3558bb481f0","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"603","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:2d","maintenances":[],"modification_date":"2023-07-12T09:45:40.689784+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.194.160.55","private_nics":[{"creation_date":"2023-07-12T09:45:45.911135+00:00","id":"ca5b5ac5-c55b-441c-8973-4dce5b318a50","mac_address":"02:00:00:13:5d:bf","modification_date":"2023-07-12T09:46:17.129745+00:00","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","server_id":"4de6e031-267e-4d5f-a940-d3558bb481f0","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:45:29.214963+00:00","export_uri":null,"id":"84d27cb0-679a-4cf2-826f-0c30d887ba25","modification_date":"2023-07-12T09:45:29.214963+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4de6e031-267e-4d5f-a940-d3558bb481f0","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.472674+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e6c098b1-27fb-4122-a199-67a4b10a2860","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"901","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:77","maintenances":[],"modification_date":"2023-10-20T14:18:45.667855+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.32.17","private_nics":[{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:19:22.894671+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.472674+00:00","export_uri":null,"id":"87f51bef-dd4c-4d60-a2ca-fb33696ef6b0","modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e6c098b1-27fb-4122-a199-67a4b10a2860","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3102"
+      - "3119"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:22 GMT
+      - Fri, 20 Oct 2023 14:19:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1497,7 +1538,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aace38a6-9cc7-4f69-92fd-85ac49afe301
+      - 8c37be79-6c9d-419c-a147-bd29d7f0b7aa
     status: 200 OK
     code: 200
     duration: ""
@@ -1506,9 +1547,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1520,7 +1561,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:22 GMT
+      - Fri, 20 Oct 2023 14:19:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1530,7 +1571,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0dc70c8f-8556-4184-9def-d0eb3e0e16b0
+      - b3319a6c-b814-4426-8824-6fd59ae1bf1c
     status: 200 OK
     code: 200
     duration: ""
@@ -1539,12 +1580,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-07-12T09:45:45.911135+00:00","id":"ca5b5ac5-c55b-441c-8973-4dce5b318a50","mac_address":"02:00:00:13:5d:bf","modification_date":"2023-07-12T09:46:17.129745+00:00","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","server_id":"4de6e031-267e-4d5f-a940-d3558bb481f0","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:19:22.894671+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -1553,9 +1594,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:22 GMT
+      - Fri, 20 Oct 2023 14:19:27 GMT
       Link:
-      - </servers/4de6e031-267e-4d5f-a940-d3558bb481f0/private_nics?page=1&per_page=50&>;
+      - </servers/e6c098b1-27fb-4122-a199-67a4b10a2860/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -1566,7 +1607,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b62483fc-52a8-4324-9c91-d134e2bc00d6
+      - 6f5071ca-a69f-4369-bdfd-ae95afd0e564
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -1577,21 +1618,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4043f415-6786-40ee-a9cf-ec99e4afb5bf
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d6afbf3f-19c9-4b30-af0c-776d2871e1bb
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":"02:00:00:13:5D:BD","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"ready","updated_at":"2023-07-12T09:45:37.116881Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":"02:00:00:14:57:CE","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"ready","updated_at":"2023-10-20T14:18:36.984154Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "935"
+      - "984"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:22 GMT
+      - Fri, 20 Oct 2023 14:19:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1601,32 +1642,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 446e7c12-0538-47f9-946d-e6c00cbe00c8
+      - 736d56f5-2751-4b02-90cd-3eeb22aa5cd8
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_network_id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":"02:00:00:13:5d:bf","ip_address":"10.0.0.3"}'
+    body: '{"gateway_network_id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","mac_address":"02:00:00:14:57:d1","ip_address":"10.0.0.3"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries
     method: POST
   response:
-    body: '{"created_at":"2023-07-12T09:46:22.684519Z","gateway_network_id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","hostname":"","id":"5fd348fe-0b44-4569-9491-6520fd9ea1b9","ip_address":"10.0.0.3","mac_address":"02:00:00:13:5d:bf","type":"reservation","updated_at":"2023-07-12T09:46:22.684519Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T14:18:51.810512Z","gateway_network_id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","hostname":"scaleway-instance","id":"84ccdd7d-b4bf-45b7-9310-eb334f41e22c","ip_address":"10.0.0.3","mac_address":"02:00:00:14:57:d1","type":"reservation","updated_at":"2023-10-20T14:19:28.947930Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "302"
+      - "327"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:22 GMT
+      - Fri, 20 Oct 2023 14:19:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1636,7 +1677,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c123a2df-e784-484f-971d-900d7cf9479d
+      - c75e1890-bb06-4a0b-834b-83f4ef63312c
     status: 200 OK
     code: 200
     duration: ""
@@ -1645,21 +1686,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4043f415-6786-40ee-a9cf-ec99e4afb5bf
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d6afbf3f-19c9-4b30-af0c-776d2871e1bb
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":"02:00:00:13:5D:BD","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"ready","updated_at":"2023-07-12T09:45:37.116881Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":"02:00:00:14:57:CE","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"ready","updated_at":"2023-10-20T14:18:36.984154Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "935"
+      - "984"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:22 GMT
+      - Fri, 20 Oct 2023 14:19:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1669,7 +1710,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa546970-9106-4040-8d70-2c2b1d2f3fd9
+      - 874705a4-05b7-4136-961b-7153ee548aaa
     status: 200 OK
     code: 200
     duration: ""
@@ -1678,21 +1719,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/5fd348fe-0b44-4569-9491-6520fd9ea1b9
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/84ccdd7d-b4bf-45b7-9310-eb334f41e22c
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:46:22.684519Z","gateway_network_id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","hostname":"","id":"5fd348fe-0b44-4569-9491-6520fd9ea1b9","ip_address":"10.0.0.3","mac_address":"02:00:00:13:5d:bf","type":"reservation","updated_at":"2023-07-12T09:46:22.684519Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T14:18:51.810512Z","gateway_network_id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","hostname":"scaleway-instance","id":"84ccdd7d-b4bf-45b7-9310-eb334f41e22c","ip_address":"10.0.0.3","mac_address":"02:00:00:14:57:d1","type":"reservation","updated_at":"2023-10-20T14:19:28.947930Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "302"
+      - "327"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:22 GMT
+      - Fri, 20 Oct 2023 14:19:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1702,7 +1743,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6272ac8-4f8d-4667-a199-f567c442b750
+      - 90d1aab2-d281-49cf-a2d4-f18c4bdff599
     status: 200 OK
     code: 200
     duration: ""
@@ -1711,22 +1752,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/184afad5-9d19-4bb6-916a-95bbff5b9461
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/38056808-01b1-40cd-9c29-0ef6cd790859
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:45:29.601163Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":"02:00:00:13:5D:BD","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"ready","updated_at":"2023-07-12T09:45:37.116881Z","zone":"fr-par-1"}],"id":"184afad5-9d19-4bb6-916a-95bbff5b9461","ip":{"address":"51.15.232.92","created_at":"2023-07-12T09:45:29.099151Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"1095bdd0-a080-4b52-9f66-f24bbde919db","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"92-232-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:45:29.099151Z","zone":"fr-par-1"},"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:45:37.224400Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.035978Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":"02:00:00:14:57:CE","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"ready","updated_at":"2023-10-20T14:18:36.984154Z","zone":"fr-par-1"}],"id":"38056808-01b1-40cd-9c29-0ef6cd790859","ip":{"address":"51.15.245.191","created_at":"2023-10-20T14:18:26.936140Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"52b38e88-8e0b-4580-8776-8b524fc7aca3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"191-245-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.936140Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:37.102467Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1867"
+      - "1964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:23 GMT
+      - Fri, 20 Oct 2023 14:19:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1736,7 +1777,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ee84b28-c927-44e7-b981-02348bf6b038
+      - deabee3c-3b11-4ef2-8e5c-ac266e3119a1
     status: 200 OK
     code: 200
     duration: ""
@@ -1745,22 +1786,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/184afad5-9d19-4bb6-916a-95bbff5b9461
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/38056808-01b1-40cd-9c29-0ef6cd790859
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:45:29.601163Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":"02:00:00:13:5D:BD","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"ready","updated_at":"2023-07-12T09:45:37.116881Z","zone":"fr-par-1"}],"id":"184afad5-9d19-4bb6-916a-95bbff5b9461","ip":{"address":"51.15.232.92","created_at":"2023-07-12T09:45:29.099151Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"1095bdd0-a080-4b52-9f66-f24bbde919db","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"92-232-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:45:29.099151Z","zone":"fr-par-1"},"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:45:37.224400Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.035978Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":"02:00:00:14:57:CE","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"ready","updated_at":"2023-10-20T14:18:36.984154Z","zone":"fr-par-1"}],"id":"38056808-01b1-40cd-9c29-0ef6cd790859","ip":{"address":"51.15.245.191","created_at":"2023-10-20T14:18:26.936140Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"52b38e88-8e0b-4580-8776-8b524fc7aca3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"191-245-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.936140Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:37.102467Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1867"
+      - "1964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:23 GMT
+      - Fri, 20 Oct 2023 14:19:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1770,32 +1811,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed447b4e-31d5-41e8-a472-04cead25531e
+      - 03e5602e-63ab-4129-9f14-d215db15d464
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","public_port":2023,"private_ip":"10.0.0.3","private_port":22,"protocol":"tcp"}'
+    body: '{"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","public_port":2023,"private_ip":"10.0.0.3","private_port":22,"protocol":"tcp"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules
     method: POST
   response:
-    body: '{"created_at":"2023-07-12T09:46:23.166862Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"30796bd2-be4d-4e5a-8eaa-5f3839e8d764","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2023-07-12T09:46:23.166862Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T14:19:29.282485Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"81c6f301-0cb7-47a8-8f28-b37e78770b7f","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2023-10-20T14:19:29.282485Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "279"
+      - "287"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:23 GMT
+      - Fri, 20 Oct 2023 14:19:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1805,7 +1846,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d009abb-c2f8-40e4-86f5-21c241b00504
+      - 4a0ea8a6-0867-487d-ba84-b8a1fca83ba2
     status: 200 OK
     code: 200
     duration: ""
@@ -1814,22 +1855,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/184afad5-9d19-4bb6-916a-95bbff5b9461
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/38056808-01b1-40cd-9c29-0ef6cd790859
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:45:29.601163Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":"02:00:00:13:5D:BD","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"ready","updated_at":"2023-07-12T09:46:23.083984Z","zone":"fr-par-1"}],"id":"184afad5-9d19-4bb6-916a-95bbff5b9461","ip":{"address":"51.15.232.92","created_at":"2023-07-12T09:45:29.099151Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"1095bdd0-a080-4b52-9f66-f24bbde919db","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"92-232-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:45:29.099151Z","zone":"fr-par-1"},"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:45:37.224400Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.035978Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":"02:00:00:14:57:CE","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"ready","updated_at":"2023-10-20T14:18:36.984154Z","zone":"fr-par-1"}],"id":"38056808-01b1-40cd-9c29-0ef6cd790859","ip":{"address":"51.15.245.191","created_at":"2023-10-20T14:18:26.936140Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"52b38e88-8e0b-4580-8776-8b524fc7aca3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"191-245-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.936140Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:37.102467Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1867"
+      - "1964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:23 GMT
+      - Fri, 20 Oct 2023 14:19:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1839,7 +1880,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b42e8056-1bc2-499f-82a9-3148b5b4adbf
+      - ba8aa4bb-2c6d-41b6-a267-a9c7217db4ba
     status: 200 OK
     code: 200
     duration: ""
@@ -1848,21 +1889,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/30796bd2-be4d-4e5a-8eaa-5f3839e8d764
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/81c6f301-0cb7-47a8-8f28-b37e78770b7f
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:46:23.166862Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"30796bd2-be4d-4e5a-8eaa-5f3839e8d764","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2023-07-12T09:46:23.166862Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T14:19:29.282485Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"81c6f301-0cb7-47a8-8f28-b37e78770b7f","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2023-10-20T14:19:29.282485Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "279"
+      - "287"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:23 GMT
+      - Fri, 20 Oct 2023 14:19:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1872,7 +1913,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ec455b3-faaf-43db-bf30-338acc1a09ac
+      - 643f0a2a-ff00-4782-b8fd-7226b83afca0
     status: 200 OK
     code: 200
     duration: ""
@@ -1881,21 +1922,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/eefd7a68-9adb-4b1f-bd37-6320aaab5cb8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/32426185-49c2-4047-a113-32594639fbf2
     method: GET
   response:
-    body: '{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "556"
+      - "574"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:23 GMT
+      - Fri, 20 Oct 2023 14:19:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1905,7 +1946,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38e6aee7-b636-4726-831b-03c25bac666e
+      - 35aaf8a9-fc72-4798-9a7d-e66ad8d04490
     status: 200 OK
     code: 200
     duration: ""
@@ -1914,21 +1955,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/30796bd2-be4d-4e5a-8eaa-5f3839e8d764
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/81c6f301-0cb7-47a8-8f28-b37e78770b7f
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:46:23.166862Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"30796bd2-be4d-4e5a-8eaa-5f3839e8d764","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2023-07-12T09:46:23.166862Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T14:19:29.282485Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"81c6f301-0cb7-47a8-8f28-b37e78770b7f","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2023-10-20T14:19:29.282485Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "279"
+      - "287"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:23 GMT
+      - Fri, 20 Oct 2023 14:19:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1938,7 +1979,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9c243cf-b88b-459f-a7f8-de25283a863f
+      - fc9df22b-7163-417a-97a6-221c2fed4f4a
     status: 200 OK
     code: 200
     duration: ""
@@ -1947,21 +1988,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/1095bdd0-a080-4b52-9f66-f24bbde919db
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/52b38e88-8e0b-4580-8776-8b524fc7aca3
     method: GET
   response:
-    body: '{"address":"51.15.232.92","created_at":"2023-07-12T09:45:29.099151Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"1095bdd0-a080-4b52-9f66-f24bbde919db","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"92-232-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:45:29.099151Z","zone":"fr-par-1"}'
+    body: '{"address":"51.15.245.191","created_at":"2023-10-20T14:18:26.936140Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"52b38e88-8e0b-4580-8776-8b524fc7aca3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"191-245-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.936140Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "390"
+      - "401"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:23 GMT
+      - Fri, 20 Oct 2023 14:19:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1971,7 +2012,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09fb0808-cfd3-4e84-9aaf-fe69e58c9ce3
+      - 35e80b03-84ea-470c-be3a-6fd498b935b5
     status: 200 OK
     code: 200
     duration: ""
@@ -1980,21 +2021,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/eefd7a68-9adb-4b1f-bd37-6320aaab5cb8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/32426185-49c2-4047-a113-32594639fbf2
     method: GET
   response:
-    body: '{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "556"
+      - "574"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:23 GMT
+      - Fri, 20 Oct 2023 14:19:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2004,7 +2045,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e277a00b-9272-4048-9587-3fdf3a814cec
+      - e533cfa0-1a90-4d3b-9180-67e67828ab6d
     status: 200 OK
     code: 200
     duration: ""
@@ -2013,22 +2054,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/951d085f-c13a-4075-b56c-7b566cc7d0e8
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:45:28.388263Z","dhcp_enabled":false,"id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","name":"My
-      Private Network","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-07-12T09:45:28.388263Z","id":"444af6ff-d09e-4cec-bb65-2cde61767ebe","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:35.064086Z"},{"created_at":"2023-07-12T09:45:28.388263Z","id":"5a16f223-4aa2-4cf5-bc0f-0615076b962a","subnet":"fd46:78ab:30b8:fc50::/64","updated_at":"2023-07-12T09:45:35.064086Z"}],"tags":[],"updated_at":"2023-07-12T09:46:22.917970Z","vpc_id":"f6d48c13-6586-4ad2-9cdb-99cfceb7c49c"}'
+    body: '{"created_at":"2023-10-20T14:18:26.291733Z","dhcp_enabled":true,"id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","name":"My
+      Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-10-20T14:18:26.291733Z","id":"52cf5211-72fc-4c11-920a-ace8324198f1","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:32.587449Z"},{"created_at":"2023-10-20T14:18:26.291733Z","id":"e81a0a9b-9573-4a40-a27a-712a7f43ec84","subnet":"fd5f:519c:6d46:40e3::/64","updated_at":"2023-10-20T14:18:32.590739Z"}],"tags":[],"updated_at":"2023-10-20T14:18:36.675179Z","vpc_id":"ef0c019a-0168-4482-83c5-deccc3209b2f"}'
     headers:
       Content-Length:
-      - "700"
+      - "716"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:23 GMT
+      - Fri, 20 Oct 2023 14:19:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2038,7 +2079,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 388f590d-5656-4185-a739-abe5b8d2d116
+      - 221f407e-0339-49e1-9288-8bddf6a46938
     status: 200 OK
     code: 200
     duration: ""
@@ -2047,22 +2088,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/184afad5-9d19-4bb6-916a-95bbff5b9461
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/38056808-01b1-40cd-9c29-0ef6cd790859
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:45:29.601163Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":"02:00:00:13:5D:BD","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"ready","updated_at":"2023-07-12T09:46:23.083984Z","zone":"fr-par-1"}],"id":"184afad5-9d19-4bb6-916a-95bbff5b9461","ip":{"address":"51.15.232.92","created_at":"2023-07-12T09:45:29.099151Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"1095bdd0-a080-4b52-9f66-f24bbde919db","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"92-232-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:45:29.099151Z","zone":"fr-par-1"},"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:45:37.224400Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.035978Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":"02:00:00:14:57:CE","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"ready","updated_at":"2023-10-20T14:18:36.984154Z","zone":"fr-par-1"}],"id":"38056808-01b1-40cd-9c29-0ef6cd790859","ip":{"address":"51.15.245.191","created_at":"2023-10-20T14:18:26.936140Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"52b38e88-8e0b-4580-8776-8b524fc7aca3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"191-245-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.936140Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:37.102467Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1867"
+      - "1964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:24 GMT
+      - Fri, 20 Oct 2023 14:19:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2072,7 +2113,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - acd7166b-c625-42a3-93b5-4cf09af84a29
+      - 0fb4fbc0-dd5e-4d87-8bbc-20223b756f9d
     status: 200 OK
     code: 200
     duration: ""
@@ -2081,29 +2122,96 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d6afbf3f-19c9-4b30-af0c-776d2871e1bb
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":"02:00:00:14:57:CE","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"ready","updated_at":"2023-10-20T14:18:36.984154Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "984"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a69c69a3-5e21-4995-ba05-5309d544639e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/38056808-01b1-40cd-9c29-0ef6cd790859
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.035978Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":"02:00:00:14:57:CE","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"ready","updated_at":"2023-10-20T14:18:36.984154Z","zone":"fr-par-1"}],"id":"38056808-01b1-40cd-9c29-0ef6cd790859","ip":{"address":"51.15.245.191","created_at":"2023-10-20T14:18:26.936140Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"52b38e88-8e0b-4580-8776-8b524fc7aca3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"191-245-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.936140Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:37.102467Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1964"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e0a09825-f8c2-4229-b398-9a49c2215a51
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:45:29.214963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"4de6e031-267e-4d5f-a940-d3558bb481f0","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"603","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:2d","maintenances":[],"modification_date":"2023-07-12T09:45:40.689784+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.194.160.55","private_nics":[{"creation_date":"2023-07-12T09:45:45.911135+00:00","id":"ca5b5ac5-c55b-441c-8973-4dce5b318a50","mac_address":"02:00:00:13:5d:bf","modification_date":"2023-07-12T09:46:17.129745+00:00","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","server_id":"4de6e031-267e-4d5f-a940-d3558bb481f0","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:45:29.214963+00:00","export_uri":null,"id":"84d27cb0-679a-4cf2-826f-0c30d887ba25","modification_date":"2023-07-12T09:45:29.214963+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4de6e031-267e-4d5f-a940-d3558bb481f0","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.472674+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e6c098b1-27fb-4122-a199-67a4b10a2860","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"901","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:77","maintenances":[],"modification_date":"2023-10-20T14:18:45.667855+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.32.17","private_nics":[{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:19:22.894671+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.472674+00:00","export_uri":null,"id":"87f51bef-dd4c-4d60-a2ca-fb33696ef6b0","modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e6c098b1-27fb-4122-a199-67a4b10a2860","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3102"
+      - "3119"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:24 GMT
+      - Fri, 20 Oct 2023 14:19:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2113,7 +2221,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00f8f6c2-ac0f-40b9-ab9b-2251192c73bb
+      - ac9e2b14-2c66-4c99-8fb7-b12a5b8e95ed
     status: 200 OK
     code: 200
     duration: ""
@@ -2122,9 +2230,42 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0/user_data
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d6afbf3f-19c9-4b30-af0c-776d2871e1bb
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":"02:00:00:14:57:CE","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"ready","updated_at":"2023-10-20T14:18:36.984154Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "984"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b73c1ba4-160b-4876-af0f-26a2da674cf6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2136,7 +2277,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:24 GMT
+      - Fri, 20 Oct 2023 14:19:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2146,7 +2287,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d59a1ed7-ec75-4516-91d5-c8da02569bf2
+      - 398d3e32-9f7e-4668-8af5-1c37d1d43d38
     status: 200 OK
     code: 200
     duration: ""
@@ -2155,45 +2296,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4043f415-6786-40ee-a9cf-ec99e4afb5bf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/private_nics
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":"02:00:00:13:5D:BD","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"ready","updated_at":"2023-07-12T09:46:23.083984Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "935"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:46:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ec4d2ea1-44e7-46b6-96a0-148ec47a5df1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0/private_nics
-    method: GET
-  response:
-    body: '{"private_nics":[{"creation_date":"2023-07-12T09:45:45.911135+00:00","id":"ca5b5ac5-c55b-441c-8973-4dce5b318a50","mac_address":"02:00:00:13:5d:bf","modification_date":"2023-07-12T09:46:17.129745+00:00","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","server_id":"4de6e031-267e-4d5f-a940-d3558bb481f0","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:19:22.894671+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -2202,9 +2310,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:24 GMT
+      - Fri, 20 Oct 2023 14:19:30 GMT
       Link:
-      - </servers/4de6e031-267e-4d5f-a940-d3558bb481f0/private_nics?page=1&per_page=50&>;
+      - </servers/e6c098b1-27fb-4122-a199-67a4b10a2860/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API-Gateway
@@ -2215,7 +2323,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82ae40be-af02-4c92-8d7c-b7ee5eabe93a
+      - f9471c7f-40a2-4d15-b609-480652be78e9
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -2226,22 +2334,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/184afad5-9d19-4bb6-916a-95bbff5b9461
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/84ccdd7d-b4bf-45b7-9310-eb334f41e22c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:45:29.601163Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":"02:00:00:13:5D:BD","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"ready","updated_at":"2023-07-12T09:46:23.083984Z","zone":"fr-par-1"}],"id":"184afad5-9d19-4bb6-916a-95bbff5b9461","ip":{"address":"51.15.232.92","created_at":"2023-07-12T09:45:29.099151Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"1095bdd0-a080-4b52-9f66-f24bbde919db","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"92-232-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:45:29.099151Z","zone":"fr-par-1"},"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:45:37.224400Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T14:18:51.810512Z","gateway_network_id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","hostname":"scaleway-instance","id":"84ccdd7d-b4bf-45b7-9310-eb334f41e22c","ip_address":"10.0.0.3","mac_address":"02:00:00:14:57:d1","type":"reservation","updated_at":"2023-10-20T14:19:28.947930Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1867"
+      - "327"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:24 GMT
+      - Fri, 20 Oct 2023 14:19:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2358,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd8802f6-d525-4c72-a095-7ae9970c4930
+      - bf280884-987d-411b-b326-ec6931101b37
     status: 200 OK
     code: 200
     duration: ""
@@ -2260,21 +2367,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4043f415-6786-40ee-a9cf-ec99e4afb5bf
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/81c6f301-0cb7-47a8-8f28-b37e78770b7f
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":"02:00:00:13:5D:BD","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"ready","updated_at":"2023-07-12T09:46:23.083984Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T14:19:29.282485Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"81c6f301-0cb7-47a8-8f28-b37e78770b7f","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2023-10-20T14:19:29.282485Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "935"
+      - "287"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:24 GMT
+      - Fri, 20 Oct 2023 14:19:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad4c88d5-1f80-4023-a50e-be6afa602bd2
+      - 5f666675-c6cd-4317-995b-15e9cf81465f
     status: 200 OK
     code: 200
     duration: ""
@@ -2293,21 +2400,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/5fd348fe-0b44-4569-9491-6520fd9ea1b9
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/81c6f301-0cb7-47a8-8f28-b37e78770b7f
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:46:22.684519Z","gateway_network_id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","hostname":"","id":"5fd348fe-0b44-4569-9491-6520fd9ea1b9","ip_address":"10.0.0.3","mac_address":"02:00:00:13:5d:bf","type":"reservation","updated_at":"2023-07-12T09:46:22.684519Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-10-20T14:19:29.282485Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"81c6f301-0cb7-47a8-8f28-b37e78770b7f","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2023-10-20T14:19:29.282485Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "302"
+      - "287"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:24 GMT
+      - Fri, 20 Oct 2023 14:19:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2424,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4150fdbe-c14f-4cb1-b4b2-747f70b2db5d
+      - 1af3528c-06fe-4889-bed7-9c9d0cbd0fc6
     status: 200 OK
     code: 200
     duration: ""
@@ -2326,21 +2433,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/30796bd2-be4d-4e5a-8eaa-5f3839e8d764
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/38056808-01b1-40cd-9c29-0ef6cd790859
     method: GET
   response:
-    body: '{"created_at":"2023-07-12T09:46:23.166862Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"30796bd2-be4d-4e5a-8eaa-5f3839e8d764","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2023-07-12T09:46:23.166862Z","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.035978Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":"02:00:00:14:57:CE","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"ready","updated_at":"2023-10-20T14:18:36.984154Z","zone":"fr-par-1"}],"id":"38056808-01b1-40cd-9c29-0ef6cd790859","ip":{"address":"51.15.245.191","created_at":"2023-10-20T14:18:26.936140Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"52b38e88-8e0b-4580-8776-8b524fc7aca3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"191-245-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.936140Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:37.102467Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "279"
+      - "1964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:24 GMT
+      - Fri, 20 Oct 2023 14:19:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 316836f6-30c2-4090-903d-d2abd21b0284
+      - e5cee28d-183a-43c9-967c-cd371f3fbf5f
     status: 200 OK
     code: 200
     duration: ""
@@ -2359,76 +2467,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/30796bd2-be4d-4e5a-8eaa-5f3839e8d764
-    method: GET
-  response:
-    body: '{"created_at":"2023-07-12T09:46:23.166862Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"30796bd2-be4d-4e5a-8eaa-5f3839e8d764","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2023-07-12T09:46:23.166862Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "279"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:46:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 73ac3a61-6139-44f6-ad51-6a73ecf7e9aa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/184afad5-9d19-4bb6-916a-95bbff5b9461
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:45:29.601163Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":"02:00:00:13:5D:BD","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"ready","updated_at":"2023-07-12T09:46:23.083984Z","zone":"fr-par-1"}],"id":"184afad5-9d19-4bb6-916a-95bbff5b9461","ip":{"address":"51.15.232.92","created_at":"2023-07-12T09:45:29.099151Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"1095bdd0-a080-4b52-9f66-f24bbde919db","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"92-232-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:45:29.099151Z","zone":"fr-par-1"},"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:45:37.224400Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1867"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:46:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 276c750a-3392-4895-9da8-c1a86ae4d2c5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/30796bd2-be4d-4e5a-8eaa-5f3839e8d764
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/81c6f301-0cb7-47a8-8f28-b37e78770b7f
     method: DELETE
   response:
     body: ""
@@ -2438,7 +2479,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:25 GMT
+      - Fri, 20 Oct 2023 14:19:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2448,7 +2489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8dd9cb39-ddba-4b6e-b3f4-3a6587744ff2
+      - 5ffbbb22-c174-4616-bdf2-cf6feeec3eeb
     status: 204 No Content
     code: 204
     duration: ""
@@ -2457,22 +2498,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/184afad5-9d19-4bb6-916a-95bbff5b9461
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/38056808-01b1-40cd-9c29-0ef6cd790859
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:45:29.601163Z","gateway_networks":[{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":"02:00:00:13:5D:BD","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"ready","updated_at":"2023-07-12T09:46:23.083984Z","zone":"fr-par-1"}],"id":"184afad5-9d19-4bb6-916a-95bbff5b9461","ip":{"address":"51.15.232.92","created_at":"2023-07-12T09:45:29.099151Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"1095bdd0-a080-4b52-9f66-f24bbde919db","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"92-232-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:45:29.099151Z","zone":"fr-par-1"},"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:45:37.224400Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.035978Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":"02:00:00:14:57:CE","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"ready","updated_at":"2023-10-20T14:18:36.984154Z","zone":"fr-par-1"}],"id":"38056808-01b1-40cd-9c29-0ef6cd790859","ip":{"address":"51.15.245.191","created_at":"2023-10-20T14:18:26.936140Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"52b38e88-8e0b-4580-8776-8b524fc7aca3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"191-245-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.936140Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:37.102467Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1867"
+      - "1964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:25 GMT
+      - Fri, 20 Oct 2023 14:19:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +2523,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b560ec2e-2aca-4d44-85c0-dca954d85758
+      - 73512560-7c69-4454-b2c9-398e05244b19
     status: 200 OK
     code: 200
     duration: ""
@@ -2491,21 +2532,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4043f415-6786-40ee-a9cf-ec99e4afb5bf
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d6afbf3f-19c9-4b30-af0c-776d2871e1bb
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":"02:00:00:13:5D:BD","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"ready","updated_at":"2023-07-12T09:46:23.083984Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":"02:00:00:14:57:CE","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"ready","updated_at":"2023-10-20T14:18:36.984154Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "935"
+      - "984"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:25 GMT
+      - Fri, 20 Oct 2023 14:19:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2515,7 +2556,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a472985-087f-4a2f-9a9e-eede79dea566
+      - 6ccd91b6-9cb4-44f0-8960-5fd294c508f5
     status: 200 OK
     code: 200
     duration: ""
@@ -2524,9 +2565,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/5fd348fe-0b44-4569-9491-6520fd9ea1b9
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/84ccdd7d-b4bf-45b7-9310-eb334f41e22c
     method: DELETE
   response:
     body: ""
@@ -2536,7 +2577,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:25 GMT
+      - Fri, 20 Oct 2023 14:19:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2546,7 +2587,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a668c40a-f6e0-4a9b-9f11-da367ac05151
+      - 00afece5-4a9a-4f28-ba62-d36bb2f890d3
     status: 204 No Content
     code: 204
     duration: ""
@@ -2555,21 +2596,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4043f415-6786-40ee-a9cf-ec99e4afb5bf
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d6afbf3f-19c9-4b30-af0c-776d2871e1bb
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":"02:00:00:13:5D:BD","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"ready","updated_at":"2023-07-12T09:46:23.083984Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":"02:00:00:14:57:CE","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"ready","updated_at":"2023-10-20T14:18:36.984154Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "935"
+      - "984"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:25 GMT
+      - Fri, 20 Oct 2023 14:19:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2579,7 +2620,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d98644f8-165b-4b1e-a6b7-c812f03e854f
+      - 7ed1a271-8f9a-4efe-9836-a664eba2ce7f
     status: 200 OK
     code: 200
     duration: ""
@@ -2588,21 +2629,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4043f415-6786-40ee-a9cf-ec99e4afb5bf
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d6afbf3f-19c9-4b30-af0c-776d2871e1bb
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":"02:00:00:13:5D:BD","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"ready","updated_at":"2023-07-12T09:46:25.462113Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":"02:00:00:14:57:CE","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"ready","updated_at":"2023-10-20T14:18:36.984154Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "935"
+      - "984"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:25 GMT
+      - Fri, 20 Oct 2023 14:19:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2612,7 +2653,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc93a34e-6155-4f52-9bad-3277363216fe
+      - 06a0e1a1-08ae-436a-9d96-2cc0d79a9ece
     status: 200 OK
     code: 200
     duration: ""
@@ -2621,29 +2662,60 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d6afbf3f-19c9-4b30-af0c-776d2871e1bb?cleanup_dhcp=true
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 523aeb60-cea5-438b-8ffb-116a674146df
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:45:29.214963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"4de6e031-267e-4d5f-a940-d3558bb481f0","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"603","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:2d","maintenances":[],"modification_date":"2023-07-12T09:45:40.689784+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.194.160.55","private_nics":[{"creation_date":"2023-07-12T09:45:45.911135+00:00","id":"ca5b5ac5-c55b-441c-8973-4dce5b318a50","mac_address":"02:00:00:13:5d:bf","modification_date":"2023-07-12T09:46:17.129745+00:00","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","server_id":"4de6e031-267e-4d5f-a940-d3558bb481f0","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:45:29.214963+00:00","export_uri":null,"id":"84d27cb0-679a-4cf2-826f-0c30d887ba25","modification_date":"2023-07-12T09:45:29.214963+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4de6e031-267e-4d5f-a940-d3558bb481f0","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.472674+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e6c098b1-27fb-4122-a199-67a4b10a2860","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"901","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:77","maintenances":[],"modification_date":"2023-10-20T14:18:45.667855+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.32.17","private_nics":[{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:19:22.894671+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.472674+00:00","export_uri":null,"id":"87f51bef-dd4c-4d60-a2ca-fb33696ef6b0","modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e6c098b1-27fb-4122-a199-67a4b10a2860","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3102"
+      - "3119"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:25 GMT
+      - Fri, 20 Oct 2023 14:19:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2653,7 +2725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24091061-adef-45b9-a090-d7b922559ff6
+      - 325506e7-ee6d-4831-9748-7e51410e6fb9
     status: 200 OK
     code: 200
     duration: ""
@@ -2662,52 +2734,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4043f415-6786-40ee-a9cf-ec99e4afb5bf?cleanup_dhcp=true
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 12 Jul 2023 09:46:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7bbce2ae-a3f9-4f41-ab01-fc827c23d776
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4043f415-6786-40ee-a9cf-ec99e4afb5bf
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d6afbf3f-19c9-4b30-af0c-776d2871e1bb
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-07-12T09:45:35.309213Z","dhcp":{"address":"10.0.0.1","created_at":"2023-07-12T09:45:28.348136Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-07-12T09:45:28.348136Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","mac_address":"02:00:00:13:5D:BD","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","status":"detaching","updated_at":"2023-07-12T09:46:25.609985Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-10-20T14:18:34.046806Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-20T14:18:26.286291Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"32426185-49c2-4047-a113-32594639fbf2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-20T14:18:26.286291Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","ipam_config":null,"mac_address":"02:00:00:14:57:CE","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","status":"detaching","updated_at":"2023-10-20T14:19:31.512047Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "939"
+      - "988"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:25 GMT
+      - Fri, 20 Oct 2023 14:19:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2717,7 +2758,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6812839e-2057-4f7d-a41f-781ac01736d7
+      - 4d7de7e1-d0a6-4f6d-bace-f7bcd5594691
     status: 200 OK
     code: 200
     duration: ""
@@ -2728,12 +2769,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/4de6e031-267e-4d5f-a940-d3558bb481f0/action","href_result":"/servers/4de6e031-267e-4d5f-a940-d3558bb481f0","id":"558f380f-f646-4e84-b6e4-c76f5e1c44b3","started_at":"2023-07-12T09:46:26.052728+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/action","href_result":"/servers/e6c098b1-27fb-4122-a199-67a4b10a2860","id":"437fd9b6-88bb-4061-88d8-3507b1c901cc","started_at":"2023-10-20T14:19:32.082584+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -2742,9 +2783,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:26 GMT
+      - Fri, 20 Oct 2023 14:19:32 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/558f380f-f646-4e84-b6e4-c76f5e1c44b3
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/437fd9b6-88bb-4061-88d8-3507b1c901cc
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2754,7 +2795,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb4b76bd-d04f-4285-93b3-03a393fb0aba
+      - 2d2165f8-8540-481b-af4a-78c2f07b669d
     status: 202 Accepted
     code: 202
     duration: ""
@@ -2763,29 +2804,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:45:29.214963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"4de6e031-267e-4d5f-a940-d3558bb481f0","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"603","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:2d","maintenances":[],"modification_date":"2023-07-12T09:46:25.612511+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.194.160.55","private_nics":[{"creation_date":"2023-07-12T09:45:45.911135+00:00","id":"ca5b5ac5-c55b-441c-8973-4dce5b318a50","mac_address":"02:00:00:13:5d:bf","modification_date":"2023-07-12T09:46:17.129745+00:00","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","server_id":"4de6e031-267e-4d5f-a940-d3558bb481f0","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:45:29.214963+00:00","export_uri":null,"id":"84d27cb0-679a-4cf2-826f-0c30d887ba25","modification_date":"2023-07-12T09:45:29.214963+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4de6e031-267e-4d5f-a940-d3558bb481f0","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.472674+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e6c098b1-27fb-4122-a199-67a4b10a2860","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"901","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:77","maintenances":[],"modification_date":"2023-10-20T14:19:31.589128+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.32.17","private_nics":[{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:19:22.894671+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.472674+00:00","export_uri":null,"id":"87f51bef-dd4c-4d60-a2ca-fb33696ef6b0","modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e6c098b1-27fb-4122-a199-67a4b10a2860","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3070"
+      - "3087"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:26 GMT
+      - Fri, 20 Oct 2023 14:19:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2795,7 +2836,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d346a94-247b-46f0-94b6-465863b75763
+      - 4f19db91-2f13-47de-a1d8-d4235c7398e8
     status: 200 OK
     code: 200
     duration: ""
@@ -2804,12 +2845,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4043f415-6786-40ee-a9cf-ec99e4afb5bf
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d6afbf3f-19c9-4b30-af0c-776d2871e1bb
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"4043f415-6786-40ee-a9cf-ec99e4afb5bf","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"d6afbf3f-19c9-4b30-af0c-776d2871e1bb","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2818,7 +2859,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:30 GMT
+      - Fri, 20 Oct 2023 14:19:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2828,7 +2869,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a45d2c79-96cf-466c-ae11-064e08d95c1e
+      - 33f5ca7e-64eb-4922-9d66-83fc605a27ca
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2837,22 +2878,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/184afad5-9d19-4bb6-916a-95bbff5b9461
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/38056808-01b1-40cd-9c29-0ef6cd790859
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:45:29.601163Z","gateway_networks":[],"id":"184afad5-9d19-4bb6-916a-95bbff5b9461","ip":{"address":"51.15.232.92","created_at":"2023-07-12T09:45:29.099151Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"1095bdd0-a080-4b52-9f66-f24bbde919db","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"92-232-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:45:29.099151Z","zone":"fr-par-1"},"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:45:37.224400Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.035978Z","gateway_networks":[],"id":"38056808-01b1-40cd-9c29-0ef6cd790859","ip":{"address":"51.15.245.191","created_at":"2023-10-20T14:18:26.936140Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"52b38e88-8e0b-4580-8776-8b524fc7aca3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"191-245-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.936140Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:37.102467Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "932"
+      - "980"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:30 GMT
+      - Fri, 20 Oct 2023 14:19:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2862,7 +2903,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02fef471-68dc-479f-be21-d5e51a0f0cf3
+      - c5873e75-43e9-4147-b39d-88db164fee68
     status: 200 OK
     code: 200
     duration: ""
@@ -2871,12 +2912,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/eefd7a68-9adb-4b1f-bd37-6320aaab5cb8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/32426185-49c2-4047-a113-32594639fbf2
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"eefd7a68-9adb-4b1f-bd37-6320aaab5cb8","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"32426185-49c2-4047-a113-32594639fbf2","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -2885,7 +2926,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:30 GMT
+      - Fri, 20 Oct 2023 14:19:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2895,7 +2936,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b986d5e-3726-4eab-87d7-14d2dfeb4a39
+      - 5e5d029f-6b63-4142-8c53-37932b364265
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2904,22 +2945,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/184afad5-9d19-4bb6-916a-95bbff5b9461
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/38056808-01b1-40cd-9c29-0ef6cd790859
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-07-12T09:45:29.601163Z","gateway_networks":[],"id":"184afad5-9d19-4bb6-916a-95bbff5b9461","ip":{"address":"51.15.232.92","created_at":"2023-07-12T09:45:29.099151Z","gateway_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","id":"1095bdd0-a080-4b52-9f66-f24bbde919db","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"92-232-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-07-12T09:45:29.099151Z","zone":"fr-par-1"},"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-07-12T09:45:37.224400Z","upstream_dns_servers":[],"version":"0.5.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T14:18:27.035978Z","gateway_networks":[],"id":"38056808-01b1-40cd-9c29-0ef6cd790859","ip":{"address":"51.15.245.191","created_at":"2023-10-20T14:18:26.936140Z","gateway_id":"38056808-01b1-40cd-9c29-0ef6cd790859","id":"52b38e88-8e0b-4580-8776-8b524fc7aca3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"191-245-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T14:18:26.936140Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-20T14:18:37.102467Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "932"
+      - "980"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:30 GMT
+      - Fri, 20 Oct 2023 14:19:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2929,7 +2970,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ac322a7-b784-4049-a116-34ea23489863
+      - 09761d5e-6b74-4561-9ac3-6a4644b2cbb9
     status: 200 OK
     code: 200
     duration: ""
@@ -2938,9 +2979,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/184afad5-9d19-4bb6-916a-95bbff5b9461?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/38056808-01b1-40cd-9c29-0ef6cd790859?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -2950,7 +2991,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:31 GMT
+      - Fri, 20 Oct 2023 14:19:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2960,7 +3001,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0701b01-a87b-4000-8c7c-a9bbb44509b2
+      - 9a5cdbea-ba5b-46e5-9b5d-315a4fa993f5
     status: 204 No Content
     code: 204
     duration: ""
@@ -2969,12 +3010,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/184afad5-9d19-4bb6-916a-95bbff5b9461
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/38056808-01b1-40cd-9c29-0ef6cd790859
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"184afad5-9d19-4bb6-916a-95bbff5b9461","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"38056808-01b1-40cd-9c29-0ef6cd790859","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2983,7 +3024,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:31 GMT
+      - Fri, 20 Oct 2023 14:19:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2993,7 +3034,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84aeee53-fabc-4b2a-9aec-50a8710720b7
+      - 187aeb9b-f24e-41af-b787-ed8fdf09c3b5
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3002,9 +3043,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/1095bdd0-a080-4b52-9f66-f24bbde919db
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/52b38e88-8e0b-4580-8776-8b524fc7aca3
     method: DELETE
   response:
     body: ""
@@ -3014,7 +3055,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:31 GMT
+      - Fri, 20 Oct 2023 14:19:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3024,7 +3065,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 240f6b91-9036-43f2-bc79-659c4040109b
+      - aa98632d-48f8-431e-a875-c068221f287b
     status: 204 No Content
     code: 204
     duration: ""
@@ -3033,29 +3074,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:45:29.214963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"4de6e031-267e-4d5f-a940-d3558bb481f0","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"603","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:2d","maintenances":[],"modification_date":"2023-07-12T09:46:25.612511+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.194.160.55","private_nics":[{"creation_date":"2023-07-12T09:45:45.911135+00:00","id":"ca5b5ac5-c55b-441c-8973-4dce5b318a50","mac_address":"02:00:00:13:5d:bf","modification_date":"2023-07-12T09:46:17.129745+00:00","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","server_id":"4de6e031-267e-4d5f-a940-d3558bb481f0","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:45:29.214963+00:00","export_uri":null,"id":"84d27cb0-679a-4cf2-826f-0c30d887ba25","modification_date":"2023-07-12T09:45:29.214963+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4de6e031-267e-4d5f-a940-d3558bb481f0","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.472674+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e6c098b1-27fb-4122-a199-67a4b10a2860","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"901","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:77","maintenances":[],"modification_date":"2023-10-20T14:19:31.589128+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.32.17","private_nics":[{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:19:22.894671+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.472674+00:00","export_uri":null,"id":"87f51bef-dd4c-4d60-a2ca-fb33696ef6b0","modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e6c098b1-27fb-4122-a199-67a4b10a2860","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3070"
+      - "3087"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:31 GMT
+      - Fri, 20 Oct 2023 14:19:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3065,7 +3106,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d76bf9f4-e68b-4769-a37e-6446d3f69657
+      - 375a89cb-ad0b-462b-9d85-17229eb2469a
     status: 200 OK
     code: 200
     duration: ""
@@ -3074,29 +3115,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:45:29.214963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"4de6e031-267e-4d5f-a940-d3558bb481f0","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"603","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:2d","maintenances":[],"modification_date":"2023-07-12T09:46:25.612511+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.194.160.55","private_nics":[{"creation_date":"2023-07-12T09:45:45.911135+00:00","id":"ca5b5ac5-c55b-441c-8973-4dce5b318a50","mac_address":"02:00:00:13:5d:bf","modification_date":"2023-07-12T09:46:17.129745+00:00","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","server_id":"4de6e031-267e-4d5f-a940-d3558bb481f0","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:45:29.214963+00:00","export_uri":null,"id":"84d27cb0-679a-4cf2-826f-0c30d887ba25","modification_date":"2023-07-12T09:45:29.214963+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4de6e031-267e-4d5f-a940-d3558bb481f0","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.472674+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e6c098b1-27fb-4122-a199-67a4b10a2860","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"901","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:77","maintenances":[],"modification_date":"2023-10-20T14:19:31.589128+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.32.17","private_nics":[{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:19:22.894671+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.472674+00:00","export_uri":null,"id":"87f51bef-dd4c-4d60-a2ca-fb33696ef6b0","modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e6c098b1-27fb-4122-a199-67a4b10a2860","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3070"
+      - "3087"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:36 GMT
+      - Fri, 20 Oct 2023 14:19:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3106,7 +3147,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c940565f-c522-4851-bfe1-01bf65156197
+      - ba3ca904-f5dc-49f3-8222-c4ace165fc22
     status: 200 OK
     code: 200
     duration: ""
@@ -3115,29 +3156,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:45:29.214963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"4de6e031-267e-4d5f-a940-d3558bb481f0","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"603","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:1c:fa:2d","maintenances":[],"modification_date":"2023-07-12T09:46:25.612511+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.194.160.55","private_nics":[{"creation_date":"2023-07-12T09:45:45.911135+00:00","id":"ca5b5ac5-c55b-441c-8973-4dce5b318a50","mac_address":"02:00:00:13:5d:bf","modification_date":"2023-07-12T09:46:17.129745+00:00","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","server_id":"4de6e031-267e-4d5f-a940-d3558bb481f0","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:45:29.214963+00:00","export_uri":null,"id":"84d27cb0-679a-4cf2-826f-0c30d887ba25","modification_date":"2023-07-12T09:45:29.214963+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4de6e031-267e-4d5f-a940-d3558bb481f0","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.472674+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e6c098b1-27fb-4122-a199-67a4b10a2860","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"901","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:77","maintenances":[],"modification_date":"2023-10-20T14:19:31.589128+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.32.17","private_nics":[{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:19:22.894671+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.472674+00:00","export_uri":null,"id":"87f51bef-dd4c-4d60-a2ca-fb33696ef6b0","modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e6c098b1-27fb-4122-a199-67a4b10a2860","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3070"
+      - "3087"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:41 GMT
+      - Fri, 20 Oct 2023 14:19:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3147,7 +3188,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63b75123-0f0c-480e-b6a2-bf1146d4d200
+      - 5901eb85-375c-46d7-8d9a-498d375859bf
     status: 200 OK
     code: 200
     duration: ""
@@ -3156,29 +3197,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:45:29.214963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"4de6e031-267e-4d5f-a940-d3558bb481f0","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:2d","maintenances":[],"modification_date":"2023-07-12T09:46:44.009823+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-07-12T09:45:45.911135+00:00","id":"ca5b5ac5-c55b-441c-8973-4dce5b318a50","mac_address":"02:00:00:13:5d:bf","modification_date":"2023-07-12T09:46:17.129745+00:00","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","server_id":"4de6e031-267e-4d5f-a940-d3558bb481f0","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:45:29.214963+00:00","export_uri":null,"id":"84d27cb0-679a-4cf2-826f-0c30d887ba25","modification_date":"2023-07-12T09:45:29.214963+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4de6e031-267e-4d5f-a940-d3558bb481f0","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.472674+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e6c098b1-27fb-4122-a199-67a4b10a2860","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"901","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:b1:77","maintenances":[],"modification_date":"2023-10-20T14:19:31.589128+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.68.32.17","private_nics":[{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:19:22.894671+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.472674+00:00","export_uri":null,"id":"87f51bef-dd4c-4d60-a2ca-fb33696ef6b0","modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e6c098b1-27fb-4122-a199-67a4b10a2860","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2947"
+      - "3087"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:46 GMT
+      - Fri, 20 Oct 2023 14:19:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3188,7 +3229,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5f37c52-5c38-4420-bfdf-bbfaa59ce485
+      - f1ba48cf-fc00-4dfe-9c2d-7eaccc6888de
     status: 200 OK
     code: 200
     duration: ""
@@ -3197,29 +3238,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-07-12T09:45:29.214963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"4de6e031-267e-4d5f-a940-d3558bb481f0","image":{"arch":"x86_64","creation_date":"2023-06-28T15:18:39.577162+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"b1a2f4e7-0efb-4986-a9b9-bca05a2d1658","modification_date":"2023-06-28T15:18:39.577162+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"ebd99a69-6131-453a-96cc-d0695bcc3513","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:1c:fa:2d","maintenances":[],"modification_date":"2023-07-12T09:46:44.009823+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-07-12T09:45:45.911135+00:00","id":"ca5b5ac5-c55b-441c-8973-4dce5b318a50","mac_address":"02:00:00:13:5d:bf","modification_date":"2023-07-12T09:46:17.129745+00:00","private_network_id":"b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737","server_id":"4de6e031-267e-4d5f-a940-d3558bb481f0","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-07-12T09:45:29.214963+00:00","export_uri":null,"id":"84d27cb0-679a-4cf2-826f-0c30d887ba25","modification_date":"2023-07-12T09:45:29.214963+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4de6e031-267e-4d5f-a940-d3558bb481f0","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.472674+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e6c098b1-27fb-4122-a199-67a4b10a2860","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b1:77","maintenances":[],"modification_date":"2023-10-20T14:19:55.235292+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:19:22.894671+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.472674+00:00","export_uri":null,"id":"87f51bef-dd4c-4d60-a2ca-fb33696ef6b0","modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e6c098b1-27fb-4122-a199-67a4b10a2860","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2947"
+      - "2967"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:46 GMT
+      - Fri, 20 Oct 2023 14:19:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3229,7 +3270,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9dc9d895-f6cd-42db-9146-e16a31c676cb
+      - e31b7136-4ac9-4a2a-bc60-341d6b5d4db7
     status: 200 OK
     code: 200
     duration: ""
@@ -3238,9 +3279,80 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/private_nics
+    method: GET
+  response:
+    body: '{"private_nics":[{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:19:22.894671+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:58 GMT
+      Link:
+      - </servers/e6c098b1-27fb-4122-a199-67a4b10a2860/private_nics?page=1&per_page=50&>;
+        rel="last"
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b45842c6-8f63-427f-8ccb-e67e1e079379
+      X-Total-Count:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/private_nics/c99d3bd0-86cc-4a85-9591-4bb630c9fd39
+    method: GET
+  response:
+    body: '{"private_nic":{"creation_date":"2023-10-20T14:18:51.027324+00:00","id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","mac_address":"02:00:00:14:57:d1","modification_date":"2023-10-20T14:19:22.894671+00:00","private_network_id":"951d085f-c13a-4075-b56c-7b566cc7d0e8","server_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","state":"available","tags":[],"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "378"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:19:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 32a1573a-2650-4c6a-82ca-618cd0b45bdb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/private_nics/c99d3bd0-86cc-4a85-9591-4bb630c9fd39
     method: DELETE
   response:
     body: ""
@@ -3248,7 +3360,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Wed, 12 Jul 2023 09:46:47 GMT
+      - Fri, 20 Oct 2023 14:19:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3258,7 +3370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 480b36b3-63c1-4c43-8f13-890012401e63
+      - 41d609ca-a6f8-42e4-8b44-0b3fcf6785d8
     status: 204 No Content
     code: 204
     duration: ""
@@ -3267,21 +3379,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4de6e031-267e-4d5f-a940-d3558bb481f0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860/private_nics/c99d3bd0-86cc-4a85-9591-4bb630c9fd39
     method: GET
   response:
-    body: '{"message":"\"4de6e031-267e-4d5f-a940-d3558bb481f0\" not found","type":"unknown_resource"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"c99d3bd0-86cc-4a85-9591-4bb630c9fd39","type":"not_found"}'
     headers:
       Content-Length:
-      - "93"
+      - "148"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:47 GMT
+      - Fri, 20 Oct 2023 14:19:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3291,7 +3403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68c0d22c-8333-4806-85cf-a888707ce525
+      - 6163da2e-9eed-4778-a33d-800120a71e24
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3300,17 +3412,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84d27cb0-679a-4cf2-826f-0c30d887ba25
-    method: DELETE
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860
+    method: GET
   response:
-    body: ""
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-20T14:18:28.472674+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e6c098b1-27fb-4122-a199-67a4b10a2860","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:29:b1:77","maintenances":[],"modification_date":"2023-10-20T14:19:55.235292+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-20T14:18:28.472674+00:00","export_uri":null,"id":"87f51bef-dd4c-4d60-a2ca-fb33696ef6b0","modification_date":"2023-10-20T14:18:28.472674+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e6c098b1-27fb-4122-a199-67a4b10a2860","name":"Scaleway
+      Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
+      Content-Length:
+      - "2606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:47 GMT
+      - Fri, 20 Oct 2023 14:19:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3320,7 +3444,36 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2cd51fef-cab3-4f1a-ad37-d8fc87856c7b
+      - 77ad5a88-0cb5-42ac-b532-e8c5ed4eedfa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Fri, 20 Oct 2023 14:19:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d36ac5a3-6100-461b-9981-c52489333bbc
     status: 204 No Content
     code: 204
     duration: ""
@@ -3329,9 +3482,71 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b8d15c52-ec9c-4b3f-b481-4aa0c7b6b737
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e6c098b1-27fb-4122-a199-67a4b10a2860
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"e6c098b1-27fb-4122-a199-67a4b10a2860","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Oct 2023 14:20:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e2ce2ddc-642b-465f-86c4-f364dfa37691
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/87f51bef-dd4c-4d60-a2ca-fb33696ef6b0
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Fri, 20 Oct 2023 14:20:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1478e04d-9827-4737-9f8e-742e1cf91247
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/951d085f-c13a-4075-b56c-7b566cc7d0e8
     method: DELETE
   response:
     body: ""
@@ -3341,7 +3556,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 12 Jul 2023 09:46:48 GMT
+      - Fri, 20 Oct 2023 14:20:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3351,7 +3566,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d32aa529-26cd-4ab5-abac-d1efceb51695
+      - 8954549b-0bb9-46f4-b927-bd7885a16dac
     status: 204 No Content
     code: 204
     duration: ""


### PR DESCRIPTION
Delete private-nic before server when managed by `instance_server` resource.
Useful for the workflow:
- Delete Server
- Delete PN

It would fail because the PN was not empty yet