### PR TITLE
test(k8s): fix nightly tests: add PN to data source pool test too

### DIFF
--- a/scaleway/data_source_k8s_pool_test.go
+++ b/scaleway/data_source_k8s_pool_test.go
@@ -20,12 +20,17 @@ func TestAccScalewayDataSourceK8SPool_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
+					resource "scaleway_vpc_private_network" "main" {
+						name = "test-data-source-pool"
+					}
+
 					resource "scaleway_k8s_cluster" "main" {
 					  	name 	= "%s"
 						version = "%s"
 						cni     = "cilium"
 					  	tags    = [ "terraform-test", "data_scaleway_k8s_pool", "basic" ]
 						delete_additional_resources = true
+						private_network_id = scaleway_vpc_private_network.main.id
 					}
 					
 					resource "scaleway_k8s_pool" "default" {
@@ -38,12 +43,17 @@ func TestAccScalewayDataSourceK8SPool_Basic(t *testing.T) {
 			},
 			{
 				Config: fmt.Sprintf(`
+					resource "scaleway_vpc_private_network" "main" {
+						name = "test-data-source-pool"
+					}
+
 					resource "scaleway_k8s_cluster" "main" {
 					  	name 	= "%s"
 						version = "%s"
 						cni     = "cilium"
 					  	tags    = [ "terraform-test", "data_scaleway_k8s_cluster", "basic" ]
 						delete_additional_resources = true
+						private_network_id = scaleway_vpc_private_network.main.id
 					}
 
 					resource "scaleway_k8s_pool" "default" {

--- a/scaleway/testdata/data-source-k8s-pool-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-k8s-pool-basic.cassette.yaml
@@ -6,25 +6,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
-      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
-      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
-      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
-      1.21.14","name":"1.21.14","region":"fr-par"}]}'
+    body: '{"versions":[{"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","SidecarContainers","ValidatingAdmissionPolicy"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.28.2","name":"1.28.2","region":"fr-par"},{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod","ValidatingAdmissionPolicy","CSINodeExpandSecret"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.27.6","name":"1.27.6","region":"fr-par"},{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod","ValidatingAdmissionPolicy","CSINodeExpandSecret"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.26.9","name":"1.26.9","region":"fr-par"},{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod","CSINodeExpandSecret"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.25.14","name":"1.25.14","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.17","name":"1.24.17","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.17","name":"1.23.17","region":"fr-par"}]}'
     headers:
-      Content-Length:
-      - "3135"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:49:11 GMT
+      - Thu, 02 Nov 2023 15:33:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,32 +34,100 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6970920-dd54-49a7-b407-25b5607d51d7
+      - 3a17aeb2-2602-420d-a706-d3262990d97e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"tf-cluster-pool","description":"","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"version":"1.24.7","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
+    body: '{"name":"test-data-source-pool","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+    method: POST
+  response:
+    body: '{"created_at":"2023-11-02T15:33:53.182844Z","dhcp_enabled":true,"id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","name":"test-data-source-pool","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-02T15:33:53.182844Z","id":"8b259f89-423a-4607-9979-13dd7515cc29","subnet":"172.16.4.0/22","updated_at":"2023-11-02T15:33:53.182844Z"},{"created_at":"2023-11-02T15:33:53.182844Z","id":"05ee4fd6-0b54-497d-9684-b3673ddeb02c","subnet":"fd5f:519c:6d46:cb39::/64","updated_at":"2023-11-02T15:33:53.182844Z"}],"tags":[],"updated_at":"2023-11-02T15:33:53.182844Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "704"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:33:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7866d486-65bc-4879-a65b-d9eee72f9c68
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7c0f88fe-47b2-44c5-be75-7e0d3766bc55
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-02T15:33:53.182844Z","dhcp_enabled":true,"id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","name":"test-data-source-pool","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-02T15:33:53.182844Z","id":"8b259f89-423a-4607-9979-13dd7515cc29","subnet":"172.16.4.0/22","updated_at":"2023-11-02T15:33:53.182844Z"},{"created_at":"2023-11-02T15:33:53.182844Z","id":"05ee4fd6-0b54-497d-9684-b3673ddeb02c","subnet":"fd5f:519c:6d46:cb39::/64","updated_at":"2023-11-02T15:33:53.182844Z"}],"tags":[],"updated_at":"2023-11-02T15:33:53.182844Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "704"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:33:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d7e852c1-20ca-4bf3-ae62-31a278453f2b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"tf-cluster-pool","description":"","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637956936Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-01-02T15:49:11.652745126Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614473Z","created_at":"2023-11-02T15:33:54.422614473Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-02T15:33:54.439759890Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1330"
+      - "1462"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:49:11 GMT
+      - Thu, 02 Nov 2023 15:33:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 800bd4a7-009c-407f-887d-a7c31628124a
+      - b0613fb4-02bd-4aeb-b18b-eddb861027c4
     status: 200 OK
     code: 200
     duration: ""
@@ -78,21 +146,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-01-02T15:49:11.652745Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-02T15:33:54.439760Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1324"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:49:11 GMT
+      - Thu, 02 Nov 2023 15:33:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06252e65-ccc9-4b09-acd0-0356d51458e1
+      - 13da070d-d6ae-4bbc-bc5e-38989f72d750
     status: 200 OK
     code: 200
     duration: ""
@@ -111,21 +179,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-01-02T15:49:13.173709Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-02T15:33:56.176242Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1329"
+      - "1458"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:49:16 GMT
+      - Thu, 02 Nov 2023 15:33:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -135,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14dd383c-3169-4eaf-883b-164f6def5c83
+      - f6d086f9-47d5-4a6a-958b-49571ad7933b
     status: 200 OK
     code: 200
     duration: ""
@@ -144,21 +212,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-01-02T15:49:13.173709Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-02T15:33:56.176242Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1329"
+      - "1458"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:49:16 GMT
+      - Thu, 02 Nov 2023 15:33:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -168,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - adc02072-1bef-4bbb-9db8-a5366e0a772e
+      - 4201e14b-4b4f-40a9-87b2-ebdc228b9cc9
     status: 200 OK
     code: 200
     duration: ""
@@ -177,12 +245,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVeFRrUnJlRTFzYjFoRVZFMTZUVVJGZDAxVVJURk9SR3Q0VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTekV6Q25kMk4yaDRabkZoUW5WTVJtcHZSME0yTjA5TldIWmpiQ3N4UjFaNlVqbEhjbkZMZUZoV2MydHlVRU52YkdaUVR6ZzVXVkJUTTI1MlJYRjVhREozWVZJS1JWYzNkVlI1U0N0bWVXMDJSVVZyUVRaQmNEWjZNa2cwUWsxREszbENjM3BpVWtSVmNGVlBhblpoVTFGVVprMTRiek5aZEU1Tk1USkVMekJrVXpWa1NncE9kR3BRUWpSR2MwUkVUbVU0YjJFd2VVbG1VRzlYYkhwbGVITlFWSEV6YmxJemEzZ3pRbFpVWmtKTlNISlViakoyTUU5MldIbE5RM1ZQYjFreFRFSklDa3N2ZG05S2VFeEpWbkJKUVRWd1RFdEliak5pYkhSbWQyNTRhRk5tUkVGd2NrcHdjVEZDZDNKcGNIQXdiREpLVnpCS1JqRklRbWhsZFRkWE9XeFdUMmdLUlRsb1dsSk1ZVFo1ZWxOV2VFdHRjMDFuWkZoUVJWQjNZMWhhYTJVNWNuRlpXbEZ4YTFWSVQzZzRiRFEzV0c5ck56WkNVMWRyT1dGdk9HMVhhRlpLT0FwVGVYRXJVMmREU1VRMVlsRlJNMFJ0Vm1RNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTksydExhVFptUVdKUlZUWXlXbkJYYkVGTVdXZzRla2swUzFwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFdGWlhhVXBPWkRobWNtTlRhbEptZFZCMGNreGFXR3d5YVZCbGExbzVSVlpsWXpWemRIWlJjMmRLVkhCMWJDdElTUXBTTDFKUlJrZEZaakZUYUVGTWNIWnZZVkYxTlhKM00wTk5Ua1l6VUhSeU5ISldabkJuVHl0eVdXeDZaWEpHUWxadUwwbFBMemREYWxkelNISjJUa2huQ2xSMldFSlZaMFZsZUhsb1NqaHJjVUY0UldwSmIzYzNNRUV5WVZsR1FrRlNSemhYYTJ4SVRrVjZNVlZTZEhoYVYybEJVbVpCWVZCRFlqTnZVVXBFTlVnS2JFUmxaMGQzZEZsbU9WTjBXbWR3TlRWYWRtNTFURGhxVUdoVmFtMTVRMWh0YjNCWE5VeHNiRWhuVTFWblRsaDZSWGd3TlRJd0t6Z3pjelJXYmxCa1VBcEliRlpvYjJwa1lUbFZOQzl4V1RGMGMzbFJXbFptS3pOWVFWRjBXSHB1VDI5cGVWVk9ZbFp3SzNGUGMwTmxTVXRKUmtGbE4wUmpObTFZUWtKeFJHeDRDak5VZHk5VlZERTBVVVV4S3l0bVZIQXljVGt3UlZsMlowZG5VRXhoVFRGSFRIQnRWd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNjEyMDYwNTItNjIxYS00NDM0LWEyZjAtMjQyOWE1N2U3MWI3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA5ZWk5bzZoWFNydmgwT0JsQTJxZ29PTE4yTWtYUGxwYkRCRWp5SHJyOUtYZlJ0U3JYYlhJYVhBeA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGROVkVVeFRYcE5NVTVXYjFoRVZFMTZUVlJGZDAxVVJURk5lazB4VGxadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXRUQ2xRclIzTTBkbmhYU1RWdVpVbFNia3AyWWtORGEybDVNbVJhTDNSbWNESkRORWRKYmxaNFIyUmFSa1U1YUUxa2JVYzNNMDFJUmtkaVJHaG1TM1ZKVDIwS1pUTmhaSEZDU1ZSRlYyaHZVa3BIYldsd2RFeENkRFl5ZG1kQ1FtdERSa1JCVURWNmNISkZiVkF3TTFJd1RUTjFUMlZwVm5NeFFXSnVZM2RyYzBSblJ3bzJOVFJ5S3padFpGWlVRazAxYURGMVVuTTFNWHBOY0VoV1NGQlNlWFIwUzIxd1dqWjBhRVZuTjI4MFJtbEJWVWdyTmt3cmFHOVdha1owYTBabkx6QTBDak5aWkc4NFNISmlUQzlyVjA5eVNXMXhTbmN3UkRaSWFIWllTRmh5TTNSc09FMTJkM1J1V21adWR6bHVSR3B5UW14WU1rcE9aMDlCVFhsUVEzcFNjbmdLTkVwdU1FTk9VM2R6VERGRVJsWlJOQ3RNYVVNeE9YUlRZVEF5VjBkbU5sSXJORmhJUmtsSWFXOHlTMXBXUzJVeFlYbG1aRXRVTUdaRGVqVnhVbXhYU0FvM1dtdDVUVXAwYm1JMlFrZGFZMHR3YjFkRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS2NUZGFMMGsxZUZWbFZuRnRSa2hKVFVFNE5uRXZhVXc1ZFRSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ09FTnlSVmd6Y0V0NmVrUnJWa3BuYURWR2RrWTJaRkF2TUZkTFpsaEtWRUZQYUVsYVozQlRRakJqV0M4MGFuRjFlZ3B4VUhaeVR6TnhTMDVYU25KTVpVUkljU3Q0ZEZkaldWaHdWa0ZqVkdselZGTnNRMUpyVkN0akswRlBUMlJXWld0UmRFZGliMlV2Y1hsR1ozaHdlVU5PQ21kS2FrdFJTMEZtYkRKcVVWTjBTbEZuUmpSV1EwWjZaV0YyWmpFM1JDODVjWE5tZFVoQmIxcGtaMU4wV1ZkSVNrNDVhRVJ0VVRCak4wbE1lbTg1WVdnS1RIZFFOMEl5Ym5KMk1XMXFPVWQ1VWpaUE4xbEtTalJSYVV0RGFGQkNNamQxWlRKM015dFhTbWhHTTI1clpXcDVPVkpUWjNGWFFuSXZXV1pNY1dGbWFRcHhTbkJSVkZsa1duTlVZemRUZFRaT05qTnJPR1V3WVNzMlJqTkNVekUwYWs1T1p6RkZhMGRLVnpGUVJVZDNWbGxSWVV0RkszUk5ha294ZFZwSmJtVmhDbm96WVVwQ1MxTTFiMmh6YUhWeWNIa3JiVEpyVHpaRlNsWXlieXN6ZFVZMlMySlhad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vY2MwMzRiYzAtOTY4OS00NGY1LTlhNzItNGQ5OWFjZGJiY2FmLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBOczhnZ1FJYW01VUVWMUlvS0hKT2pxS2dOeUx2TDVHWVRPQXFRYnZwUkN6VzMzdWJvVGRXbHozNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -191,7 +259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:49:17 GMT
+      - Thu, 02 Nov 2023 15:33:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -201,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b87f7d0-c6c5-48bb-b9bc-a9c923cbc4a7
+      - 0f560a7a-d90b-40d8-9eb9-b021d35f9b11
     status: 200 OK
     code: 200
     duration: ""
@@ -210,21 +278,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-01-02T15:49:13.173709Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-02T15:33:56.176242Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1329"
+      - "1458"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:49:17 GMT
+      - Thu, 02 Nov 2023 15:33:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -234,32 +302,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85375952-53e2-47ee-8c6a-cfdfd8238b6d
+      - 18a842fe-7795-4f6a-a0ee-c4177934656c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"kubelet_args":{},"upgrade_policy":null,"zone":"fr-par-1","root_volume_type":"default_volume_type","root_volume_size":null}'
+    body: '{"name":"tf-pool","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362256Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889946643Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "620"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:49:18 GMT
+      - Thu, 02 Nov 2023 15:34:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 246fd9d1-f741-4f00-b21c-bc99ba4a0ac7
+      - 36192e96-defa-45eb-aada-1be399bb28a9
     status: 200 OK
     code: 200
     duration: ""
@@ -278,21 +346,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:49:18 GMT
+      - Thu, 02 Nov 2023 15:34:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40f63509-7dad-4883-8e9b-6ac18f731892
+      - 53458060-caa7-4ef8-b516-89f64887e0e4
     status: 200 OK
     code: 200
     duration: ""
@@ -311,21 +379,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:49:23 GMT
+      - Thu, 02 Nov 2023 15:34:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -335,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d5d0a24-6e05-4161-b08a-685ef045f4b9
+      - 57c42cbd-ca87-42f5-ada8-7bc01f90a69f
     status: 200 OK
     code: 200
     duration: ""
@@ -344,21 +412,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:49:28 GMT
+      - Thu, 02 Nov 2023 15:34:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -368,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9fa0f530-b187-4e03-8480-51820197de79
+      - 5a42bfd2-387e-45a7-9f63-afa93fb87190
     status: 200 OK
     code: 200
     duration: ""
@@ -377,21 +445,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:49:33 GMT
+      - Thu, 02 Nov 2023 15:34:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -401,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d067b88-3009-421c-92ff-8f4bb9541183
+      - 2ac5fbf2-f857-43cf-a148-8802550aa94c
     status: 200 OK
     code: 200
     duration: ""
@@ -410,21 +478,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:49:38 GMT
+      - Thu, 02 Nov 2023 15:34:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -434,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77e56a93-6efc-4f5f-af9b-8dfc781ab587
+      - 8844334f-5c4c-4190-bbc3-b36c1f726383
     status: 200 OK
     code: 200
     duration: ""
@@ -443,21 +511,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:49:43 GMT
+      - Thu, 02 Nov 2023 15:34:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -467,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0233a2ea-923e-4ed9-812a-31d9033dc8bb
+      - 2bdbcdc2-7e0f-49b0-8388-76c6227b40d5
     status: 200 OK
     code: 200
     duration: ""
@@ -476,21 +544,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:49:48 GMT
+      - Thu, 02 Nov 2023 15:34:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -500,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3cfc8ee-e091-4900-add8-5e1ba549d3db
+      - 835aad0f-e1a1-45c9-9032-de75a5c9ec78
     status: 200 OK
     code: 200
     duration: ""
@@ -509,21 +577,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:49:53 GMT
+      - Thu, 02 Nov 2023 15:34:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -533,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b35a7269-6ab3-403b-8cae-9ed3c9710b45
+      - 5e725001-539b-448d-a22a-7515af8532e4
     status: 200 OK
     code: 200
     duration: ""
@@ -542,21 +610,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:49:58 GMT
+      - Thu, 02 Nov 2023 15:34:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -566,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d67c76d7-919f-4da8-a981-29042069c71c
+      - d547aab2-63a0-4d6d-a3af-ff5b51acf60b
     status: 200 OK
     code: 200
     duration: ""
@@ -575,21 +643,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:50:03 GMT
+      - Thu, 02 Nov 2023 15:34:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -599,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35ccea63-522f-4f65-b0d3-9ff6f3a65da8
+      - ad4ad128-f680-4b4a-b03c-9143e748d284
     status: 200 OK
     code: 200
     duration: ""
@@ -608,21 +676,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:50:08 GMT
+      - Thu, 02 Nov 2023 15:34:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -632,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8cb595b6-0254-43e5-a681-a69872694f9c
+      - 452d61bf-2157-4f6b-b921-fa782f1455f6
     status: 200 OK
     code: 200
     duration: ""
@@ -641,21 +709,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:50:13 GMT
+      - Thu, 02 Nov 2023 15:34:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -665,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82e614c4-07b3-45ca-9787-ebc5236cdec2
+      - aedb4863-93d5-4b9e-bcc0-00c2ca6de6ac
     status: 200 OK
     code: 200
     duration: ""
@@ -674,21 +742,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:50:18 GMT
+      - Thu, 02 Nov 2023 15:35:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -698,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee420242-62ea-472b-b9b5-ab7009316ba5
+      - d117b4da-5bc0-4b1f-95e9-3e480b2b3856
     status: 200 OK
     code: 200
     duration: ""
@@ -707,21 +775,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:50:23 GMT
+      - Thu, 02 Nov 2023 15:35:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -731,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3fd23cde-89dc-4e5f-96a5-84b9714cebe0
+      - 3e57ad65-ed08-491a-8a7a-9fb2d9931c3e
     status: 200 OK
     code: 200
     duration: ""
@@ -740,21 +808,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:50:28 GMT
+      - Thu, 02 Nov 2023 15:35:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -764,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d0cdeaf-b7c8-49fb-bb33-e676fe823ed7
+      - e17e11da-2577-4ec5-89f8-8e2061811343
     status: 200 OK
     code: 200
     duration: ""
@@ -773,21 +841,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:50:33 GMT
+      - Thu, 02 Nov 2023 15:35:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -797,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00679209-943b-45c6-a2ef-a80193644b97
+      - aa0c9f42-61bb-4d86-8e5f-c9f499e89987
     status: 200 OK
     code: 200
     duration: ""
@@ -806,21 +874,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:50:39 GMT
+      - Thu, 02 Nov 2023 15:35:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -830,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f55a8b4d-c02b-4776-ae1e-9a90c066c96c
+      - 32075981-ab6a-430e-aa0c-8faa67b968c0
     status: 200 OK
     code: 200
     duration: ""
@@ -839,21 +907,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:50:44 GMT
+      - Thu, 02 Nov 2023 15:35:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -863,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a9dbae4-7b03-4280-85de-6957328974eb
+      - 2c99ab4f-c076-4e8a-80f3-5752190e32a2
     status: 200 OK
     code: 200
     duration: ""
@@ -872,21 +940,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:50:49 GMT
+      - Thu, 02 Nov 2023 15:35:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -896,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c411b0b1-2a5c-44f5-9f02-e06d043d1439
+      - 2a828040-5a1c-4f8d-b46e-0a84f67f8edf
     status: 200 OK
     code: 200
     duration: ""
@@ -905,21 +973,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:50:54 GMT
+      - Thu, 02 Nov 2023 15:35:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -929,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11dadd90-5cfb-483a-ade3-f2093569d74d
+      - a3a0e70b-603c-4b49-afd5-8c2dc02e4c67
     status: 200 OK
     code: 200
     duration: ""
@@ -938,21 +1006,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:50:59 GMT
+      - Thu, 02 Nov 2023 15:35:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -962,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce33dde0-dfac-4810-b9dc-0d4605e9e084
+      - 98ad4fd6-89e3-457f-b56d-1f69b8e70349
     status: 200 OK
     code: 200
     duration: ""
@@ -971,21 +1039,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:51:04 GMT
+      - Thu, 02 Nov 2023 15:35:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -995,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6842c69-aa89-46a3-9377-19844fc209e6
+      - e9916378-9849-46bf-a99a-d11e118e145e
     status: 200 OK
     code: 200
     duration: ""
@@ -1004,21 +1072,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:51:09 GMT
+      - Thu, 02 Nov 2023 15:35:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1028,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10eb3843-0dbe-4587-bce0-66246b6d19d6
+      - b593c6b0-54c8-4652-9c76-a779aa87554e
     status: 200 OK
     code: 200
     duration: ""
@@ -1037,21 +1105,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:51:14 GMT
+      - Thu, 02 Nov 2023 15:35:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1061,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab61aa01-5e7f-459c-9d8f-7efa1c058842
+      - 73327f58-0fbd-4523-a4b0-1bdd3e8866be
     status: 200 OK
     code: 200
     duration: ""
@@ -1070,21 +1138,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:51:19 GMT
+      - Thu, 02 Nov 2023 15:36:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1094,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14348602-4ab0-4eb0-b5a8-eac1fa5f8654
+      - b37e6ef3-8e0b-42b6-91ca-1dcc5056dd2f
     status: 200 OK
     code: 200
     duration: ""
@@ -1103,21 +1171,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:51:24 GMT
+      - Thu, 02 Nov 2023 15:36:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1127,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ca1f799-b304-4336-b08b-8add39f7c132
+      - d771ab36-27a3-4357-b156-e13183442ec0
     status: 200 OK
     code: 200
     duration: ""
@@ -1136,21 +1204,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:51:29 GMT
+      - Thu, 02 Nov 2023 15:36:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1160,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d6ff016-e08d-4174-ab03-b27d79f0ca08
+      - f6b95289-e50a-46be-a348-6d15453c0882
     status: 200 OK
     code: 200
     duration: ""
@@ -1169,21 +1237,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:51:34 GMT
+      - Thu, 02 Nov 2023 15:36:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1193,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0505b0d7-7fd8-42e3-8d31-f53dec87e02f
+      - 3507185b-8e1c-4dff-8fe1-bf806435f805
     status: 200 OK
     code: 200
     duration: ""
@@ -1202,21 +1270,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:51:39 GMT
+      - Thu, 02 Nov 2023 15:36:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1226,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8118ae32-bbd6-4b36-803a-5ece321f557e
+      - 46f76552-03fe-4807-99be-75b756c5ae84
     status: 200 OK
     code: 200
     duration: ""
@@ -1235,21 +1303,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:51:44 GMT
+      - Thu, 02 Nov 2023 15:36:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1259,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff3d4f32-66d8-4486-a5a8-b58541c3e540
+      - 0ba1dff5-70f8-469b-84fd-4a9dd8851b5e
     status: 200 OK
     code: 200
     duration: ""
@@ -1268,21 +1336,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:51:49 GMT
+      - Thu, 02 Nov 2023 15:36:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1292,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c454bbbc-bd1e-4e9f-a2b6-d99bf834e490
+      - 15558e99-5f6d-414e-acdb-ca129b2b2e47
     status: 200 OK
     code: 200
     duration: ""
@@ -1301,21 +1369,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:51:54 GMT
+      - Thu, 02 Nov 2023 15:36:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1325,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da0c2b6b-1b9c-4ecd-a746-ee9f8173878a
+      - 51ca80eb-fa5a-4e13-ba9e-8e30d563d4eb
     status: 200 OK
     code: 200
     duration: ""
@@ -1334,21 +1402,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:51:59 GMT
+      - Thu, 02 Nov 2023 15:36:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1358,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee9b8be4-6ae9-4489-81ae-cba02947ac20
+      - 8db36358-382a-40bd-9ecc-58054cbc9c7f
     status: 200 OK
     code: 200
     duration: ""
@@ -1367,21 +1435,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:52:05 GMT
+      - Thu, 02 Nov 2023 15:36:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1391,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57325235-04c0-49d2-ac7b-5835dbaaabd4
+      - ed324f4e-b3dc-4edc-9c5d-6c3c213c11f2
     status: 200 OK
     code: 200
     duration: ""
@@ -1400,21 +1468,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:52:10 GMT
+      - Thu, 02 Nov 2023 15:36:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1424,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8299a1cf-2a64-4689-82f6-1ef842495047
+      - 83ddfd31-cb65-40b5-ac6a-c9527e5f1ff8
     status: 200 OK
     code: 200
     duration: ""
@@ -1433,21 +1501,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:52:15 GMT
+      - Thu, 02 Nov 2023 15:36:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1457,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fd03fa7-f3ce-4fed-97ff-3876e0cff778
+      - 6fdc48fa-18de-498b-b2a4-8ae7c7921b50
     status: 200 OK
     code: 200
     duration: ""
@@ -1466,21 +1534,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:52:20 GMT
+      - Thu, 02 Nov 2023 15:37:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1490,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f440f98b-dd92-4e1b-9928-a399009f2483
+      - d35217e1-cba6-46ae-9359-88a8bda291aa
     status: 200 OK
     code: 200
     duration: ""
@@ -1499,21 +1567,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:52:25 GMT
+      - Thu, 02 Nov 2023 15:37:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1523,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3568e53c-bbbd-4d6f-b4c2-14e30ddad051
+      - 85f9843f-b219-425e-96c0-f4a17ed123dc
     status: 200 OK
     code: 200
     duration: ""
@@ -1532,21 +1600,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:52:30 GMT
+      - Thu, 02 Nov 2023 15:37:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1556,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e98c43b3-4bfa-44a2-b019-23fa0ce097d7
+      - a7d74b1b-1724-4e9b-9f6a-d46379364e2e
     status: 200 OK
     code: 200
     duration: ""
@@ -1565,21 +1633,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:52:35 GMT
+      - Thu, 02 Nov 2023 15:37:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1589,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04f6f294-d3b0-4c13-8b77-c23e7809eaac
+      - 5feb1e00-4741-4382-a398-2e1e93ad70ba
     status: 200 OK
     code: 200
     duration: ""
@@ -1598,21 +1666,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:52:40 GMT
+      - Thu, 02 Nov 2023 15:37:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1622,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18fdb272-0521-4eb3-825e-3212c87d28bf
+      - abe32590-46af-44f2-852f-d71612c7911b
     status: 200 OK
     code: 200
     duration: ""
@@ -1631,21 +1699,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:52:45 GMT
+      - Thu, 02 Nov 2023 15:37:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1655,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6e58c24-7d73-4aeb-b2fd-c59c05c80c28
+      - 054c6919-f196-456c-a5a0-67e942618f63
     status: 200 OK
     code: 200
     duration: ""
@@ -1664,21 +1732,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:52:50 GMT
+      - Thu, 02 Nov 2023 15:37:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1688,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ad5fb3d-7f61-46c3-bd18-0df2ec768ebc
+      - 6dce56d9-e18a-4102-8325-ccdedf2348a3
     status: 200 OK
     code: 200
     duration: ""
@@ -1697,21 +1765,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:52:55 GMT
+      - Thu, 02 Nov 2023 15:37:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1721,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d855d9b-70f9-493a-993e-2a1b2b8f1711
+      - e2972b19-c073-4870-b3b1-e05a56fe24f8
     status: 200 OK
     code: 200
     duration: ""
@@ -1730,21 +1798,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:00 GMT
+      - Thu, 02 Nov 2023 15:37:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1754,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c69db0f-7564-4460-9fc1-60d2310aaa43
+      - 919f0200-6828-4aba-b817-ea6e699b5191
     status: 200 OK
     code: 200
     duration: ""
@@ -1763,21 +1831,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:05 GMT
+      - Thu, 02 Nov 2023 15:37:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1787,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ef87e5a-7bba-44d3-8216-f89e01f95672
+      - 8e69d7c8-9b76-4ae4-8636-873b066142aa
     status: 200 OK
     code: 200
     duration: ""
@@ -1796,21 +1864,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:10 GMT
+      - Thu, 02 Nov 2023 15:37:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1820,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1807b07c-c069-470c-8d33-aa6356c4079d
+      - a6b719d5-79c1-489e-99b8-3b1ad9fccc5f
     status: 200 OK
     code: 200
     duration: ""
@@ -1829,21 +1897,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:15 GMT
+      - Thu, 02 Nov 2023 15:37:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1853,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b59fe6f-2eda-49e5-8b45-4e1821db2da5
+      - 4eff105f-2ab0-462c-bdbf-4eea03bad540
     status: 200 OK
     code: 200
     duration: ""
@@ -1862,21 +1930,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:20 GMT
+      - Thu, 02 Nov 2023 15:38:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1886,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66961d05-3fe7-4017-a5ca-8f82d030995c
+      - 3cfcd0ed-eef1-481b-9800-ab0c0b653658
     status: 200 OK
     code: 200
     duration: ""
@@ -1895,21 +1963,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-01-02T15:50:07.843757Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1321"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:20 GMT
+      - Thu, 02 Nov 2023 15:38:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1919,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f223904-3ede-4e70-b771-1f3078c25e18
+      - 903cf6b2-bc75-48a6-a004-eebcf3bedd10
     status: 200 OK
     code: 200
     duration: ""
@@ -1928,21 +1996,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:21 GMT
+      - Thu, 02 Nov 2023 15:38:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1952,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6027b482-d265-4c25-8dfa-9b4bc3c8d87d
+      - 6adf2821-558b-4f5f-8721-f42597c77bf1
     status: 200 OK
     code: 200
     duration: ""
@@ -1961,21 +2029,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:17.901613Z"}],"total_count":1}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:21 GMT
+      - Thu, 02 Nov 2023 15:38:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1985,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e0db11b-0571-4d4e-85b2-6c1869fb852c
+      - 9e18998a-0840-413e-a3c9-a2bee23c3c31
     status: 200 OK
     code: 200
     duration: ""
@@ -1994,21 +2062,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-01-02T15:50:07.843757Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1321"
+      - "644"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:21 GMT
+      - Thu, 02 Nov 2023 15:38:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2018,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 147d24e3-04f9-4d36-bd97-d4646fd64690
+      - 6fa58cc3-f6ff-4d75-8a5d-ce28ed35fe65
     status: 200 OK
     code: 200
     duration: ""
@@ -2027,12 +2095,639 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVeFRrUnJlRTFzYjFoRVZFMTZUVVJGZDAxVVJURk9SR3Q0VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTekV6Q25kMk4yaDRabkZoUW5WTVJtcHZSME0yTjA5TldIWmpiQ3N4UjFaNlVqbEhjbkZMZUZoV2MydHlVRU52YkdaUVR6ZzVXVkJUTTI1MlJYRjVhREozWVZJS1JWYzNkVlI1U0N0bWVXMDJSVVZyUVRaQmNEWjZNa2cwUWsxREszbENjM3BpVWtSVmNGVlBhblpoVTFGVVprMTRiek5aZEU1Tk1USkVMekJrVXpWa1NncE9kR3BRUWpSR2MwUkVUbVU0YjJFd2VVbG1VRzlYYkhwbGVITlFWSEV6YmxJemEzZ3pRbFpVWmtKTlNISlViakoyTUU5MldIbE5RM1ZQYjFreFRFSklDa3N2ZG05S2VFeEpWbkJKUVRWd1RFdEliak5pYkhSbWQyNTRhRk5tUkVGd2NrcHdjVEZDZDNKcGNIQXdiREpLVnpCS1JqRklRbWhsZFRkWE9XeFdUMmdLUlRsb1dsSk1ZVFo1ZWxOV2VFdHRjMDFuWkZoUVJWQjNZMWhhYTJVNWNuRlpXbEZ4YTFWSVQzZzRiRFEzV0c5ck56WkNVMWRyT1dGdk9HMVhhRlpLT0FwVGVYRXJVMmREU1VRMVlsRlJNMFJ0Vm1RNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTksydExhVFptUVdKUlZUWXlXbkJYYkVGTVdXZzRla2swUzFwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFdGWlhhVXBPWkRobWNtTlRhbEptZFZCMGNreGFXR3d5YVZCbGExbzVSVlpsWXpWemRIWlJjMmRLVkhCMWJDdElTUXBTTDFKUlJrZEZaakZUYUVGTWNIWnZZVkYxTlhKM00wTk5Ua1l6VUhSeU5ISldabkJuVHl0eVdXeDZaWEpHUWxadUwwbFBMemREYWxkelNISjJUa2huQ2xSMldFSlZaMFZsZUhsb1NqaHJjVUY0UldwSmIzYzNNRUV5WVZsR1FrRlNSemhYYTJ4SVRrVjZNVlZTZEhoYVYybEJVbVpCWVZCRFlqTnZVVXBFTlVnS2JFUmxaMGQzZEZsbU9WTjBXbWR3TlRWYWRtNTFURGhxVUdoVmFtMTVRMWh0YjNCWE5VeHNiRWhuVTFWblRsaDZSWGd3TlRJd0t6Z3pjelJXYmxCa1VBcEliRlpvYjJwa1lUbFZOQzl4V1RGMGMzbFJXbFptS3pOWVFWRjBXSHB1VDI5cGVWVk9ZbFp3SzNGUGMwTmxTVXRKUmtGbE4wUmpObTFZUWtKeFJHeDRDak5VZHk5VlZERTBVVVV4S3l0bVZIQXljVGt3UlZsMlowZG5VRXhoVFRGSFRIQnRWd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNjEyMDYwNTItNjIxYS00NDM0LWEyZjAtMjQyOWE1N2U3MWI3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA5ZWk5bzZoWFNydmgwT0JsQTJxZ29PTE4yTWtYUGxwYkRCRWp5SHJyOUtYZlJ0U3JYYlhJYVhBeA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "644"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:38:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9539fd16-ba84-42da-82fc-1fc1e7905e0e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "644"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:38:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 79f16505-1c07-4c59-82f7-34a6d1d2d7cf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "644"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:38:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6433dcbf-2613-4dbf-87f2-2f3a1c513a30
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "644"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:38:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 47b88033-77f0-41a1-a367-89c0fde95914
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "644"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:38:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c4faf7bd-4f45-4a7a-be77-804a717aeb0d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "644"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:38:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b3c0d897-7d1f-4a85-8369-1f869efd6618
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "644"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:38:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3c8c6d89-d817-40a5-b8f8-dedf0ec1d2cd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "644"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:39:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8673b34b-d89f-41f3-9579-527cc8f691ca
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "644"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:39:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 48977626-193b-4261-b035-ce0b7f3e8520
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "644"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:39:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 60e345d1-475b-45a9-be99-5ecb58f917d0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "644"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:39:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f6d6a113-8a43-47dd-ac36-45b448700001
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "644"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:39:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dd067141-9c18-4448-bf5f-bed4d7a2f281
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "644"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:39:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d3722522-0a7c-4462-81f4-e60f1d725449
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "642"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:39:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d27a8b95-a509-4aed-8c5e-7e6450986883
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-02T15:35:08.308277Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1450"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:39:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 92b9b129-93fe-4b1e-8f3d-805ccc08c3d9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "642"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:39:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0a7d8a69-d650-4e11-9b48-92b46ec920cc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:30.122950Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "641"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:39:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 97e49bb9-1246-4e8d-bf81-9a99c0a0ccc4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7c0f88fe-47b2-44c5-be75-7e0d3766bc55
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-02T15:33:53.182844Z","dhcp_enabled":true,"id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","name":"test-data-source-pool","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-02T15:33:53.182844Z","id":"8b259f89-423a-4607-9979-13dd7515cc29","subnet":"172.16.4.0/22","updated_at":"2023-11-02T15:33:53.182844Z"},{"created_at":"2023-11-02T15:33:53.182844Z","id":"05ee4fd6-0b54-497d-9684-b3673ddeb02c","subnet":"fd5f:519c:6d46:cb39::/64","updated_at":"2023-11-02T15:33:53.182844Z"}],"tags":[],"updated_at":"2023-11-02T15:33:53.182844Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "704"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:39:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2c7df3ba-bb16-49a4-bafc-6c54009a4dbf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-02T15:35:08.308277Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1450"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:39:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 05a50443-b22d-48cc-8dfc-a1c75d25cafa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGROVkVVeFRYcE5NVTVXYjFoRVZFMTZUVlJGZDAxVVJURk5lazB4VGxadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXRUQ2xRclIzTTBkbmhYU1RWdVpVbFNia3AyWWtORGEybDVNbVJhTDNSbWNESkRORWRKYmxaNFIyUmFSa1U1YUUxa2JVYzNNMDFJUmtkaVJHaG1TM1ZKVDIwS1pUTmhaSEZDU1ZSRlYyaHZVa3BIYldsd2RFeENkRFl5ZG1kQ1FtdERSa1JCVURWNmNISkZiVkF3TTFJd1RUTjFUMlZwVm5NeFFXSnVZM2RyYzBSblJ3bzJOVFJ5S3padFpGWlVRazAxYURGMVVuTTFNWHBOY0VoV1NGQlNlWFIwUzIxd1dqWjBhRVZuTjI4MFJtbEJWVWdyTmt3cmFHOVdha1owYTBabkx6QTBDak5aWkc4NFNISmlUQzlyVjA5eVNXMXhTbmN3UkRaSWFIWllTRmh5TTNSc09FMTJkM1J1V21adWR6bHVSR3B5UW14WU1rcE9aMDlCVFhsUVEzcFNjbmdLTkVwdU1FTk9VM2R6VERGRVJsWlJOQ3RNYVVNeE9YUlRZVEF5VjBkbU5sSXJORmhJUmtsSWFXOHlTMXBXUzJVeFlYbG1aRXRVTUdaRGVqVnhVbXhYU0FvM1dtdDVUVXAwYm1JMlFrZGFZMHR3YjFkRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS2NUZGFMMGsxZUZWbFZuRnRSa2hKVFVFNE5uRXZhVXc1ZFRSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ09FTnlSVmd6Y0V0NmVrUnJWa3BuYURWR2RrWTJaRkF2TUZkTFpsaEtWRUZQYUVsYVozQlRRakJqV0M4MGFuRjFlZ3B4VUhaeVR6TnhTMDVYU25KTVpVUkljU3Q0ZEZkaldWaHdWa0ZqVkdselZGTnNRMUpyVkN0akswRlBUMlJXWld0UmRFZGliMlV2Y1hsR1ozaHdlVU5PQ21kS2FrdFJTMEZtYkRKcVVWTjBTbEZuUmpSV1EwWjZaV0YyWmpFM1JDODVjWE5tZFVoQmIxcGtaMU4wV1ZkSVNrNDVhRVJ0VVRCak4wbE1lbTg1WVdnS1RIZFFOMEl5Ym5KMk1XMXFPVWQ1VWpaUE4xbEtTalJSYVV0RGFGQkNNamQxWlRKM015dFhTbWhHTTI1clpXcDVPVkpUWjNGWFFuSXZXV1pNY1dGbWFRcHhTbkJSVkZsa1duTlVZemRUZFRaT05qTnJPR1V3WVNzMlJqTkNVekUwYWs1T1p6RkZhMGRLVnpGUVJVZDNWbGxSWVV0RkszUk5ha294ZFZwSmJtVmhDbm96WVVwQ1MxTTFiMmh6YUhWeWNIa3JiVEpyVHpaRlNsWXlieXN6ZFVZMlMySlhad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vY2MwMzRiYzAtOTY4OS00NGY1LTlhNzItNGQ5OWFjZGJiY2FmLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBOczhnZ1FJYW01VUVWMUlvS0hKT2pxS2dOeUx2TDVHWVRPQXFRYnZwUkN6VzMzdWJvVGRXbHozNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -2041,7 +2736,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:21 GMT
+      - Thu, 02 Nov 2023 15:39:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2051,7 +2746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a56a412f-a4ed-41ad-8687-c05a29389699
+      - 6e39fbf8-7e32-4871-9aa5-fe2136d001f5
     status: 200 OK
     code: 200
     duration: ""
@@ -2060,21 +2755,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "642"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:21 GMT
+      - Thu, 02 Nov 2023 15:39:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2084,7 +2779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c38660d-5e17-47f9-bafc-eb28338ac372
+      - ec18d2b6-8913-4be2-9c5d-a73f64e7da45
     status: 200 OK
     code: 200
     duration: ""
@@ -2093,21 +2788,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:17.901613Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:36.446836Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "606"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:21 GMT
+      - Thu, 02 Nov 2023 15:39:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2117,7 +2812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97471330-c59c-49ac-b91f-e149302b3c95
+      - 8aa745fa-08c9-490e-8446-40bc51fc29c8
     status: 200 OK
     code: 200
     duration: ""
@@ -2126,21 +2821,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7c0f88fe-47b2-44c5-be75-7e0d3766bc55
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-01-02T15:50:07.843757Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"created_at":"2023-11-02T15:33:53.182844Z","dhcp_enabled":true,"id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","name":"test-data-source-pool","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-02T15:33:53.182844Z","id":"8b259f89-423a-4607-9979-13dd7515cc29","subnet":"172.16.4.0/22","updated_at":"2023-11-02T15:33:53.182844Z"},{"created_at":"2023-11-02T15:33:53.182844Z","id":"05ee4fd6-0b54-497d-9684-b3673ddeb02c","subnet":"fd5f:519c:6d46:cb39::/64","updated_at":"2023-11-02T15:33:53.182844Z"}],"tags":[],"updated_at":"2023-11-02T15:33:53.182844Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "1321"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:21 GMT
+      - Thu, 02 Nov 2023 15:39:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2150,7 +2845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1257813e-52d4-4341-9a74-83e3c4f7d8d5
+      - 24064be6-bd4c-4448-a63e-9bb6254b28af
     status: 200 OK
     code: 200
     duration: ""
@@ -2159,12 +2854,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVeFRrUnJlRTFzYjFoRVZFMTZUVVJGZDAxVVJURk9SR3Q0VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTekV6Q25kMk4yaDRabkZoUW5WTVJtcHZSME0yTjA5TldIWmpiQ3N4UjFaNlVqbEhjbkZMZUZoV2MydHlVRU52YkdaUVR6ZzVXVkJUTTI1MlJYRjVhREozWVZJS1JWYzNkVlI1U0N0bWVXMDJSVVZyUVRaQmNEWjZNa2cwUWsxREszbENjM3BpVWtSVmNGVlBhblpoVTFGVVprMTRiek5aZEU1Tk1USkVMekJrVXpWa1NncE9kR3BRUWpSR2MwUkVUbVU0YjJFd2VVbG1VRzlYYkhwbGVITlFWSEV6YmxJemEzZ3pRbFpVWmtKTlNISlViakoyTUU5MldIbE5RM1ZQYjFreFRFSklDa3N2ZG05S2VFeEpWbkJKUVRWd1RFdEliak5pYkhSbWQyNTRhRk5tUkVGd2NrcHdjVEZDZDNKcGNIQXdiREpLVnpCS1JqRklRbWhsZFRkWE9XeFdUMmdLUlRsb1dsSk1ZVFo1ZWxOV2VFdHRjMDFuWkZoUVJWQjNZMWhhYTJVNWNuRlpXbEZ4YTFWSVQzZzRiRFEzV0c5ck56WkNVMWRyT1dGdk9HMVhhRlpLT0FwVGVYRXJVMmREU1VRMVlsRlJNMFJ0Vm1RNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTksydExhVFptUVdKUlZUWXlXbkJYYkVGTVdXZzRla2swUzFwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFdGWlhhVXBPWkRobWNtTlRhbEptZFZCMGNreGFXR3d5YVZCbGExbzVSVlpsWXpWemRIWlJjMmRLVkhCMWJDdElTUXBTTDFKUlJrZEZaakZUYUVGTWNIWnZZVkYxTlhKM00wTk5Ua1l6VUhSeU5ISldabkJuVHl0eVdXeDZaWEpHUWxadUwwbFBMemREYWxkelNISjJUa2huQ2xSMldFSlZaMFZsZUhsb1NqaHJjVUY0UldwSmIzYzNNRUV5WVZsR1FrRlNSemhYYTJ4SVRrVjZNVlZTZEhoYVYybEJVbVpCWVZCRFlqTnZVVXBFTlVnS2JFUmxaMGQzZEZsbU9WTjBXbWR3TlRWYWRtNTFURGhxVUdoVmFtMTVRMWh0YjNCWE5VeHNiRWhuVTFWblRsaDZSWGd3TlRJd0t6Z3pjelJXYmxCa1VBcEliRlpvYjJwa1lUbFZOQzl4V1RGMGMzbFJXbFptS3pOWVFWRjBXSHB1VDI5cGVWVk9ZbFp3SzNGUGMwTmxTVXRKUmtGbE4wUmpObTFZUWtKeFJHeDRDak5VZHk5VlZERTBVVVV4S3l0bVZIQXljVGt3UlZsMlowZG5VRXhoVFRGSFRIQnRWd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNjEyMDYwNTItNjIxYS00NDM0LWEyZjAtMjQyOWE1N2U3MWI3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA5ZWk5bzZoWFNydmgwT0JsQTJxZ29PTE4yTWtYUGxwYkRCRWp5SHJyOUtYZlJ0U3JYYlhJYVhBeA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-02T15:35:08.308277Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1450"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:39:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9dd56730-0709-4ab3-8935-9f924414c043
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGROVkVVeFRYcE5NVTVXYjFoRVZFMTZUVlJGZDAxVVJURk5lazB4VGxadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXRUQ2xRclIzTTBkbmhYU1RWdVpVbFNia3AyWWtORGEybDVNbVJhTDNSbWNESkRORWRKYmxaNFIyUmFSa1U1YUUxa2JVYzNNMDFJUmtkaVJHaG1TM1ZKVDIwS1pUTmhaSEZDU1ZSRlYyaHZVa3BIYldsd2RFeENkRFl5ZG1kQ1FtdERSa1JCVURWNmNISkZiVkF3TTFJd1RUTjFUMlZwVm5NeFFXSnVZM2RyYzBSblJ3bzJOVFJ5S3padFpGWlVRazAxYURGMVVuTTFNWHBOY0VoV1NGQlNlWFIwUzIxd1dqWjBhRVZuTjI4MFJtbEJWVWdyTmt3cmFHOVdha1owYTBabkx6QTBDak5aWkc4NFNISmlUQzlyVjA5eVNXMXhTbmN3UkRaSWFIWllTRmh5TTNSc09FMTJkM1J1V21adWR6bHVSR3B5UW14WU1rcE9aMDlCVFhsUVEzcFNjbmdLTkVwdU1FTk9VM2R6VERGRVJsWlJOQ3RNYVVNeE9YUlRZVEF5VjBkbU5sSXJORmhJUmtsSWFXOHlTMXBXUzJVeFlYbG1aRXRVTUdaRGVqVnhVbXhYU0FvM1dtdDVUVXAwYm1JMlFrZGFZMHR3YjFkRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS2NUZGFMMGsxZUZWbFZuRnRSa2hKVFVFNE5uRXZhVXc1ZFRSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ09FTnlSVmd6Y0V0NmVrUnJWa3BuYURWR2RrWTJaRkF2TUZkTFpsaEtWRUZQYUVsYVozQlRRakJqV0M4MGFuRjFlZ3B4VUhaeVR6TnhTMDVYU25KTVpVUkljU3Q0ZEZkaldWaHdWa0ZqVkdselZGTnNRMUpyVkN0akswRlBUMlJXWld0UmRFZGliMlV2Y1hsR1ozaHdlVU5PQ21kS2FrdFJTMEZtYkRKcVVWTjBTbEZuUmpSV1EwWjZaV0YyWmpFM1JDODVjWE5tZFVoQmIxcGtaMU4wV1ZkSVNrNDVhRVJ0VVRCak4wbE1lbTg1WVdnS1RIZFFOMEl5Ym5KMk1XMXFPVWQ1VWpaUE4xbEtTalJSYVV0RGFGQkNNamQxWlRKM015dFhTbWhHTTI1clpXcDVPVkpUWjNGWFFuSXZXV1pNY1dGbWFRcHhTbkJSVkZsa1duTlVZemRUZFRaT05qTnJPR1V3WVNzMlJqTkNVekUwYWs1T1p6RkZhMGRLVnpGUVJVZDNWbGxSWVV0RkszUk5ha294ZFZwSmJtVmhDbm96WVVwQ1MxTTFiMmh6YUhWeWNIa3JiVEpyVHpaRlNsWXlieXN6ZFVZMlMySlhad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vY2MwMzRiYzAtOTY4OS00NGY1LTlhNzItNGQ5OWFjZGJiY2FmLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBOczhnZ1FJYW01VUVWMUlvS0hKT2pxS2dOeUx2TDVHWVRPQXFRYnZwUkN6VzMzdWJvVGRXbHozNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -2173,7 +2901,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:21 GMT
+      - Thu, 02 Nov 2023 15:39:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2183,7 +2911,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3094f69e-84cc-4c66-af82-7e360ef82422
+      - 204796a1-e1ba-4a8f-b742-eec44892ad87
     status: 200 OK
     code: 200
     duration: ""
@@ -2192,21 +2920,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "642"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:21 GMT
+      - Thu, 02 Nov 2023 15:39:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2216,7 +2944,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2751599-622d-4ea6-a58f-3d7cef15b859
+      - a657566e-3511-41fb-bf4b-7d36d84f13a5
     status: 200 OK
     code: 200
     duration: ""
@@ -2225,21 +2953,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:17.901613Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:36.446836Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "606"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:22 GMT
+      - Thu, 02 Nov 2023 15:39:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2249,7 +2977,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c1c1bf5-6644-439d-8457-ad41953f7f12
+      - cd52daf9-a6a5-4244-8206-89d62de7cbf2
     status: 200 OK
     code: 200
     duration: ""
@@ -2258,21 +2986,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "642"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:22 GMT
+      - Thu, 02 Nov 2023 15:39:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2282,7 +3010,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b5ef00e-70e2-4e3a-9ee4-a82ddc995442
+      - 2c4d7a6f-a7d5-4fbe-ab53-61c96e6cab1c
     status: 200 OK
     code: 200
     duration: ""
@@ -2291,21 +3019,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:17.901613Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:36.446836Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "606"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:22 GMT
+      - Thu, 02 Nov 2023 15:39:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2315,7 +3043,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c3b40bc-184b-49a2-ba69-dec78509b9dd
+      - ed2ab647-5627-496a-8387-9116968ed3d1
     status: 200 OK
     code: 200
     duration: ""
@@ -2324,21 +3052,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "642"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:22 GMT
+      - Thu, 02 Nov 2023 15:39:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2348,7 +3076,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9f400c0-1452-456f-9d59-f8081d06a7b9
+      - da02d5d1-bca5-4d2a-8bbe-bcbc1de97e9f
     status: 200 OK
     code: 200
     duration: ""
@@ -2357,21 +3085,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:17.901613Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:36.446836Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "606"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:22 GMT
+      - Thu, 02 Nov 2023 15:39:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2381,32 +3109,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2661bcb8-3039-4964-9d0a-cff2e4415055
+      - da934e8e-69fc-4701-9a90-a5c6f4092e19
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":null,"description":null,"tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":null,"maintenance_window":null},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null},"apiserver_cert_sans":null}'
+    body: '{"tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":null,"maintenance_window":null},"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585435758Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:39:38.966555637Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1330"
+      - "1459"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:22 GMT
+      - Thu, 02 Nov 2023 15:39:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +3144,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba87ea03-3828-4d29-8c03-3d949d567867
+      - a003f7ca-d067-4054-b966-1fefef560461
     status: 200 OK
     code: 200
     duration: ""
@@ -2425,21 +3153,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585436Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:39:38.966556Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1327"
+      - "1456"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:22 GMT
+      - Thu, 02 Nov 2023 15:39:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +3177,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd9c41f3-0dbf-4ca9-bda9-5b604d5b800c
+      - 0d2a8725-1493-4079-ab4c-95ddaf5e699e
     status: 200 OK
     code: 200
     duration: ""
@@ -2458,21 +3186,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585436Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:39:38.966556Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1327"
+      - "1456"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:27 GMT
+      - Thu, 02 Nov 2023 15:39:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +3210,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00745675-fac4-43bd-a998-2ee4da065370
+      - 00220f19-1b7f-4f48-a3db-75d0625ebb6f
     status: 200 OK
     code: 200
     duration: ""
@@ -2491,21 +3219,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585436Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:39:38.966556Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1327"
+      - "1456"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:32 GMT
+      - Thu, 02 Nov 2023 15:39:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2515,7 +3243,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba67562b-2a8f-4874-baa4-5cb38c494735
+      - 73f53940-7685-443a-9cf4-b1bf40b92ad2
     status: 200 OK
     code: 200
     duration: ""
@@ -2524,21 +3252,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585436Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:39:38.966556Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1327"
+      - "1456"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:38 GMT
+      - Thu, 02 Nov 2023 15:39:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2548,7 +3276,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14bc94cc-854b-4a3a-8f75-e542e812e11d
+      - 07802968-065f-470e-900c-c7a6c848d933
     status: 200 OK
     code: 200
     duration: ""
@@ -2557,21 +3285,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585436Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:39:38.966556Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1327"
+      - "1456"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:43 GMT
+      - Thu, 02 Nov 2023 15:39:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2581,7 +3309,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29922f9a-fdd4-4935-b054-2c1fa275bf0c
+      - 133bc006-30c2-49ef-8486-4dab7a7d0c86
     status: 200 OK
     code: 200
     duration: ""
@@ -2590,21 +3318,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585436Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:39:38.966556Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1327"
+      - "1456"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:48 GMT
+      - Thu, 02 Nov 2023 15:40:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2614,7 +3342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c82df568-1518-4af3-a1bc-1d0e3c7ce04c
+      - 209f48b6-8ad8-45e4-bf3d-affb82c66c27
     status: 200 OK
     code: 200
     duration: ""
@@ -2623,21 +3351,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585436Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:39:38.966556Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1327"
+      - "1456"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:53 GMT
+      - Thu, 02 Nov 2023 15:40:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2647,7 +3375,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7efba53f-f967-4bd2-8751-dde3bb528cf2
+      - 54218df8-16b0-4a49-98a8-50573ff2d71d
     status: 200 OK
     code: 200
     duration: ""
@@ -2656,21 +3384,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585436Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:39:38.966556Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1327"
+      - "1456"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:53:58 GMT
+      - Thu, 02 Nov 2023 15:40:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2680,7 +3408,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a23946b8-40f4-4c11-9dfb-9f25dfc34fff
+      - 6c869895-a26d-4203-acbc-9e94ffb62736
     status: 200 OK
     code: 200
     duration: ""
@@ -2689,21 +3417,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585436Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:40:15.523704Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1327"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:03 GMT
+      - Thu, 02 Nov 2023 15:40:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2713,7 +3441,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0997c977-5196-4c11-b005-2469b9816bce
+      - 7876a774-c408-4c45-8c45-0b7a24a24588
     status: 200 OK
     code: 200
     duration: ""
@@ -2722,21 +3450,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585436Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:40:15.523704Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1327"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:08 GMT
+      - Thu, 02 Nov 2023 15:40:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2746,7 +3474,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89fccd1f-2e5a-450a-a12d-eb542051f4b4
+      - cff6eafc-86fa-4a5f-bf19-fb1ec655b967
     status: 200 OK
     code: 200
     duration: ""
@@ -2755,78 +3483,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:54:09.993032Z","upgrade_available":false,"version":"1.24.7"}'
-    headers:
-      Content-Length:
-      - "1324"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Jan 2023 15:54:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - de6b5a72-4980-40fb-a5e0-be51e774136c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:54:09.993032Z","upgrade_available":false,"version":"1.24.7"}'
-    headers:
-      Content-Length:
-      - "1324"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Jan 2023 15:54:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d23461d4-549e-4d18-8823-bfefe496ef8f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVeFRrUnJlRTFzYjFoRVZFMTZUVVJGZDAxVVJURk9SR3Q0VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTekV6Q25kMk4yaDRabkZoUW5WTVJtcHZSME0yTjA5TldIWmpiQ3N4UjFaNlVqbEhjbkZMZUZoV2MydHlVRU52YkdaUVR6ZzVXVkJUTTI1MlJYRjVhREozWVZJS1JWYzNkVlI1U0N0bWVXMDJSVVZyUVRaQmNEWjZNa2cwUWsxREszbENjM3BpVWtSVmNGVlBhblpoVTFGVVprMTRiek5aZEU1Tk1USkVMekJrVXpWa1NncE9kR3BRUWpSR2MwUkVUbVU0YjJFd2VVbG1VRzlYYkhwbGVITlFWSEV6YmxJemEzZ3pRbFpVWmtKTlNISlViakoyTUU5MldIbE5RM1ZQYjFreFRFSklDa3N2ZG05S2VFeEpWbkJKUVRWd1RFdEliak5pYkhSbWQyNTRhRk5tUkVGd2NrcHdjVEZDZDNKcGNIQXdiREpLVnpCS1JqRklRbWhsZFRkWE9XeFdUMmdLUlRsb1dsSk1ZVFo1ZWxOV2VFdHRjMDFuWkZoUVJWQjNZMWhhYTJVNWNuRlpXbEZ4YTFWSVQzZzRiRFEzV0c5ck56WkNVMWRyT1dGdk9HMVhhRlpLT0FwVGVYRXJVMmREU1VRMVlsRlJNMFJ0Vm1RNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTksydExhVFptUVdKUlZUWXlXbkJYYkVGTVdXZzRla2swUzFwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFdGWlhhVXBPWkRobWNtTlRhbEptZFZCMGNreGFXR3d5YVZCbGExbzVSVlpsWXpWemRIWlJjMmRLVkhCMWJDdElTUXBTTDFKUlJrZEZaakZUYUVGTWNIWnZZVkYxTlhKM00wTk5Ua1l6VUhSeU5ISldabkJuVHl0eVdXeDZaWEpHUWxadUwwbFBMemREYWxkelNISjJUa2huQ2xSMldFSlZaMFZsZUhsb1NqaHJjVUY0UldwSmIzYzNNRUV5WVZsR1FrRlNSemhYYTJ4SVRrVjZNVlZTZEhoYVYybEJVbVpCWVZCRFlqTnZVVXBFTlVnS2JFUmxaMGQzZEZsbU9WTjBXbWR3TlRWYWRtNTFURGhxVUdoVmFtMTVRMWh0YjNCWE5VeHNiRWhuVTFWblRsaDZSWGd3TlRJd0t6Z3pjelJXYmxCa1VBcEliRlpvYjJwa1lUbFZOQzl4V1RGMGMzbFJXbFptS3pOWVFWRjBXSHB1VDI5cGVWVk9ZbFp3SzNGUGMwTmxTVXRKUmtGbE4wUmpObTFZUWtKeFJHeDRDak5VZHk5VlZERTBVVVV4S3l0bVZIQXljVGt3UlZsMlowZG5VRXhoVFRGSFRIQnRWd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNjEyMDYwNTItNjIxYS00NDM0LWEyZjAtMjQyOWE1N2U3MWI3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA5ZWk5bzZoWFNydmgwT0JsQTJxZ29PTE4yTWtYUGxwYkRCRWp5SHJyOUtYZlJ0U3JYYlhJYVhBeA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGROVkVVeFRYcE5NVTVXYjFoRVZFMTZUVlJGZDAxVVJURk5lazB4VGxadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXRUQ2xRclIzTTBkbmhYU1RWdVpVbFNia3AyWWtORGEybDVNbVJhTDNSbWNESkRORWRKYmxaNFIyUmFSa1U1YUUxa2JVYzNNMDFJUmtkaVJHaG1TM1ZKVDIwS1pUTmhaSEZDU1ZSRlYyaHZVa3BIYldsd2RFeENkRFl5ZG1kQ1FtdERSa1JCVURWNmNISkZiVkF3TTFJd1RUTjFUMlZwVm5NeFFXSnVZM2RyYzBSblJ3bzJOVFJ5S3padFpGWlVRazAxYURGMVVuTTFNWHBOY0VoV1NGQlNlWFIwUzIxd1dqWjBhRVZuTjI4MFJtbEJWVWdyTmt3cmFHOVdha1owYTBabkx6QTBDak5aWkc4NFNISmlUQzlyVjA5eVNXMXhTbmN3UkRaSWFIWllTRmh5TTNSc09FMTJkM1J1V21adWR6bHVSR3B5UW14WU1rcE9aMDlCVFhsUVEzcFNjbmdLTkVwdU1FTk9VM2R6VERGRVJsWlJOQ3RNYVVNeE9YUlRZVEF5VjBkbU5sSXJORmhJUmtsSWFXOHlTMXBXUzJVeFlYbG1aRXRVTUdaRGVqVnhVbXhYU0FvM1dtdDVUVXAwYm1JMlFrZGFZMHR3YjFkRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS2NUZGFMMGsxZUZWbFZuRnRSa2hKVFVFNE5uRXZhVXc1ZFRSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ09FTnlSVmd6Y0V0NmVrUnJWa3BuYURWR2RrWTJaRkF2TUZkTFpsaEtWRUZQYUVsYVozQlRRakJqV0M4MGFuRjFlZ3B4VUhaeVR6TnhTMDVYU25KTVpVUkljU3Q0ZEZkaldWaHdWa0ZqVkdselZGTnNRMUpyVkN0akswRlBUMlJXWld0UmRFZGliMlV2Y1hsR1ozaHdlVU5PQ21kS2FrdFJTMEZtYkRKcVVWTjBTbEZuUmpSV1EwWjZaV0YyWmpFM1JDODVjWE5tZFVoQmIxcGtaMU4wV1ZkSVNrNDVhRVJ0VVRCak4wbE1lbTg1WVdnS1RIZFFOMEl5Ym5KMk1XMXFPVWQ1VWpaUE4xbEtTalJSYVV0RGFGQkNNamQxWlRKM015dFhTbWhHTTI1clpXcDVPVkpUWjNGWFFuSXZXV1pNY1dGbWFRcHhTbkJSVkZsa1duTlVZemRUZFRaT05qTnJPR1V3WVNzMlJqTkNVekUwYWs1T1p6RkZhMGRLVnpGUVJVZDNWbGxSWVV0RkszUk5ha294ZFZwSmJtVmhDbm96WVVwQ1MxTTFiMmh6YUhWeWNIa3JiVEpyVHpaRlNsWXlieXN6ZFVZMlMySlhad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vY2MwMzRiYzAtOTY4OS00NGY1LTlhNzItNGQ5OWFjZGJiY2FmLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBOczhnZ1FJYW01VUVWMUlvS0hKT2pxS2dOeUx2TDVHWVRPQXFRYnZwUkN6VzMzdWJvVGRXbHozNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -2835,7 +3497,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:13 GMT
+      - Thu, 02 Nov 2023 15:40:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2845,7 +3507,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7bcfa80b-33fc-4170-9ce8-e4c69fb99e01
+      - 6c4ac7e7-008c-4ea8-ae2b-677dc4e45c6c
     status: 200 OK
     code: 200
     duration: ""
@@ -2854,21 +3516,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/pools?name=tf-pool&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}],"total_count":1}'
+    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
-      - "643"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:13 GMT
+      - Thu, 02 Nov 2023 15:40:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2878,7 +3540,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2aa3f67b-f769-498f-9089-8d351a0d1ae8
+      - 8df62ffd-8fa0-495a-9c4a-b40d55b7e557
     status: 200 OK
     code: 200
     duration: ""
@@ -2887,21 +3549,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "642"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:13 GMT
+      - Thu, 02 Nov 2023 15:40:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2911,7 +3573,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6dc12c6b-2979-4c5e-974e-427035a463b3
+      - 0e45ece1-6973-4cc0-9ff4-893c9c10f813
     status: 200 OK
     code: 200
     duration: ""
@@ -2920,21 +3582,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:35.937628Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:51.686841Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "606"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:13 GMT
+      - Thu, 02 Nov 2023 15:40:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2944,7 +3606,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9464ae43-788f-489a-ad71-95c8e69e491d
+      - 37785bd5-bf91-4dc9-98ff-98f364be0e68
     status: 200 OK
     code: 200
     duration: ""
@@ -2953,21 +3615,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "642"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:13 GMT
+      - Thu, 02 Nov 2023 15:40:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2977,7 +3639,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c03d8db8-538b-43f6-beb8-47e788a9ac41
+      - a558dad2-02b8-47ef-bd92-4167f7cb0816
     status: 200 OK
     code: 200
     duration: ""
@@ -2986,21 +3648,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "642"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:13 GMT
+      - Thu, 02 Nov 2023 15:40:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3010,7 +3672,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f57f8c50-74fc-46a9-9083-71d54c1692b8
+      - a64b2af3-3288-4e54-ac00-359001684db5
     status: 200 OK
     code: 200
     duration: ""
@@ -3019,21 +3681,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "642"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 15:40:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3043,7 +3705,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e88c926e-c3cb-46ce-85ae-6d6d790ae430
+      - 3bb033e8-88ab-48bd-840a-347dcf6358c4
     status: 200 OK
     code: 200
     duration: ""
@@ -3052,21 +3714,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/pools?name=tf-pool&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}],"total_count":1}'
+    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
-      - "643"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 15:40:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3076,7 +3738,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27e9ef09-03c5-4b1a-9684-14c473b0c984
+      - acd6a2ec-e57c-4d71-8485-7e919fadc753
     status: 200 OK
     code: 200
     duration: ""
@@ -3085,21 +3747,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:51.686841Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "615"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 15:40:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3109,7 +3771,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f53870e4-4f1d-425d-b8bb-d18ddb9632b5
+      - 11b2b07f-0228-4d1d-854c-7c7372dfb31c
     status: 200 OK
     code: 200
     duration: ""
@@ -3118,21 +3780,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:35.937628Z"}],"total_count":1}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "606"
+      - "642"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 15:40:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3142,7 +3804,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0241244-6fa2-4d90-aee7-f944376377c3
+      - 5601c003-94a9-430b-b627-0f3d34b39a50
     status: 200 OK
     code: 200
     duration: ""
@@ -3151,21 +3813,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:35.937628Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:51.686841Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "606"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 15:40:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3175,7 +3837,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67366b30-faf2-473b-abef-67786a696f5a
+      - d42fc1b0-dd6d-4b53-83f6-39ba7b8632e3
     status: 200 OK
     code: 200
     duration: ""
@@ -3184,21 +3846,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7c0f88fe-47b2-44c5-be75-7e0d3766bc55
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:54:09.993032Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"created_at":"2023-11-02T15:33:53.182844Z","dhcp_enabled":true,"id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","name":"test-data-source-pool","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-02T15:33:53.182844Z","id":"8b259f89-423a-4607-9979-13dd7515cc29","subnet":"172.16.4.0/22","updated_at":"2023-11-02T15:33:53.182844Z"},{"created_at":"2023-11-02T15:33:53.182844Z","id":"05ee4fd6-0b54-497d-9684-b3673ddeb02c","subnet":"fd5f:519c:6d46:cb39::/64","updated_at":"2023-11-02T15:33:53.182844Z"}],"tags":[],"updated_at":"2023-11-02T15:33:53.182844Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "1324"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 15:40:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3208,7 +3870,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd2ec3da-ced9-455a-92e9-2cf972f26826
+      - 35200d5b-8ed6-42f7-991a-d40a5e7ff7a3
     status: 200 OK
     code: 200
     duration: ""
@@ -3217,12 +3879,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVeFRrUnJlRTFzYjFoRVZFMTZUVVJGZDAxVVJURk9SR3Q0VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTekV6Q25kMk4yaDRabkZoUW5WTVJtcHZSME0yTjA5TldIWmpiQ3N4UjFaNlVqbEhjbkZMZUZoV2MydHlVRU52YkdaUVR6ZzVXVkJUTTI1MlJYRjVhREozWVZJS1JWYzNkVlI1U0N0bWVXMDJSVVZyUVRaQmNEWjZNa2cwUWsxREszbENjM3BpVWtSVmNGVlBhblpoVTFGVVprMTRiek5aZEU1Tk1USkVMekJrVXpWa1NncE9kR3BRUWpSR2MwUkVUbVU0YjJFd2VVbG1VRzlYYkhwbGVITlFWSEV6YmxJemEzZ3pRbFpVWmtKTlNISlViakoyTUU5MldIbE5RM1ZQYjFreFRFSklDa3N2ZG05S2VFeEpWbkJKUVRWd1RFdEliak5pYkhSbWQyNTRhRk5tUkVGd2NrcHdjVEZDZDNKcGNIQXdiREpLVnpCS1JqRklRbWhsZFRkWE9XeFdUMmdLUlRsb1dsSk1ZVFo1ZWxOV2VFdHRjMDFuWkZoUVJWQjNZMWhhYTJVNWNuRlpXbEZ4YTFWSVQzZzRiRFEzV0c5ck56WkNVMWRyT1dGdk9HMVhhRlpLT0FwVGVYRXJVMmREU1VRMVlsRlJNMFJ0Vm1RNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTksydExhVFptUVdKUlZUWXlXbkJYYkVGTVdXZzRla2swUzFwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFdGWlhhVXBPWkRobWNtTlRhbEptZFZCMGNreGFXR3d5YVZCbGExbzVSVlpsWXpWemRIWlJjMmRLVkhCMWJDdElTUXBTTDFKUlJrZEZaakZUYUVGTWNIWnZZVkYxTlhKM00wTk5Ua1l6VUhSeU5ISldabkJuVHl0eVdXeDZaWEpHUWxadUwwbFBMemREYWxkelNISjJUa2huQ2xSMldFSlZaMFZsZUhsb1NqaHJjVUY0UldwSmIzYzNNRUV5WVZsR1FrRlNSemhYYTJ4SVRrVjZNVlZTZEhoYVYybEJVbVpCWVZCRFlqTnZVVXBFTlVnS2JFUmxaMGQzZEZsbU9WTjBXbWR3TlRWYWRtNTFURGhxVUdoVmFtMTVRMWh0YjNCWE5VeHNiRWhuVTFWblRsaDZSWGd3TlRJd0t6Z3pjelJXYmxCa1VBcEliRlpvYjJwa1lUbFZOQzl4V1RGMGMzbFJXbFptS3pOWVFWRjBXSHB1VDI5cGVWVk9ZbFp3SzNGUGMwTmxTVXRKUmtGbE4wUmpObTFZUWtKeFJHeDRDak5VZHk5VlZERTBVVVV4S3l0bVZIQXljVGt3UlZsMlowZG5VRXhoVFRGSFRIQnRWd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNjEyMDYwNTItNjIxYS00NDM0LWEyZjAtMjQyOWE1N2U3MWI3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA5ZWk5bzZoWFNydmgwT0JsQTJxZ29PTE4yTWtYUGxwYkRCRWp5SHJyOUtYZlJ0U3JYYlhJYVhBeA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:40:15.523704Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1453"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:40:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 842d4c2d-dadf-4c54-bf54-2ca8aaef612c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGROVkVVeFRYcE5NVTVXYjFoRVZFMTZUVlJGZDAxVVJURk5lazB4VGxadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXRUQ2xRclIzTTBkbmhYU1RWdVpVbFNia3AyWWtORGEybDVNbVJhTDNSbWNESkRORWRKYmxaNFIyUmFSa1U1YUUxa2JVYzNNMDFJUmtkaVJHaG1TM1ZKVDIwS1pUTmhaSEZDU1ZSRlYyaHZVa3BIYldsd2RFeENkRFl5ZG1kQ1FtdERSa1JCVURWNmNISkZiVkF3TTFJd1RUTjFUMlZwVm5NeFFXSnVZM2RyYzBSblJ3bzJOVFJ5S3padFpGWlVRazAxYURGMVVuTTFNWHBOY0VoV1NGQlNlWFIwUzIxd1dqWjBhRVZuTjI4MFJtbEJWVWdyTmt3cmFHOVdha1owYTBabkx6QTBDak5aWkc4NFNISmlUQzlyVjA5eVNXMXhTbmN3UkRaSWFIWllTRmh5TTNSc09FMTJkM1J1V21adWR6bHVSR3B5UW14WU1rcE9aMDlCVFhsUVEzcFNjbmdLTkVwdU1FTk9VM2R6VERGRVJsWlJOQ3RNYVVNeE9YUlRZVEF5VjBkbU5sSXJORmhJUmtsSWFXOHlTMXBXUzJVeFlYbG1aRXRVTUdaRGVqVnhVbXhYU0FvM1dtdDVUVXAwYm1JMlFrZGFZMHR3YjFkRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS2NUZGFMMGsxZUZWbFZuRnRSa2hKVFVFNE5uRXZhVXc1ZFRSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ09FTnlSVmd6Y0V0NmVrUnJWa3BuYURWR2RrWTJaRkF2TUZkTFpsaEtWRUZQYUVsYVozQlRRakJqV0M4MGFuRjFlZ3B4VUhaeVR6TnhTMDVYU25KTVpVUkljU3Q0ZEZkaldWaHdWa0ZqVkdselZGTnNRMUpyVkN0akswRlBUMlJXWld0UmRFZGliMlV2Y1hsR1ozaHdlVU5PQ21kS2FrdFJTMEZtYkRKcVVWTjBTbEZuUmpSV1EwWjZaV0YyWmpFM1JDODVjWE5tZFVoQmIxcGtaMU4wV1ZkSVNrNDVhRVJ0VVRCak4wbE1lbTg1WVdnS1RIZFFOMEl5Ym5KMk1XMXFPVWQ1VWpaUE4xbEtTalJSYVV0RGFGQkNNamQxWlRKM015dFhTbWhHTTI1clpXcDVPVkpUWjNGWFFuSXZXV1pNY1dGbWFRcHhTbkJSVkZsa1duTlVZemRUZFRaT05qTnJPR1V3WVNzMlJqTkNVekUwYWs1T1p6RkZhMGRLVnpGUVJVZDNWbGxSWVV0RkszUk5ha294ZFZwSmJtVmhDbm96WVVwQ1MxTTFiMmh6YUhWeWNIa3JiVEpyVHpaRlNsWXlieXN6ZFVZMlMySlhad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vY2MwMzRiYzAtOTY4OS00NGY1LTlhNzItNGQ5OWFjZGJiY2FmLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBOczhnZ1FJYW01VUVWMUlvS0hKT2pxS2dOeUx2TDVHWVRPQXFRYnZwUkN6VzMzdWJvVGRXbHozNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -3231,7 +3926,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 15:40:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3241,7 +3936,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 240876eb-bb78-469b-b98c-2af607238f79
+      - 9a393840-1ab3-4de5-af96-7661c8269e8d
     status: 200 OK
     code: 200
     duration: ""
@@ -3250,21 +3945,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "642"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 15:40:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3274,7 +3969,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 077873d7-a04a-4257-b9e7-d739b8ef1a29
+      - 88e27911-a3e9-4125-960c-eeaba07d5ca8
     status: 200 OK
     code: 200
     duration: ""
@@ -3283,21 +3978,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:35.937628Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:51.686841Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "606"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 15:40:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3307,7 +4002,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bea62d76-e737-4f1d-9894-7ac8c0892c44
+      - a8460d43-7df5-4b6f-bf60-fd0b5db116a9
     status: 200 OK
     code: 200
     duration: ""
@@ -3316,21 +4011,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "642"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 15:40:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3340,7 +4035,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 210609bc-6794-451d-b826-2b7700c0d74b
+      - 947affd8-7618-457b-b5a7-f586fd27dae7
     status: 200 OK
     code: 200
     duration: ""
@@ -3349,21 +4044,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/pools?name=tf-pool&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}],"total_count":1}'
+    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
-      - "643"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 15:40:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3373,7 +4068,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 902c5a18-f673-4b37-a58f-326dff1dab15
+      - 1cd7a3f4-4222-4cef-b454-105d553406af
     status: 200 OK
     code: 200
     duration: ""
@@ -3382,21 +4077,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:35.937628Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:51.686841Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "606"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 15:40:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3406,7 +4101,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7cd9711-4807-4a28-8808-4c6597df2d1d
+      - cb0230dc-ed77-4607-b02f-ddbac0ad3886
     status: 200 OK
     code: 200
     duration: ""
@@ -3415,21 +4110,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "642"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 15:40:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3439,7 +4134,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2da491b-690a-4242-825d-4a4aa0133eaa
+      - 0c5ad6f3-14a3-4678-977e-82cc5e4deff4
     status: 200 OK
     code: 200
     duration: ""
@@ -3448,21 +4143,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:35.937628Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:51.686841Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "606"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 15:40:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3472,7 +4167,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01ec6cf7-2974-438e-9faf-178bc19df415
+      - ccff9e0d-9be4-4ac3-99ae-716b71b34e43
     status: 200 OK
     code: 200
     duration: ""
@@ -3481,21 +4176,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "642"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 15:40:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3505,7 +4200,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc05965f-eb63-46b1-a1e3-c45a0194f2c4
+      - a9ae5d7a-48c5-4bca-932b-5b7ef3eaeda0
     status: 200 OK
     code: 200
     duration: ""
@@ -3514,21 +4209,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/pools?name=tf-pool&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}],"total_count":1}'
+    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
-      - "643"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 15:40:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3538,7 +4233,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3283cf0d-0535-45f2-9b54-9d4fc486c2c0
+      - e8412d4f-017a-466f-b4d3-6b66b6fb9ea3
     status: 200 OK
     code: 200
     duration: ""
@@ -3547,21 +4242,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:35.937628Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:51.686841Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "606"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 15:40:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3571,7 +4266,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a414b73-e6eb-4859-a2a8-3afca24362b5
+      - 17734774-b9b1-4454-8a02-927706b4cf64
     status: 200 OK
     code: 200
     duration: ""
@@ -3580,21 +4275,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "642"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 15:40:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3604,7 +4299,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5f44d78-87f7-448f-a20f-24fee31ce1f5
+      - 4bf436e0-a181-4bd4-8f8f-4d160a9c4c79
     status: 200 OK
     code: 200
     duration: ""
@@ -3613,21 +4308,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:35.937628Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:51.686841Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "606"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 15:40:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3637,7 +4332,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce75f877-54f6-4b90-b86d-e6eca26f31e3
+      - c7122a9d-8d28-4c7a-9612-c2bf1ca34a98
     status: 200 OK
     code: 200
     duration: ""
@@ -3646,21 +4341,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
     method: DELETE
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:54:15.059116293Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:40:22.611178892Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "621"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:15 GMT
+      - Thu, 02 Nov 2023 15:40:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3670,7 +4365,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef1d143e-c132-4553-9a9f-6b3378feba08
+      - 4459d860-742e-44d4-8566-27fde546dbc7
     status: 200 OK
     code: 200
     duration: ""
@@ -3679,21 +4374,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:54:15.146354947Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:40:22.693681518Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1330"
+      - "1459"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:15 GMT
+      - Thu, 02 Nov 2023 15:40:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3703,7 +4398,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aec0af3d-6902-4f23-8d3a-395d061ca436
+      - 0aa20a3c-c66a-47cb-935f-5e78d6b7a009
     status: 200 OK
     code: 200
     duration: ""
@@ -3712,21 +4407,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:54:15.146355Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:40:22.693682Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1327"
+      - "1456"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:15 GMT
+      - Thu, 02 Nov 2023 15:40:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3736,7 +4431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fd17f93-4bb0-4aa3-86aa-c237cf10dbf9
+      - 44961d33-815d-4bd8-94eb-dea38d2f97bb
     status: 200 OK
     code: 200
     duration: ""
@@ -3745,21 +4440,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:54:15.146355Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:40:22.693682Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1327"
+      - "1456"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:20 GMT
+      - Thu, 02 Nov 2023 15:40:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3769,7 +4464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 747f76d5-b065-4912-a74a-64cbe213e21a
+      - 63b6c9c5-3b6d-43f5-ae89-c7fda448355c
     status: 200 OK
     code: 200
     duration: ""
@@ -3778,21 +4473,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:54:15.146355Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:40:22.693682Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1327"
+      - "1456"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:25 GMT
+      - Thu, 02 Nov 2023 15:40:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3802,7 +4497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4780d2df-fb3f-4a8e-8203-bd6188aa06b5
+      - 1ff96878-3508-41cd-ad7c-b177db3fabe9
     status: 200 OK
     code: 200
     duration: ""
@@ -3811,21 +4506,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:54:15.146355Z","upgrade_available":false,"version":"1.24.7"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:40:22.693682Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1327"
+      - "1456"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:30 GMT
+      - Thu, 02 Nov 2023 15:40:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3835,7 +4530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b68461ea-d4a6-47a6-8d53-ef734aa94798
+      - 44eb12e5-a7c8-44e0-8eda-71a4242ce82e
     status: 200 OK
     code: 200
     duration: ""
@@ -3844,12 +4539,78 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"61206052-621a-4434-a2f0-2429a57e71b7","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:40:22.693682Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1456"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:40:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3d24faa0-4fb1-434f-b11a-4079f7672b22
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:40:22.693682Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1456"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:40:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a724d997-ffbd-4859-ab29-39c2187c69db
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3858,7 +4619,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:35 GMT
+      - Thu, 02 Nov 2023 15:40:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3868,7 +4629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 303af0f0-1f91-4d12-8206-ab2b36ec0f97
+      - 224f167a-a532-4054-b746-5d3f520e4131
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3877,21 +4638,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
-    method: GET
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7c0f88fe-47b2-44c5-be75-7e0d3766bc55
+    method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"61206052-621a-4434-a2f0-2429a57e71b7","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","type":"not_found"}'
     headers:
       Content-Length:
-      - "128"
+      - "136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Jan 2023 15:54:35 GMT
+      - Thu, 02 Nov 2023 15:40:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3901,7 +4662,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 076ef259-8554-4af8-ba03-7955ce363291
+      - d59da220-6249-4795-a1d8-898a59b08fea
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 15:40:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 475bbfc9-f4c4-4ce0-94c7-5e02379c5607
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
Fixes the current error in the nightly tests. Private networks were added in the tests in #2172 but I missed the data source test for the pools.