### PR TITLE
feat(rdb): allow actions to handle a full disk situation

### DIFF
--- a/docs/resources/rdb_instance.md
+++ b/docs/resources/rdb_instance.md
@@ -119,6 +119,9 @@ The following arguments are supported:
 ~> **Important:** Updates to `node_type` will upgrade the Database Instance to the desired `node_type` without any
 interruption. Keep in mind that you cannot downgrade a Database Instance.
 
+~> **Important:** Once your instance reaches `disk_full` status, if you are using `lssd` storage, you should upgrade the node_type,
+and if you are using `bssd` storage, you should increase the volume size before making any other change to your instance.
+
 - `engine` - (Required) Database Instance's engine version (e.g. `PostgreSQL-11`).
 
 ~> **Important:** Updates to `engine` will recreate the Database Instance.
@@ -126,6 +129,8 @@ interruption. Keep in mind that you cannot downgrade a Database Instance.
 - `volume_type` - (Optional, default to `lssd`) Type of volume where data are stored (`bssd` or `lssd`).
 
 - `volume_size_in_gb` - (Optional) Volume size (in GB) when `volume_type` is set to `bssd`.
+
+~> **Important:** Once your instance reaches `disk_full` status, you should increase the volume size before making any other change to your instance.
 
 - `user_name` - (Optional) Identifier for the first user of the database instance.
 

--- a/scaleway/testdata/data-source-rdb-acl-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-rdb-acl-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:03 GMT
+      - Thu, 02 Nov 2023 18:46:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1386f343-fc3c-430d-82d5-33557bdcace4
+      - cb8fe6be-4537-4197-a247-df449b291f18
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayDataSourceRDBAcl_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayDataSourceRDBAcl_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "780"
+      - "753"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:10 GMT
+      - Thu, 02 Nov 2023 18:46:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15bc044c-5fd5-4538-a056-904afc046a90
+      - c727a597-fd36-4114-92d7-e018366f9352
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "780"
+      - "753"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:10 GMT
+      - Thu, 02 Nov 2023 18:46:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa3c4e64-c93c-435d-88c8-db7cd30acdd9
+      - 98916dad-c143-4f55-90be-deef6f85762c
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "780"
+      - "753"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:40 GMT
+      - Thu, 02 Nov 2023 18:47:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ac90a23-663c-45f6-a7b4-f2a1f1662ac0
+      - d3533768-6902-4bf7-981a-215fca7ebd81
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "780"
+      - "753"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:52:11 GMT
+      - Thu, 02 Nov 2023 18:47:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53a7c265-7fe1-482e-958a-457971a60067
+      - ebdb483f-bc8a-452e-bb03-ced201ebdc49
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "780"
+      - "753"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:52:41 GMT
+      - Thu, 02 Nov 2023 18:48:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba058e6a-b216-47ec-89c3-9e888fe19251
+      - 1a339142-6396-4611-b920-f76ccbcc8112
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "780"
+      - "753"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:53:11 GMT
+      - Thu, 02 Nov 2023 18:48:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba2af0e8-bed5-458f-b6ab-c7606814bdfc
+      - f056fbfd-33bf-4061-848a-6ba65afcee08
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "780"
+      - "753"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:53:41 GMT
+      - Thu, 02 Nov 2023 18:49:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2045a93f-9ac2-4503-bbf0-3f7c935535bc
+      - f0387883-f994-4c9b-9c44-519ced9a3ffd
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,12 +594,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14e9ecf6-ff34-4e98-a08d-c4453fe5f66c
+      - a11cff5f-316b-4803-a60c-f3806ec4bf48
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"backup_schedule_frequency":null,"backup_schedule_retention":null,"is_backup_schedule_disabled":false,"name":null,"tags":null,"logs_policy":null,"backup_same_region":false,"backup_schedule_start_hour":null}'
+    body: '{"is_backup_schedule_disabled":false,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -607,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da350ca6-6952-46f6-a664-298913b124ff
+      - f74c37e1-84aa-4ffa-b66d-754f34475867
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15ce1c3a-6e67-4afb-9c39-2536dc865611
+      - 817bebba-ef18-44b1-a691-25205ddfecfc
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVVTNNQ3VSTnErT0ZFS0ZDc1B2dVF6UHJsekxjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU9Gb1hEVE16TVRBeE56RTFOVEUxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFxZXNmSXhTcXJ5UWVTVnF2WVVIQ1JEelZkTXcwd280ZU52dGNnUUdBSFRWRXZWYklFTzBTbmJ3cnZMOEYKZ3U5ZjZ6RXlZVzlKSnZjRThjVVVDcThDcDA2cWRVRHFkLysvUGFMM2tISHVTWjRMbE5paUpsL0FEMTBGUkJaVApNeVpjUEQxVTZkdUlxcms5T2lSeTRGem1MSUJCRG8xUzVvcG5TYnRaNVlCYnJac2lSNko0MS9FY0lXWkNuM2E1CnVneEoyUTh6cHJ6RGhvOEI5aXJndVMxVzQrL3c0KzltTTQvalU5RXBSbGlqdGtQaFNTTlpsdWxKZUYwNXI0VmMKeUV0czFjSDl4MW1sZnZVS0JFamoxNTlnV09yNE01dkFsMkxvZXdVQnNDMXNLZnRxKzhReTNuc0N4Y2pTSjIxNwpNdG5wcmU3SVhoTU1nQ08vUGlMTjhhYzNqUUlEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdFlqQXhZVFJtWTJZdE9XRmpNQzAwT0dJM0xUaG1PVFF0TW1VNFlXRXdNemt4TVdWakxuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5rVkFod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUJ3Vkh4a3p2cXNMNEx3bk5sYlpxOU1RVUpFNmp3aXhPZ0RSTTlGUmI2MW9qRUkvcERHTkVnZVNzbEpiZG1KCllHaEl6V1doalJSbGhxbitSalRIRHkzMUkrVURKaUpJVXh6Mng5OEdlNUVtT0VINmtadDNETVBuNGRXL3JPbDQKODJGbDk4cjJKOEhld2pwSW1vNGRZSGs5MVJrbC9Ld2YwU1kyK3FjNW1EcVJTOUpRWThQaC9Iekx0MWV0czZOMQptaHNXTTJpaFhYU0hjSnJuK2FTNUY2LzNmcmpWcndUSkplcndTK20zZ1h5ZEdJWjJadFhQZ1c4aW9wYzNrclh4CnNkd0ZKaGVLbkNhREJDSUd0K3htcEFsN3V4RjNVN1hRRGFhMlNOVnZLTkRKYi94aWhycFNCUDVGWUhGcmYxWWcKRDVMbEhBS2NOVHFpSDFXWm55YTNRd1I5Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVWnMvc0VPTTZIVzlJbkRoK2had1l0a0RCNlQ0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXlXaGNOTXpNeE1ETXdNVGcwTnpJeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxXNmtJT2x3TDIzSTNHK3dVR0Q1UDdjNnZIc1EzQy9lREtUcGorVkZkU1cxajVtVUlxdGNna28KZDZVSmhNY1FPMVZMK0JwWWhjZjlINmVwQXFvaHZvaEJuYWNPK0gvRHY0aGl1dnF0VEV5MGNJNXV5NHRiaEtzMApDUDJRZkdpa2dnOHNLb2YzWVZDejlLK2dQcE9jR0ZPWTdtK09td25GVGZjTEdnRHFjdU52MkZITVlVUW1lVUluCkYyU2hybEpQMjJhZzBJY2xZb0RSdFZpV1JnVEMrR05jV2lBbXdsaDBZWnRTYWJPS1Jxakh6OTFpQlBDSE1BWnYKdWxUbWg5UWRYVkgwdkV1NDVMUDY1YUhpZzdUV1g5UUF3WnNPOGlvZkc5cmUwUHVMTHYzZ3dGNGZBNEVoa0xnagpPR3B3VGFOSUpPdDIxSktkTWd1RG9zK0hpMXZ4MmowQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0TVRZeFpHSTFPREV0TkdRM09DMDBNbU14TFdGbE5EQXROR1ZsWmpkbFlUVTMKTXpFeExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpNYmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1prZktBM2NhZittVGx6S1VUMDJVekRlQk9Ya0gyR2RYQ1dJaFo5cStWd0pueW1qRTkwRXlVCkNRdjBYK05oQ1VFdnJUZ1R2UHJGTzF2MHd2ZjVUM0ppS1lsMDNxZENmTWI2SDlWZEFFOGc0SHJjb21sT2JMMGsKWElZeVMvai9iWmtQa2U1dXlxQTdWcmt4WEVDYmtyU2pjUjFTdnFHMFczWXRvR2o1dUVBZzNXWWFPalJrczdZTApsYmlZVDRjclJKYnljMUM1MkRpUDQ2ZVRKR3BCUnRDRUtpbW9jRDhJRVlNNjIwTjZPZmdIQmFrT2c5WFBRSVBYCjN2K0l6SzhYZUpHRmptbFE5SnZlMUptNGFzZkJzeGgrbzFaY2ZnS1hpV0hob3FjcWNjeE5WRTNMZCtwdFhnRkUKdzZGdDJuWnNRdld6NXRMVEN0eFBiV0VMZitsZGUzamIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:49:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25e293d3-49c8-4120-a85c-7c428e848dfb
+      - 07078e70-cbdf-41ea-b9f5-169731fa05e0
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:12 GMT
+      - Thu, 02 Nov 2023 18:49:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3209edf3-2d8c-441c-93d9-0c264117a44b
+      - 95cab0fb-314b-4513-96d6-c0d45811adea
     status: 200 OK
     code: 200
     duration: ""
@@ -741,19 +741,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
     method: PUT
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":22504,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":22504,"protocol":"tcp"}]}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}]}'
     headers:
       Content-Length:
-      - "240"
+      - "229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:12 GMT
+      - Thu, 02 Nov 2023 18:49:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +763,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1d292b1-ee83-4a59-8d41-0afb2ebe8aa9
+      - 1726f6db-7c3f-4ed0-a122-7396401bc42a
     status: 200 OK
     code: 200
     duration: ""
@@ -774,19 +774,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1274"
+      - "1232"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:12 GMT
+      - Thu, 02 Nov 2023 18:49:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0d9b35f-da3f-42d3-a033-cef878a77f3b
+      - 888b7d37-1a36-420b-87bd-f566295c88d3
     status: 200 OK
     code: 200
     duration: ""
@@ -807,19 +807,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:42 GMT
+      - Thu, 02 Nov 2023 18:50:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca52bd37-2c23-4ef1-82a4-7c5219ba32eb
+      - fb52f405-f509-4e2f-901e-ed1a19c71eee
     status: 200 OK
     code: 200
     duration: ""
@@ -840,19 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":22504,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":22504,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "257"
+      - "245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:42 GMT
+      - Thu, 02 Nov 2023 18:50:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8208df07-7e91-4f3b-81db-9b478915022a
+      - 6cd07ebc-28a1-42cf-be51-12c481a2ee26
     status: 200 OK
     code: 200
     duration: ""
@@ -873,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:43 GMT
+      - Thu, 02 Nov 2023 18:50:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9d77e35-1206-405c-b8fc-364b252ce11b
+      - ef4a882c-c161-4d43-aaaf-1e3847956c11
     status: 200 OK
     code: 200
     duration: ""
@@ -906,19 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVVTNNQ3VSTnErT0ZFS0ZDc1B2dVF6UHJsekxjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU9Gb1hEVE16TVRBeE56RTFOVEUxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFxZXNmSXhTcXJ5UWVTVnF2WVVIQ1JEelZkTXcwd280ZU52dGNnUUdBSFRWRXZWYklFTzBTbmJ3cnZMOEYKZ3U5ZjZ6RXlZVzlKSnZjRThjVVVDcThDcDA2cWRVRHFkLysvUGFMM2tISHVTWjRMbE5paUpsL0FEMTBGUkJaVApNeVpjUEQxVTZkdUlxcms5T2lSeTRGem1MSUJCRG8xUzVvcG5TYnRaNVlCYnJac2lSNko0MS9FY0lXWkNuM2E1CnVneEoyUTh6cHJ6RGhvOEI5aXJndVMxVzQrL3c0KzltTTQvalU5RXBSbGlqdGtQaFNTTlpsdWxKZUYwNXI0VmMKeUV0czFjSDl4MW1sZnZVS0JFamoxNTlnV09yNE01dkFsMkxvZXdVQnNDMXNLZnRxKzhReTNuc0N4Y2pTSjIxNwpNdG5wcmU3SVhoTU1nQ08vUGlMTjhhYzNqUUlEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdFlqQXhZVFJtWTJZdE9XRmpNQzAwT0dJM0xUaG1PVFF0TW1VNFlXRXdNemt4TVdWakxuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5rVkFod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUJ3Vkh4a3p2cXNMNEx3bk5sYlpxOU1RVUpFNmp3aXhPZ0RSTTlGUmI2MW9qRUkvcERHTkVnZVNzbEpiZG1KCllHaEl6V1doalJSbGhxbitSalRIRHkzMUkrVURKaUpJVXh6Mng5OEdlNUVtT0VINmtadDNETVBuNGRXL3JPbDQKODJGbDk4cjJKOEhld2pwSW1vNGRZSGs5MVJrbC9Ld2YwU1kyK3FjNW1EcVJTOUpRWThQaC9Iekx0MWV0czZOMQptaHNXTTJpaFhYU0hjSnJuK2FTNUY2LzNmcmpWcndUSkplcndTK20zZ1h5ZEdJWjJadFhQZ1c4aW9wYzNrclh4CnNkd0ZKaGVLbkNhREJDSUd0K3htcEFsN3V4RjNVN1hRRGFhMlNOVnZLTkRKYi94aWhycFNCUDVGWUhGcmYxWWcKRDVMbEhBS2NOVHFpSDFXWm55YTNRd1I5Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVWnMvc0VPTTZIVzlJbkRoK2had1l0a0RCNlQ0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXlXaGNOTXpNeE1ETXdNVGcwTnpJeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxXNmtJT2x3TDIzSTNHK3dVR0Q1UDdjNnZIc1EzQy9lREtUcGorVkZkU1cxajVtVUlxdGNna28KZDZVSmhNY1FPMVZMK0JwWWhjZjlINmVwQXFvaHZvaEJuYWNPK0gvRHY0aGl1dnF0VEV5MGNJNXV5NHRiaEtzMApDUDJRZkdpa2dnOHNLb2YzWVZDejlLK2dQcE9jR0ZPWTdtK09td25GVGZjTEdnRHFjdU52MkZITVlVUW1lVUluCkYyU2hybEpQMjJhZzBJY2xZb0RSdFZpV1JnVEMrR05jV2lBbXdsaDBZWnRTYWJPS1Jxakh6OTFpQlBDSE1BWnYKdWxUbWg5UWRYVkgwdkV1NDVMUDY1YUhpZzdUV1g5UUF3WnNPOGlvZkc5cmUwUHVMTHYzZ3dGNGZBNEVoa0xnagpPR3B3VGFOSUpPdDIxSktkTWd1RG9zK0hpMXZ4MmowQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0TVRZeFpHSTFPREV0TkdRM09DMDBNbU14TFdGbE5EQXROR1ZsWmpkbFlUVTMKTXpFeExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpNYmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1prZktBM2NhZittVGx6S1VUMDJVekRlQk9Ya0gyR2RYQ1dJaFo5cStWd0pueW1qRTkwRXlVCkNRdjBYK05oQ1VFdnJUZ1R2UHJGTzF2MHd2ZjVUM0ppS1lsMDNxZENmTWI2SDlWZEFFOGc0SHJjb21sT2JMMGsKWElZeVMvai9iWmtQa2U1dXlxQTdWcmt4WEVDYmtyU2pjUjFTdnFHMFczWXRvR2o1dUVBZzNXWWFPalJrczdZTApsYmlZVDRjclJKYnljMUM1MkRpUDQ2ZVRKR3BCUnRDRUtpbW9jRDhJRVlNNjIwTjZPZmdIQmFrT2c5WFBRSVBYCjN2K0l6SzhYZUpHRmptbFE5SnZlMUptNGFzZkJzeGgrbzFaY2ZnS1hpV0hob3FjcWNjeE5WRTNMZCtwdFhnRkUKdzZGdDJuWnNRdld6NXRMVEN0eFBiV0VMZitsZGUzamIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:43 GMT
+      - Thu, 02 Nov 2023 18:50:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3fb498ef-34a1-4603-84e3-ae94a7483af3
+      - 9235daa2-79c3-4e13-bc5d-ff6c29520ebc
     status: 200 OK
     code: 200
     duration: ""
@@ -939,19 +939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:43 GMT
+      - Thu, 02 Nov 2023 18:50:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d18eea5c-e027-47b4-8200-1ff2e9036f38
+      - 82afcab5-0453-4f2a-9aae-b1b5a0f31552
     status: 200 OK
     code: 200
     duration: ""
@@ -972,19 +972,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":22504,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":22504,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "257"
+      - "245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:43 GMT
+      - Thu, 02 Nov 2023 18:50:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb380ce9-9a32-447f-8517-4bf6516d5489
+      - 111aa8d4-7a46-4459-a406-c650610d0c76
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,19 +1005,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:44 GMT
+      - Thu, 02 Nov 2023 18:50:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c271d3a1-9198-4ccd-833b-0a48b15e2995
+      - 00980610-e79b-4a92-8c15-ff1af2ca116a
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +1038,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVVTNNQ3VSTnErT0ZFS0ZDc1B2dVF6UHJsekxjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU9Gb1hEVE16TVRBeE56RTFOVEUxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFxZXNmSXhTcXJ5UWVTVnF2WVVIQ1JEelZkTXcwd280ZU52dGNnUUdBSFRWRXZWYklFTzBTbmJ3cnZMOEYKZ3U5ZjZ6RXlZVzlKSnZjRThjVVVDcThDcDA2cWRVRHFkLysvUGFMM2tISHVTWjRMbE5paUpsL0FEMTBGUkJaVApNeVpjUEQxVTZkdUlxcms5T2lSeTRGem1MSUJCRG8xUzVvcG5TYnRaNVlCYnJac2lSNko0MS9FY0lXWkNuM2E1CnVneEoyUTh6cHJ6RGhvOEI5aXJndVMxVzQrL3c0KzltTTQvalU5RXBSbGlqdGtQaFNTTlpsdWxKZUYwNXI0VmMKeUV0czFjSDl4MW1sZnZVS0JFamoxNTlnV09yNE01dkFsMkxvZXdVQnNDMXNLZnRxKzhReTNuc0N4Y2pTSjIxNwpNdG5wcmU3SVhoTU1nQ08vUGlMTjhhYzNqUUlEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdFlqQXhZVFJtWTJZdE9XRmpNQzAwT0dJM0xUaG1PVFF0TW1VNFlXRXdNemt4TVdWakxuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5rVkFod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUJ3Vkh4a3p2cXNMNEx3bk5sYlpxOU1RVUpFNmp3aXhPZ0RSTTlGUmI2MW9qRUkvcERHTkVnZVNzbEpiZG1KCllHaEl6V1doalJSbGhxbitSalRIRHkzMUkrVURKaUpJVXh6Mng5OEdlNUVtT0VINmtadDNETVBuNGRXL3JPbDQKODJGbDk4cjJKOEhld2pwSW1vNGRZSGs5MVJrbC9Ld2YwU1kyK3FjNW1EcVJTOUpRWThQaC9Iekx0MWV0czZOMQptaHNXTTJpaFhYU0hjSnJuK2FTNUY2LzNmcmpWcndUSkplcndTK20zZ1h5ZEdJWjJadFhQZ1c4aW9wYzNrclh4CnNkd0ZKaGVLbkNhREJDSUd0K3htcEFsN3V4RjNVN1hRRGFhMlNOVnZLTkRKYi94aWhycFNCUDVGWUhGcmYxWWcKRDVMbEhBS2NOVHFpSDFXWm55YTNRd1I5Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVWnMvc0VPTTZIVzlJbkRoK2had1l0a0RCNlQ0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXlXaGNOTXpNeE1ETXdNVGcwTnpJeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxXNmtJT2x3TDIzSTNHK3dVR0Q1UDdjNnZIc1EzQy9lREtUcGorVkZkU1cxajVtVUlxdGNna28KZDZVSmhNY1FPMVZMK0JwWWhjZjlINmVwQXFvaHZvaEJuYWNPK0gvRHY0aGl1dnF0VEV5MGNJNXV5NHRiaEtzMApDUDJRZkdpa2dnOHNLb2YzWVZDejlLK2dQcE9jR0ZPWTdtK09td25GVGZjTEdnRHFjdU52MkZITVlVUW1lVUluCkYyU2hybEpQMjJhZzBJY2xZb0RSdFZpV1JnVEMrR05jV2lBbXdsaDBZWnRTYWJPS1Jxakh6OTFpQlBDSE1BWnYKdWxUbWg5UWRYVkgwdkV1NDVMUDY1YUhpZzdUV1g5UUF3WnNPOGlvZkc5cmUwUHVMTHYzZ3dGNGZBNEVoa0xnagpPR3B3VGFOSUpPdDIxSktkTWd1RG9zK0hpMXZ4MmowQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0TVRZeFpHSTFPREV0TkdRM09DMDBNbU14TFdGbE5EQXROR1ZsWmpkbFlUVTMKTXpFeExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpNYmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1prZktBM2NhZittVGx6S1VUMDJVekRlQk9Ya0gyR2RYQ1dJaFo5cStWd0pueW1qRTkwRXlVCkNRdjBYK05oQ1VFdnJUZ1R2UHJGTzF2MHd2ZjVUM0ppS1lsMDNxZENmTWI2SDlWZEFFOGc0SHJjb21sT2JMMGsKWElZeVMvai9iWmtQa2U1dXlxQTdWcmt4WEVDYmtyU2pjUjFTdnFHMFczWXRvR2o1dUVBZzNXWWFPalJrczdZTApsYmlZVDRjclJKYnljMUM1MkRpUDQ2ZVRKR3BCUnRDRUtpbW9jRDhJRVlNNjIwTjZPZmdIQmFrT2c5WFBRSVBYCjN2K0l6SzhYZUpHRmptbFE5SnZlMUptNGFzZkJzeGgrbzFaY2ZnS1hpV0hob3FjcWNjeE5WRTNMZCtwdFhnRkUKdzZGdDJuWnNRdld6NXRMVEN0eFBiV0VMZitsZGUzamIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:44 GMT
+      - Thu, 02 Nov 2023 18:50:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 964c129c-354d-40b0-8817-a710891d46e3
+      - 3eb2edc9-f90b-44bb-9bd7-9b61bf519c08
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +1071,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:44 GMT
+      - Thu, 02 Nov 2023 18:50:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57d320ac-5aa8-4fac-8d3e-a7e8099c8f5d
+      - 9d53bae2-4510-4e6c-89d5-fb65defbc4a5
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,19 +1104,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:44 GMT
+      - Thu, 02 Nov 2023 18:50:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aeb242cb-f36e-48d0-ba21-7e9b668e5c62
+      - 7fb3f25e-ef50-4325-b146-8cb14c32978e
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,19 +1137,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":22504,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":22504,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "257"
+      - "245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:44 GMT
+      - Thu, 02 Nov 2023 18:50:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7207f7aa-f398-4703-b262-9d438c8c8a8b
+      - cea169f2-ba30-45e0-98f4-61be25f06ce2
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,19 +1170,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":22504,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":22504,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "257"
+      - "245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:44 GMT
+      - Thu, 02 Nov 2023 18:50:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a77aed0-a3d1-4c08-93aa-66ecb1f3d807
+      - 0d2c42f9-3d1c-4dd5-9e40-7901981e1df3
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,19 +1203,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:44 GMT
+      - Thu, 02 Nov 2023 18:50:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95219d29-fe83-405e-a003-859016861a18
+      - 289b722b-c4c9-4083-b3f4-1dd1a0772fba
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,19 +1236,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":22504,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":22504,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "257"
+      - "245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:44 GMT
+      - Thu, 02 Nov 2023 18:50:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08be3b3c-8121-4bc0-b750-3e9d6debb301
+      - 7aa32d09-adeb-45fe-a52b-ec04ddb7f046
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,19 +1269,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:45 GMT
+      - Thu, 02 Nov 2023 18:50:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c80e0d13-23a8-4850-99b2-e1961f0ab144
+      - 565377e2-7e3d-4b72-bc03-b584c579c9c0
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,19 +1302,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":22504,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":22504,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "257"
+      - "245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:45 GMT
+      - Thu, 02 Nov 2023 18:50:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1328f233-4268-4120-afec-3ef8d552ddc0
+      - ce5ce677-4995-46d5-b3b4-018413fd806e
     status: 200 OK
     code: 200
     duration: ""
@@ -1335,19 +1335,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:50 GMT
+      - Thu, 02 Nov 2023 18:50:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9bd5450-09d3-406d-b3b5-0e7508dc0ec0
+      - 92263ac4-e108-4bcd-8565-6ecd51ce099e
     status: 200 OK
     code: 200
     duration: ""
@@ -1368,19 +1368,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVVTNNQ3VSTnErT0ZFS0ZDc1B2dVF6UHJsekxjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU9Gb1hEVE16TVRBeE56RTFOVEUxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFxZXNmSXhTcXJ5UWVTVnF2WVVIQ1JEelZkTXcwd280ZU52dGNnUUdBSFRWRXZWYklFTzBTbmJ3cnZMOEYKZ3U5ZjZ6RXlZVzlKSnZjRThjVVVDcThDcDA2cWRVRHFkLysvUGFMM2tISHVTWjRMbE5paUpsL0FEMTBGUkJaVApNeVpjUEQxVTZkdUlxcms5T2lSeTRGem1MSUJCRG8xUzVvcG5TYnRaNVlCYnJac2lSNko0MS9FY0lXWkNuM2E1CnVneEoyUTh6cHJ6RGhvOEI5aXJndVMxVzQrL3c0KzltTTQvalU5RXBSbGlqdGtQaFNTTlpsdWxKZUYwNXI0VmMKeUV0czFjSDl4MW1sZnZVS0JFamoxNTlnV09yNE01dkFsMkxvZXdVQnNDMXNLZnRxKzhReTNuc0N4Y2pTSjIxNwpNdG5wcmU3SVhoTU1nQ08vUGlMTjhhYzNqUUlEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdFlqQXhZVFJtWTJZdE9XRmpNQzAwT0dJM0xUaG1PVFF0TW1VNFlXRXdNemt4TVdWakxuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5rVkFod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUJ3Vkh4a3p2cXNMNEx3bk5sYlpxOU1RVUpFNmp3aXhPZ0RSTTlGUmI2MW9qRUkvcERHTkVnZVNzbEpiZG1KCllHaEl6V1doalJSbGhxbitSalRIRHkzMUkrVURKaUpJVXh6Mng5OEdlNUVtT0VINmtadDNETVBuNGRXL3JPbDQKODJGbDk4cjJKOEhld2pwSW1vNGRZSGs5MVJrbC9Ld2YwU1kyK3FjNW1EcVJTOUpRWThQaC9Iekx0MWV0czZOMQptaHNXTTJpaFhYU0hjSnJuK2FTNUY2LzNmcmpWcndUSkplcndTK20zZ1h5ZEdJWjJadFhQZ1c4aW9wYzNrclh4CnNkd0ZKaGVLbkNhREJDSUd0K3htcEFsN3V4RjNVN1hRRGFhMlNOVnZLTkRKYi94aWhycFNCUDVGWUhGcmYxWWcKRDVMbEhBS2NOVHFpSDFXWm55YTNRd1I5Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVWnMvc0VPTTZIVzlJbkRoK2had1l0a0RCNlQ0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXlXaGNOTXpNeE1ETXdNVGcwTnpJeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxXNmtJT2x3TDIzSTNHK3dVR0Q1UDdjNnZIc1EzQy9lREtUcGorVkZkU1cxajVtVUlxdGNna28KZDZVSmhNY1FPMVZMK0JwWWhjZjlINmVwQXFvaHZvaEJuYWNPK0gvRHY0aGl1dnF0VEV5MGNJNXV5NHRiaEtzMApDUDJRZkdpa2dnOHNLb2YzWVZDejlLK2dQcE9jR0ZPWTdtK09td25GVGZjTEdnRHFjdU52MkZITVlVUW1lVUluCkYyU2hybEpQMjJhZzBJY2xZb0RSdFZpV1JnVEMrR05jV2lBbXdsaDBZWnRTYWJPS1Jxakh6OTFpQlBDSE1BWnYKdWxUbWg5UWRYVkgwdkV1NDVMUDY1YUhpZzdUV1g5UUF3WnNPOGlvZkc5cmUwUHVMTHYzZ3dGNGZBNEVoa0xnagpPR3B3VGFOSUpPdDIxSktkTWd1RG9zK0hpMXZ4MmowQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0TVRZeFpHSTFPREV0TkdRM09DMDBNbU14TFdGbE5EQXROR1ZsWmpkbFlUVTMKTXpFeExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpNYmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1prZktBM2NhZittVGx6S1VUMDJVekRlQk9Ya0gyR2RYQ1dJaFo5cStWd0pueW1qRTkwRXlVCkNRdjBYK05oQ1VFdnJUZ1R2UHJGTzF2MHd2ZjVUM0ppS1lsMDNxZENmTWI2SDlWZEFFOGc0SHJjb21sT2JMMGsKWElZeVMvai9iWmtQa2U1dXlxQTdWcmt4WEVDYmtyU2pjUjFTdnFHMFczWXRvR2o1dUVBZzNXWWFPalJrczdZTApsYmlZVDRjclJKYnljMUM1MkRpUDQ2ZVRKR3BCUnRDRUtpbW9jRDhJRVlNNjIwTjZPZmdIQmFrT2c5WFBRSVBYCjN2K0l6SzhYZUpHRmptbFE5SnZlMUptNGFzZkJzeGgrbzFaY2ZnS1hpV0hob3FjcWNjeE5WRTNMZCtwdFhnRkUKdzZGdDJuWnNRdld6NXRMVEN0eFBiV0VMZitsZGUzamIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:50 GMT
+      - Thu, 02 Nov 2023 18:50:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb657d8a-1727-431b-8968-75d28993fb42
+      - b8cb9e8e-52d0-4315-92ae-676cad763559
     status: 200 OK
     code: 200
     duration: ""
@@ -1401,19 +1401,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:50 GMT
+      - Thu, 02 Nov 2023 18:50:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1423,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 519e2b53-507b-450c-ab4c-3ef90c24945c
+      - 1e866011-d0c9-469e-a041-f18466d7d782
     status: 200 OK
     code: 200
     duration: ""
@@ -1434,19 +1434,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:50 GMT
+      - Thu, 02 Nov 2023 18:50:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77b8edb2-fabe-418c-8e7f-735d142ff289
+      - a0b01b52-b97c-44e5-80e7-31f17dd3a46b
     status: 200 OK
     code: 200
     duration: ""
@@ -1467,19 +1467,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":22504,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":22504,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "257"
+      - "245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:50 GMT
+      - Thu, 02 Nov 2023 18:50:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b56b9db9-0afd-4838-bf93-eccc5808943a
+      - 00e50848-51b2-455a-a436-9246266b9e17
     status: 200 OK
     code: 200
     duration: ""
@@ -1500,19 +1500,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":22504,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":22504,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "257"
+      - "245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:50 GMT
+      - Thu, 02 Nov 2023 18:50:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d956920-cde7-4869-affa-85092bf5194b
+      - 9a78e7a8-d0d5-419f-8d8e-09de744695f9
     status: 200 OK
     code: 200
     duration: ""
@@ -1533,19 +1533,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:51 GMT
+      - Thu, 02 Nov 2023 18:50:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1555,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a07d866-05a6-4d81-be9a-2e931075ec03
+      - 866455e0-20e3-468c-b50e-2c973b6e6a6d
     status: 200 OK
     code: 200
     duration: ""
@@ -1566,19 +1566,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":22504,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":22504,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "257"
+      - "245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:51 GMT
+      - Thu, 02 Nov 2023 18:50:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aaec4a51-8116-43a5-ac8a-c60d5e3e11aa
+      - 87397804-a0ad-47d9-9674-ab05b0537025
     status: 200 OK
     code: 200
     duration: ""
@@ -1599,19 +1599,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:51 GMT
+      - Thu, 02 Nov 2023 18:50:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1621,7 +1621,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 038f8c8b-3860-4091-bb3b-493856207c16
+      - 47b4c4c3-12a2-4114-8df5-0561acbde405
     status: 200 OK
     code: 200
     duration: ""
@@ -1634,19 +1634,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
     method: DELETE
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":22504,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":22504,"protocol":"tcp"}]}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}]}'
     headers:
       Content-Length:
-      - "240"
+      - "229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:52 GMT
+      - Thu, 02 Nov 2023 18:50:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1656,7 +1656,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7586b60-1c44-4342-bbd2-95f91cf2114d
+      - 69d81b0f-1943-4347-aaa1-b73e26162e1d
     status: 200 OK
     code: 200
     duration: ""
@@ -1667,19 +1667,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1274"
+      - "1232"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:52 GMT
+      - Thu, 02 Nov 2023 18:50:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1689,7 +1689,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8cab8eb0-7b23-4d9b-947d-efc78962a9ad
+      - 5c53fc80-50bc-4326-ab8f-a0cf75887c80
     status: 200 OK
     code: 200
     duration: ""
@@ -1700,19 +1700,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:22 GMT
+      - Thu, 02 Nov 2023 18:50:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1722,7 +1722,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9ba541f-97c6-493f-a786-b6b2efcf6bff
+      - 850102af-f79d-4816-87d5-caa1b93bc445
     status: 200 OK
     code: 200
     duration: ""
@@ -1733,19 +1733,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:22 GMT
+      - Thu, 02 Nov 2023 18:50:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1755,7 +1755,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5fee9533-481e-4dc0-8584-5a40e491ba1d
+      - ed858e4f-6978-484c-bbe6-27a5f3c3398a
     status: 200 OK
     code: 200
     duration: ""
@@ -1766,19 +1766,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1271"
+      - "1229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:23 GMT
+      - Thu, 02 Nov 2023 18:50:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1788,7 +1788,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f14ea1a2-ed98-4c52-87b9-f737eb9df17e
+      - 1ab7394e-d2a7-4d4c-b765-62e71850c74b
     status: 200 OK
     code: 200
     duration: ""
@@ -1799,19 +1799,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.351945Z","retention":7},"created_at":"2023-10-20T15:51:10.351945Z","endpoint":{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504},"endpoints":[{"id":"1d58a824-8e12-4249-a486-7004edb9adfc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":22504}],"engine":"PostgreSQL-15","id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1271"
+      - "1229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:23 GMT
+      - Thu, 02 Nov 2023 18:50:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1821,7 +1821,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2a1f1c5-b0ec-4058-a633-457960de4f0e
+      - ca52ef53-460f-4d89-bba7-897a0d028b35
     status: 200 OK
     code: 200
     duration: ""
@@ -1832,10 +1832,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"161db581-4d78-42c1-ae40-4eef7ea57311","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1844,7 +1844,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:53 GMT
+      - Thu, 02 Nov 2023 18:51:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1854,7 +1854,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f304bacf-b417-4ab0-bd91-298e7d1513a3
+      - 5a1d6816-bd48-4ce6-b701-851e6267097e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1865,10 +1865,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"b01a4fcf-9ac0-48b7-8f94-2e8aa03911ec","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"161db581-4d78-42c1-ae40-4eef7ea57311","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1877,7 +1877,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:53 GMT
+      - Thu, 02 Nov 2023 18:51:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1887,7 +1887,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4e5bf2f-9247-41ee-9351-790bad123e00
+      - d66f58c2-487a-4a2d-bff7-29a7ce056db8
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-rdb-database-backup-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-rdb-database-backup-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:03 GMT
+      - Thu, 02 Nov 2023 18:46:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89f55285-8b69-4a41-9472-518974e5bb1a
+      - 40c2f487-9ba3-42cf-ab7d-66f3ae5a6a43
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-terraform","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-terraform","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:58:35.775036Z","retention":7},"created_at":"2023-10-20T15:58:35.775036Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "757"
+      - "730"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:36 GMT
+      - Thu, 02 Nov 2023 18:53:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a241fbd3-c78b-4f53-a06a-3fc775faf457
+      - eef5f00a-8c59-4e45-a436-746e6b356dd3
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:58:35.775036Z","retention":7},"created_at":"2023-10-20T15:58:35.775036Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "757"
+      - "730"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:36 GMT
+      - Thu, 02 Nov 2023 18:53:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c5bc0fc-a8e9-4ee7-979d-0f083bac0b81
+      - 8fbcfb72-d499-461c-a0f3-9d871eb593d4
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:58:35.775036Z","retention":7},"created_at":"2023-10-20T15:58:35.775036Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "757"
+      - "730"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:06 GMT
+      - Thu, 02 Nov 2023 18:54:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e8a8e2a-c1be-47a8-9c5d-84325a406c9f
+      - 2ba3996f-179c-46d6-928d-5a8d8637fa29
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:58:35.775036Z","retention":7},"created_at":"2023-10-20T15:58:35.775036Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "757"
+      - "730"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:36 GMT
+      - Thu, 02 Nov 2023 18:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd63841d-9403-4573-a953-cedbd4317762
+      - a9e46209-1671-4192-9911-51dc109accd4
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:58:35.775036Z","retention":7},"created_at":"2023-10-20T15:58:35.775036Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "757"
+      - "730"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:06 GMT
+      - Thu, 02 Nov 2023 18:55:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a554539-1661-4769-8edc-ea5861b2321f
+      - b0fd7eaf-a7be-42bb-a1b1-ae249dd1c784
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:58:35.775036Z","retention":7},"created_at":"2023-10-20T15:58:35.775036Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "757"
+      - "730"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:36 GMT
+      - Thu, 02 Nov 2023 18:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4903d2a8-0333-4e2f-a07e-8a5d4bb6272b
+      - a0a1240b-b0d2-49df-aa5f-08e60b03dc03
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:58:35.775036Z","retention":7},"created_at":"2023-10-20T15:58:35.775036Z","endpoint":{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015},"endpoints":[{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015}],"engine":"PostgreSQL-15","id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:06 GMT
+      - Thu, 02 Nov 2023 18:56:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,12 +561,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c17aea0-f064-4c0e-8294-529d286c0737
+      - efdff264-2781-4943-935b-3a4eed46dcad
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"backup_schedule_frequency":null,"backup_schedule_retention":null,"is_backup_schedule_disabled":false,"name":null,"tags":null,"logs_policy":null,"backup_same_region":false,"backup_schedule_start_hour":null}'
+    body: '{"is_backup_schedule_disabled":false,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -574,19 +574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:58:35.775036Z","retention":7},"created_at":"2023-10-20T15:58:35.775036Z","endpoint":{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015},"endpoints":[{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015}],"engine":"PostgreSQL-15","id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:06 GMT
+      - Thu, 02 Nov 2023 18:56:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc44493a-67d0-47b8-9a48-26023c411f02
+      - df85baef-e6c2-4a30-ab38-27289b84ff41
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:58:35.775036Z","retention":7},"created_at":"2023-10-20T15:58:35.775036Z","endpoint":{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015},"endpoints":[{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015}],"engine":"PostgreSQL-15","id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:07 GMT
+      - Thu, 02 Nov 2023 18:56:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb5c3977-c694-48cc-86f7-956ef2230c5d
+      - 0e264098-06ca-4add-ba2b-bb6ad12c2e7e
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVQVpEaXJNdTlTbUdZVGdxajQxMTkwdWZ6Sm9Fd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU9UQTBXaGNOTXpNeE1ERTNNVFUxT1RBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU9IQWZhTFVNamxZOHdKQ0RlNzJ5MFphcHMvN0hTUTl4a1NMODJuQVYyd2FFL2I3M0oxeTV0cEQKSGVPaW9GR2t1RDQvYllyM1AxTzhueG1rMkcra0dNUDVmVVJCdjkrQ0NocjlYYVBBYjdVcGpnMlNXMG1WYTB6bApwRm5EVW9RNjlobGVpS0RwdHlVdW5xMWlYOGxHY1h0Q0NzZzlmNWxUWkhLeUpVNVduV1AyOEcvSjhqYUZMWDI1CjA1aWxiVEF3ajRZOWxwTWM0UUtNUnBwcFlJV056cDB2NElGRmZ6ZVRCc2pKKzVNM1h0ZkM2NXJSRHVUR1E1SGMKeWRtVFg0T094QnN2TE9ZdUZnS1pSMjd0R2lSSjR6ZitudFNtRU1BVCtNQlk0alN1dEhKVHEzT3d2WXBDUWJ3SAp3NkJzQ0RzZ1hiYytnRmlwVFUxeG1KemNRck1rb1BFQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0WVdJMU4yVm1NMk10WkRZM055MDBPV05tTFdJd05HTXRNVFkxTVdOa00yWmgKT1dJM0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1Nqckx1eGh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQVNoVk5KL2U5RUYyNU9NVVhpcGRpTm5neWkwRnZjOHZxa0E1dGI4UnJPcDVZdFFmanBhdWJoCk45NVpFYW5IN3VFN2VWSmV1WHBzMGZoUS81VWtXLzYvQWZwRnRSZldBdEhoR2hwWjNEdHFpUnVtdHR6aDlIZlYKaVZlTVNYL1lNTURwUEI3anFYblZNZUNkRTRaeHQ3bTl1eWRiTXZWaU1NUlBkeWpsek5MSk9YbG5ueHU0Ykxaawozd3FpR2JHMXVmMmM1bGp2UFRDK25DNnpSQW5Na3pldWdWTnFFNGlCbGVmSVdFWlMycEdORjJ3RG02d21HZXp3CmdFaHB6MnlnbzBZclVQTkJqRWxCOEEvZG1ablNEeHNMajlMWENRT2VoaVVoZFlYdmx3eXRNQVl2ZE1sNG5RR3UKZ2lqbXFNRndjYzZYUW55emJGMGdvSWc3M1BrZWt3TlEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVRURUSkZhM1htUkVGQXhsdVVoQjBra2xhVjZBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTmk0eU16QXdIaGNOCk1qTXhNVEF5TVRnMU5ESTFXaGNOTXpNeE1ETXdNVGcxTkRJMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTJMakl6TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5GNnRISi9YTUdKZllqY2g1YkcvTUJRV2ljTGUwUTRRSERjOUJyS1NndEd0UHVrNjIvYWpYM0wKQXdWMjQ0czQwbjE5YUovMlRlcEk2Skg0bHdDSnl6eDFyU1pldkhpWFFSOVE1K3A5VVRCaTIxTTAwcWoraGZ2OApuZ1FkMWVvQWVacU03U0hnSlVBSGNGdzEwTzJIYW9URUx3cHQ4VjJWeW0yVVQ2TENTaThyOXltOEJXWThZTjZwCkY1RmppVDZ1YUNQcjhrc0QyRzRJc01jWHZtQjZkSFZMb0psb1JFTWdHTTZURGtsSEtLNTR6bDZYR01WZnRtZkEKbEVLam1WOHpyc0piSm9seFArZmxLWXFJdG82T0FQalptSFdSSlovUm9uYk5iTmljWmxZYkR2SHpHSURGK0huNgpUcjJGSVVRNVNkOWJSR2d1cjJ0S09uY0FQYUVORFVjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMalUyTGpJek1JSThjbmN0WkRZMk0yVmlNR0V0Wm1JMllTMDBObVpoTFRsalltTXRPV1E1TWpZNE5qSmkKT0dOaUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1Nqckptamh3UXpuamptTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXJqeVcyZ2ZZUTc0eDdiaENzK2JobEZUUXBJcDdweWs3L0ZMSUlYa3ZkWkNtZXVuVDV5UjdtCk5KUUNaamVibTlIa3VQYno5SEk3V0dQT0lWWDF0cFdMT1pxMWJRMHJqNDQwLzhQWDhaWEZSZ25aUEhHcW9xNjcKMGJoTkxOQXh3Q2ZHTUFBVnc3RjVNS2d1SVQ3d0I2ZTBDUkh1Ym1nb25JbER2REZhclZBMnhrdytyU25KYlFuYgpzZG1MZEtodFdlaGZLVmMwWk05YWIvM3h3bi9YdDBVOGdqd0xjTDR4RWU1dERLREZHbGdpcnNTMUNyK0hEZjdMClAyMVg0ZnhsWDhpTytKeXFoT01xQ3F4N3k0ZWhuekVwUWpTVjlzanpoWTFoK2hSMEJZaWZrVjJERlRUdjJiZWEKRkRTNzRtSlBLUW1IS2YzK29kZUE0NnRKQ0phckUrZm4KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:07 GMT
+      - Thu, 02 Nov 2023 18:56:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0af59e7e-59ad-4250-b8b1-296a8c80e3ea
+      - d71157ae-3026-430a-a6f8-5615d48b7db3
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:58:35.775036Z","retention":7},"created_at":"2023-10-20T15:58:35.775036Z","endpoint":{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015},"endpoints":[{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015}],"engine":"PostgreSQL-15","id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:07 GMT
+      - Thu, 02 Nov 2023 18:56:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee45a93b-1c7a-447d-87e0-8c40e2b2e44a
+      - adf736e9-d89a-4828-b810-801b48fa8fa3
     status: 200 OK
     code: 200
     duration: ""
@@ -708,19 +708,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/databases
     method: POST
   response:
     body: '{"managed":true,"name":"test-terraform","owner":"","size":0}'
     headers:
       Content-Length:
-      - "63"
+      - "60"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:07 GMT
+      - Thu, 02 Nov 2023 18:56:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -730,7 +730,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0ab49b0-1f6f-4184-a08d-fdc85a3a7ffe
+      - 9505770c-2fa8-4780-89ce-74fff590a06e
     status: 200 OK
     code: 200
     duration: ""
@@ -741,19 +741,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:58:35.775036Z","retention":7},"created_at":"2023-10-20T15:58:35.775036Z","endpoint":{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015},"endpoints":[{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015}],"engine":"PostgreSQL-15","id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:08 GMT
+      - Thu, 02 Nov 2023 18:56:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +763,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cce73b95-ebb9-4204-a02a-07e8d86ad506
+      - 75182f4c-a5fb-49a0-88dd-0a8335aa790f
     status: 200 OK
     code: 200
     duration: ""
@@ -774,118 +774,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7/databases?name=test-terraform&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "117"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:01:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c2bd021b-9891-4f64-a2f2-6bb52c4c1725
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:58:35.775036Z","retention":7},"created_at":"2023-10-20T15:58:35.775036Z","endpoint":{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015},"endpoints":[{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015}],"engine":"PostgreSQL-15","id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1249"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:01:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2387245b-4115-42bc-b8e4-f521c6dc3289
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVQVpEaXJNdTlTbUdZVGdxajQxMTkwdWZ6Sm9Fd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU9UQTBXaGNOTXpNeE1ERTNNVFUxT1RBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU9IQWZhTFVNamxZOHdKQ0RlNzJ5MFphcHMvN0hTUTl4a1NMODJuQVYyd2FFL2I3M0oxeTV0cEQKSGVPaW9GR2t1RDQvYllyM1AxTzhueG1rMkcra0dNUDVmVVJCdjkrQ0NocjlYYVBBYjdVcGpnMlNXMG1WYTB6bApwRm5EVW9RNjlobGVpS0RwdHlVdW5xMWlYOGxHY1h0Q0NzZzlmNWxUWkhLeUpVNVduV1AyOEcvSjhqYUZMWDI1CjA1aWxiVEF3ajRZOWxwTWM0UUtNUnBwcFlJV056cDB2NElGRmZ6ZVRCc2pKKzVNM1h0ZkM2NXJSRHVUR1E1SGMKeWRtVFg0T094QnN2TE9ZdUZnS1pSMjd0R2lSSjR6ZitudFNtRU1BVCtNQlk0alN1dEhKVHEzT3d2WXBDUWJ3SAp3NkJzQ0RzZ1hiYytnRmlwVFUxeG1KemNRck1rb1BFQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0WVdJMU4yVm1NMk10WkRZM055MDBPV05tTFdJd05HTXRNVFkxTVdOa00yWmgKT1dJM0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1Nqckx1eGh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQVNoVk5KL2U5RUYyNU9NVVhpcGRpTm5neWkwRnZjOHZxa0E1dGI4UnJPcDVZdFFmanBhdWJoCk45NVpFYW5IN3VFN2VWSmV1WHBzMGZoUS81VWtXLzYvQWZwRnRSZldBdEhoR2hwWjNEdHFpUnVtdHR6aDlIZlYKaVZlTVNYL1lNTURwUEI3anFYblZNZUNkRTRaeHQ3bTl1eWRiTXZWaU1NUlBkeWpsek5MSk9YbG5ueHU0Ykxaawozd3FpR2JHMXVmMmM1bGp2UFRDK25DNnpSQW5Na3pldWdWTnFFNGlCbGVmSVdFWlMycEdORjJ3RG02d21HZXp3CmdFaHB6MnlnbzBZclVQTkJqRWxCOEEvZG1ablNEeHNMajlMWENRT2VoaVVoZFlYdmx3eXRNQVl2ZE1sNG5RR3UKZ2lqbXFNRndjYzZYUW55emJGMGdvSWc3M1BrZWt3TlEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1845"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:01:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5d174674-4552-484e-98c3-61fc3cf85878
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "117"
+      - "113"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:09 GMT
+      - Thu, 02 Nov 2023 18:56:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19249b02-d01e-4465-9ff2-41b2435ddf9a
+      - 69150f20-e15c-4b3e-96dc-4f0416d957ee
     status: 200 OK
     code: 200
     duration: ""
@@ -906,19 +807,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:58:35.775036Z","retention":7},"created_at":"2023-10-20T15:58:35.775036Z","endpoint":{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015},"endpoints":[{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015}],"engine":"PostgreSQL-15","id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:09 GMT
+      - Thu, 02 Nov 2023 18:56:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca905d3c-2f3e-4c2a-81d4-7e5c88886f1d
+      - d6689337-fa01-4687-a71f-49b3fb017f7c
     status: 200 OK
     code: 200
     duration: ""
@@ -939,19 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVQVpEaXJNdTlTbUdZVGdxajQxMTkwdWZ6Sm9Fd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU9UQTBXaGNOTXpNeE1ERTNNVFUxT1RBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU9IQWZhTFVNamxZOHdKQ0RlNzJ5MFphcHMvN0hTUTl4a1NMODJuQVYyd2FFL2I3M0oxeTV0cEQKSGVPaW9GR2t1RDQvYllyM1AxTzhueG1rMkcra0dNUDVmVVJCdjkrQ0NocjlYYVBBYjdVcGpnMlNXMG1WYTB6bApwRm5EVW9RNjlobGVpS0RwdHlVdW5xMWlYOGxHY1h0Q0NzZzlmNWxUWkhLeUpVNVduV1AyOEcvSjhqYUZMWDI1CjA1aWxiVEF3ajRZOWxwTWM0UUtNUnBwcFlJV056cDB2NElGRmZ6ZVRCc2pKKzVNM1h0ZkM2NXJSRHVUR1E1SGMKeWRtVFg0T094QnN2TE9ZdUZnS1pSMjd0R2lSSjR6ZitudFNtRU1BVCtNQlk0alN1dEhKVHEzT3d2WXBDUWJ3SAp3NkJzQ0RzZ1hiYytnRmlwVFUxeG1KemNRck1rb1BFQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0WVdJMU4yVm1NMk10WkRZM055MDBPV05tTFdJd05HTXRNVFkxTVdOa00yWmgKT1dJM0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1Nqckx1eGh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQVNoVk5KL2U5RUYyNU9NVVhpcGRpTm5neWkwRnZjOHZxa0E1dGI4UnJPcDVZdFFmanBhdWJoCk45NVpFYW5IN3VFN2VWSmV1WHBzMGZoUS81VWtXLzYvQWZwRnRSZldBdEhoR2hwWjNEdHFpUnVtdHR6aDlIZlYKaVZlTVNYL1lNTURwUEI3anFYblZNZUNkRTRaeHQ3bTl1eWRiTXZWaU1NUlBkeWpsek5MSk9YbG5ueHU0Ykxaawozd3FpR2JHMXVmMmM1bGp2UFRDK25DNnpSQW5Na3pldWdWTnFFNGlCbGVmSVdFWlMycEdORjJ3RG02d21HZXp3CmdFaHB6MnlnbzBZclVQTkJqRWxCOEEvZG1ablNEeHNMajlMWENRT2VoaVVoZFlYdmx3eXRNQVl2ZE1sNG5RR3UKZ2lqbXFNRndjYzZYUW55emJGMGdvSWc3M1BrZWt3TlEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVRURUSkZhM1htUkVGQXhsdVVoQjBra2xhVjZBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTmk0eU16QXdIaGNOCk1qTXhNVEF5TVRnMU5ESTFXaGNOTXpNeE1ETXdNVGcxTkRJMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTJMakl6TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5GNnRISi9YTUdKZllqY2g1YkcvTUJRV2ljTGUwUTRRSERjOUJyS1NndEd0UHVrNjIvYWpYM0wKQXdWMjQ0czQwbjE5YUovMlRlcEk2Skg0bHdDSnl6eDFyU1pldkhpWFFSOVE1K3A5VVRCaTIxTTAwcWoraGZ2OApuZ1FkMWVvQWVacU03U0hnSlVBSGNGdzEwTzJIYW9URUx3cHQ4VjJWeW0yVVQ2TENTaThyOXltOEJXWThZTjZwCkY1RmppVDZ1YUNQcjhrc0QyRzRJc01jWHZtQjZkSFZMb0psb1JFTWdHTTZURGtsSEtLNTR6bDZYR01WZnRtZkEKbEVLam1WOHpyc0piSm9seFArZmxLWXFJdG82T0FQalptSFdSSlovUm9uYk5iTmljWmxZYkR2SHpHSURGK0huNgpUcjJGSVVRNVNkOWJSR2d1cjJ0S09uY0FQYUVORFVjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMalUyTGpJek1JSThjbmN0WkRZMk0yVmlNR0V0Wm1JMllTMDBObVpoTFRsalltTXRPV1E1TWpZNE5qSmkKT0dOaUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1Nqckptamh3UXpuamptTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXJqeVcyZ2ZZUTc0eDdiaENzK2JobEZUUXBJcDdweWs3L0ZMSUlYa3ZkWkNtZXVuVDV5UjdtCk5KUUNaamVibTlIa3VQYno5SEk3V0dQT0lWWDF0cFdMT1pxMWJRMHJqNDQwLzhQWDhaWEZSZ25aUEhHcW9xNjcKMGJoTkxOQXh3Q2ZHTUFBVnc3RjVNS2d1SVQ3d0I2ZTBDUkh1Ym1nb25JbER2REZhclZBMnhrdytyU25KYlFuYgpzZG1MZEtodFdlaGZLVmMwWk05YWIvM3h3bi9YdDBVOGdqd0xjTDR4RWU1dERLREZHbGdpcnNTMUNyK0hEZjdMClAyMVg0ZnhsWDhpTytKeXFoT01xQ3F4N3k0ZWhuekVwUWpTVjlzanpoWTFoK2hSMEJZaWZrVjJERlRUdjJiZWEKRkRTNzRtSlBLUW1IS2YzK29kZUE0NnRKQ0phckUrZm4KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:09 GMT
+      - Thu, 02 Nov 2023 18:56:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be79d55d-d308-4594-9e21-aa8f0929476e
+      - 505cf918-d35e-4601-bdee-ff1c4db59654
     status: 200 OK
     code: 200
     duration: ""
@@ -972,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "117"
+      - "113"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:10 GMT
+      - Thu, 02 Nov 2023 18:56:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,12 +895,111 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58034268-1bd8-4e08-a97f-c57f7dd1bc05
+      - 484daf0c-22f3-48e8-820b-bb4056d9208d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","database_name":"test-terraform","name":"test_backup_datasource","expires_at":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1203"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:56:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b858b430-cf78-4764-ae09-c1e528adc112
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVRURUSkZhM1htUkVGQXhsdVVoQjBra2xhVjZBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTmk0eU16QXdIaGNOCk1qTXhNVEF5TVRnMU5ESTFXaGNOTXpNeE1ETXdNVGcxTkRJMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTJMakl6TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5GNnRISi9YTUdKZllqY2g1YkcvTUJRV2ljTGUwUTRRSERjOUJyS1NndEd0UHVrNjIvYWpYM0wKQXdWMjQ0czQwbjE5YUovMlRlcEk2Skg0bHdDSnl6eDFyU1pldkhpWFFSOVE1K3A5VVRCaTIxTTAwcWoraGZ2OApuZ1FkMWVvQWVacU03U0hnSlVBSGNGdzEwTzJIYW9URUx3cHQ4VjJWeW0yVVQ2TENTaThyOXltOEJXWThZTjZwCkY1RmppVDZ1YUNQcjhrc0QyRzRJc01jWHZtQjZkSFZMb0psb1JFTWdHTTZURGtsSEtLNTR6bDZYR01WZnRtZkEKbEVLam1WOHpyc0piSm9seFArZmxLWXFJdG82T0FQalptSFdSSlovUm9uYk5iTmljWmxZYkR2SHpHSURGK0huNgpUcjJGSVVRNVNkOWJSR2d1cjJ0S09uY0FQYUVORFVjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMalUyTGpJek1JSThjbmN0WkRZMk0yVmlNR0V0Wm1JMllTMDBObVpoTFRsalltTXRPV1E1TWpZNE5qSmkKT0dOaUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1Nqckptamh3UXpuamptTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXJqeVcyZ2ZZUTc0eDdiaENzK2JobEZUUXBJcDdweWs3L0ZMSUlYa3ZkWkNtZXVuVDV5UjdtCk5KUUNaamVibTlIa3VQYno5SEk3V0dQT0lWWDF0cFdMT1pxMWJRMHJqNDQwLzhQWDhaWEZSZ25aUEhHcW9xNjcKMGJoTkxOQXh3Q2ZHTUFBVnc3RjVNS2d1SVQ3d0I2ZTBDUkh1Ym1nb25JbER2REZhclZBMnhrdytyU25KYlFuYgpzZG1MZEtodFdlaGZLVmMwWk05YWIvM3h3bi9YdDBVOGdqd0xjTDR4RWU1dERLREZHbGdpcnNTMUNyK0hEZjdMClAyMVg0ZnhsWDhpTytKeXFoT01xQ3F4N3k0ZWhuekVwUWpTVjlzanpoWTFoK2hSMEJZaWZrVjJERlRUdjJiZWEKRkRTNzRtSlBLUW1IS2YzK29kZUE0NnRKQ0phckUrZm4KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1843"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:56:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5c8abb35-6129-4cd5-804f-783d411c054b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/databases?name=test-terraform&order_by=name_asc
+    method: GET
+  response:
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "113"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:56:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3304f8e0-8e08-4e93-811b-25958bc5e44f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","database_name":"test-terraform","name":"test_backup_datasource"}'
     form: {}
     headers:
       Content-Type:
@@ -1010,16 +1010,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups
     method: POST
   response:
-    body: '{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
+    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
     headers:
       Content-Length:
-      - "409"
+      - "396"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:11 GMT
+      - Thu, 02 Nov 2023 18:56:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1029,7 +1029,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6d18fb2-ee46-41e1-bfaa-0c63dda0c66d
+      - 73bb6029-1507-42f1-a4f6-0659c5c43bef
     status: 200 OK
     code: 200
     duration: ""
@@ -1040,19 +1040,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
+    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
     headers:
       Content-Length:
-      - "409"
+      - "396"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:11 GMT
+      - Thu, 02 Nov 2023 18:56:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1062,7 +1062,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c606f8f-6186-488b-b7a4-b17085a0dfc5
+      - 23a298c4-62af-4646-b6a0-8005f8a7f6fd
     status: 200 OK
     code: 200
     duration: ""
@@ -1073,19 +1073,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}'
+    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
     headers:
       Content-Length:
-      - "431"
+      - "418"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:41 GMT
+      - Thu, 02 Nov 2023 18:56:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1095,7 +1095,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da2e90bc-045d-4962-9df2-ea90f73961de
+      - bca0a636-de3f-487f-8502-71a86cbf4a05
     status: 200 OK
     code: 200
     duration: ""
@@ -1106,19 +1106,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}'
+    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
     headers:
       Content-Length:
-      - "431"
+      - "418"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:42 GMT
+      - Thu, 02 Nov 2023 18:56:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1128,7 +1128,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bff2e64d-41b2-47fc-a67a-233c6c538090
+      - 3b9b2491-19d2-4aeb-beff-6f743256ec9a
     status: 200 OK
     code: 200
     duration: ""
@@ -1139,19 +1139,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}'
+    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
     headers:
       Content-Length:
-      - "431"
+      - "418"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:42 GMT
+      - Thu, 02 Nov 2023 18:56:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1161,73 +1161,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15059ceb-b1ed-4c9d-8445-1b4bef9c0e76
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=ab57ef3c-d677-49cf-b04c-1651cd3fa9b7&name=test_backup_datasource&order_by=created_at_asc
-    method: GET
-  response:
-    body: '{"database_backups":[{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "471"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:01:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4dd5e22e-e272-4c4d-9c0c-22b9b66a4603
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}'
-    headers:
-      Content-Length:
-      - "431"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:01:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9f9bc033-557d-48ef-a20a-1965e5dbcc2f
+      - e76a7ac8-6ffd-428d-870b-b786c1e02a04
     status: 200 OK
     code: 200
     duration: ""
@@ -1241,16 +1175,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "471"
+      - "457"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:42 GMT
+      - Thu, 02 Nov 2023 18:56:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1260,7 +1194,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2407602c-89d1-409a-8267-15a3986331dd
+      - 8a3360d3-ad48-411b-bd2e-30a12dc0101e
     status: 200 OK
     code: 200
     duration: ""
@@ -1271,19 +1205,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=d663eb0a-fb6a-46fa-9cbc-9d926862b8cb&name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}'
+    body: '{"database_backups":[{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "431"
+      - "457"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:42 GMT
+      - Thu, 02 Nov 2023 18:56:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1293,7 +1227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aff2d8b8-6397-41cc-ac7f-0f8cc282288a
+      - d2c2940a-47ba-413a-b15d-8749e6b6fd1b
     status: 200 OK
     code: 200
     duration: ""
@@ -1304,19 +1238,85 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
+    headers:
+      Content-Length:
+      - "418"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:56:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 83dac3a4-0779-4ffe-8014-ebf5eb808006
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
+    headers:
+      Content-Length:
+      - "418"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:57:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 16c42f3b-fbfe-49dd-9ac1-d562bd7300c5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "117"
+      - "113"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:42 GMT
+      - Thu, 02 Nov 2023 18:57:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1326,7 +1326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 842a93d5-bf8e-48be-886d-c339995325d5
+      - aab9b15d-65e5-4271-9b34-048a709b15c9
     status: 200 OK
     code: 200
     duration: ""
@@ -1337,19 +1337,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}'
+    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
     headers:
       Content-Length:
-      - "431"
+      - "418"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:42 GMT
+      - Thu, 02 Nov 2023 18:57:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1359,7 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bed06c07-f1b4-4170-a2c4-abb6987ddcd7
+      - d650a2f8-9e4c-4da5-b2ad-edfba67ee23f
     status: 200 OK
     code: 200
     duration: ""
@@ -1370,19 +1370,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}'
+    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
     headers:
       Content-Length:
-      - "431"
+      - "418"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:43 GMT
+      - Thu, 02 Nov 2023 18:57:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1392,7 +1392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43bd5be9-53b1-4ae0-aa6a-de4f973925e1
+      - 7e8dfc8e-0ed7-41cf-b081-0fac052d14e0
     status: 200 OK
     code: 200
     duration: ""
@@ -1403,19 +1403,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=ab57ef3c-d677-49cf-b04c-1651cd3fa9b7&name=test_backup_datasource&order_by=created_at_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=d663eb0a-fb6a-46fa-9cbc-9d926862b8cb&name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "471"
+      - "457"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:43 GMT
+      - Thu, 02 Nov 2023 18:57:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1425,7 +1425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5ff0ec5-399a-442f-b4e8-13e9f5f4829c
+      - 5b964d9b-9936-4303-a61b-40531cd995bd
     status: 200 OK
     code: 200
     duration: ""
@@ -1439,16 +1439,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "471"
+      - "457"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:43 GMT
+      - Thu, 02 Nov 2023 18:57:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1458,7 +1458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05577762-03ba-467b-a771-1936628b33f9
+      - 46432f91-74ce-4f85-bdea-19850cd7086f
     status: 200 OK
     code: 200
     duration: ""
@@ -1469,19 +1469,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}'
+    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
     headers:
       Content-Length:
-      - "431"
+      - "418"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:43 GMT
+      - Thu, 02 Nov 2023 18:57:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1491,7 +1491,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c30c4b9-990b-48ab-8abd-ea493c21a6c8
+      - 82417896-e0cb-40b6-b508-94eea9241fe2
     status: 200 OK
     code: 200
     duration: ""
@@ -1502,19 +1502,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}'
+    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
     headers:
       Content-Length:
-      - "431"
+      - "418"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:43 GMT
+      - Thu, 02 Nov 2023 18:57:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1524,7 +1524,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe567a61-708f-4a81-ae2b-2d15021796fa
+      - e1e2e281-ddeb-4f7b-a875-f02827390d62
     status: 200 OK
     code: 200
     duration: ""
@@ -1535,19 +1535,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:58:35.775036Z","retention":7},"created_at":"2023-10-20T15:58:35.775036Z","endpoint":{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015},"endpoints":[{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015}],"engine":"PostgreSQL-15","id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:43 GMT
+      - Thu, 02 Nov 2023 18:57:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1557,7 +1557,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5eece68c-7374-4385-8d64-0c11f57063be
+      - efdfc7da-409e-46bf-a472-052b465cdbeb
     status: 200 OK
     code: 200
     duration: ""
@@ -1568,19 +1568,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVQVpEaXJNdTlTbUdZVGdxajQxMTkwdWZ6Sm9Fd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU9UQTBXaGNOTXpNeE1ERTNNVFUxT1RBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU9IQWZhTFVNamxZOHdKQ0RlNzJ5MFphcHMvN0hTUTl4a1NMODJuQVYyd2FFL2I3M0oxeTV0cEQKSGVPaW9GR2t1RDQvYllyM1AxTzhueG1rMkcra0dNUDVmVVJCdjkrQ0NocjlYYVBBYjdVcGpnMlNXMG1WYTB6bApwRm5EVW9RNjlobGVpS0RwdHlVdW5xMWlYOGxHY1h0Q0NzZzlmNWxUWkhLeUpVNVduV1AyOEcvSjhqYUZMWDI1CjA1aWxiVEF3ajRZOWxwTWM0UUtNUnBwcFlJV056cDB2NElGRmZ6ZVRCc2pKKzVNM1h0ZkM2NXJSRHVUR1E1SGMKeWRtVFg0T094QnN2TE9ZdUZnS1pSMjd0R2lSSjR6ZitudFNtRU1BVCtNQlk0alN1dEhKVHEzT3d2WXBDUWJ3SAp3NkJzQ0RzZ1hiYytnRmlwVFUxeG1KemNRck1rb1BFQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0WVdJMU4yVm1NMk10WkRZM055MDBPV05tTFdJd05HTXRNVFkxTVdOa00yWmgKT1dJM0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1Nqckx1eGh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQVNoVk5KL2U5RUYyNU9NVVhpcGRpTm5neWkwRnZjOHZxa0E1dGI4UnJPcDVZdFFmanBhdWJoCk45NVpFYW5IN3VFN2VWSmV1WHBzMGZoUS81VWtXLzYvQWZwRnRSZldBdEhoR2hwWjNEdHFpUnVtdHR6aDlIZlYKaVZlTVNYL1lNTURwUEI3anFYblZNZUNkRTRaeHQ3bTl1eWRiTXZWaU1NUlBkeWpsek5MSk9YbG5ueHU0Ykxaawozd3FpR2JHMXVmMmM1bGp2UFRDK25DNnpSQW5Na3pldWdWTnFFNGlCbGVmSVdFWlMycEdORjJ3RG02d21HZXp3CmdFaHB6MnlnbzBZclVQTkJqRWxCOEEvZG1ablNEeHNMajlMWENRT2VoaVVoZFlYdmx3eXRNQVl2ZE1sNG5RR3UKZ2lqbXFNRndjYzZYUW55emJGMGdvSWc3M1BrZWt3TlEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVRURUSkZhM1htUkVGQXhsdVVoQjBra2xhVjZBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTmk0eU16QXdIaGNOCk1qTXhNVEF5TVRnMU5ESTFXaGNOTXpNeE1ETXdNVGcxTkRJMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTJMakl6TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5GNnRISi9YTUdKZllqY2g1YkcvTUJRV2ljTGUwUTRRSERjOUJyS1NndEd0UHVrNjIvYWpYM0wKQXdWMjQ0czQwbjE5YUovMlRlcEk2Skg0bHdDSnl6eDFyU1pldkhpWFFSOVE1K3A5VVRCaTIxTTAwcWoraGZ2OApuZ1FkMWVvQWVacU03U0hnSlVBSGNGdzEwTzJIYW9URUx3cHQ4VjJWeW0yVVQ2TENTaThyOXltOEJXWThZTjZwCkY1RmppVDZ1YUNQcjhrc0QyRzRJc01jWHZtQjZkSFZMb0psb1JFTWdHTTZURGtsSEtLNTR6bDZYR01WZnRtZkEKbEVLam1WOHpyc0piSm9seFArZmxLWXFJdG82T0FQalptSFdSSlovUm9uYk5iTmljWmxZYkR2SHpHSURGK0huNgpUcjJGSVVRNVNkOWJSR2d1cjJ0S09uY0FQYUVORFVjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMalUyTGpJek1JSThjbmN0WkRZMk0yVmlNR0V0Wm1JMllTMDBObVpoTFRsalltTXRPV1E1TWpZNE5qSmkKT0dOaUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1Nqckptamh3UXpuamptTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXJqeVcyZ2ZZUTc0eDdiaENzK2JobEZUUXBJcDdweWs3L0ZMSUlYa3ZkWkNtZXVuVDV5UjdtCk5KUUNaamVibTlIa3VQYno5SEk3V0dQT0lWWDF0cFdMT1pxMWJRMHJqNDQwLzhQWDhaWEZSZ25aUEhHcW9xNjcKMGJoTkxOQXh3Q2ZHTUFBVnc3RjVNS2d1SVQ3d0I2ZTBDUkh1Ym1nb25JbER2REZhclZBMnhrdytyU25KYlFuYgpzZG1MZEtodFdlaGZLVmMwWk05YWIvM3h3bi9YdDBVOGdqd0xjTDR4RWU1dERLREZHbGdpcnNTMUNyK0hEZjdMClAyMVg0ZnhsWDhpTytKeXFoT01xQ3F4N3k0ZWhuekVwUWpTVjlzanpoWTFoK2hSMEJZaWZrVjJERlRUdjJiZWEKRkRTNzRtSlBLUW1IS2YzK29kZUE0NnRKQ0phckUrZm4KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:44 GMT
+      - Thu, 02 Nov 2023 18:57:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1590,7 +1590,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1e593b4-3988-449b-b5ce-6dc1447ccbb8
+      - f6884c01-e581-4d1b-bd24-5ebf5e8eaf83
     status: 200 OK
     code: 200
     duration: ""
@@ -1601,19 +1601,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "117"
+      - "113"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:44 GMT
+      - Thu, 02 Nov 2023 18:57:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1623,7 +1623,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5eee1a38-5f99-4cbe-bce9-c634b84a4eca
+      - ee04c87d-f488-43ba-be84-67a58d2754dd
     status: 200 OK
     code: 200
     duration: ""
@@ -1634,19 +1634,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}'
+    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
     headers:
       Content-Length:
-      - "431"
+      - "418"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:44 GMT
+      - Thu, 02 Nov 2023 18:57:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1656,7 +1656,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60f1f845-52f8-4bd2-b686-2723d41b68b2
+      - 991973b0-4d37-4f69-9b90-2e93b50b0367
     status: 200 OK
     code: 200
     duration: ""
@@ -1667,19 +1667,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}'
+    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
     headers:
       Content-Length:
-      - "431"
+      - "418"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:44 GMT
+      - Thu, 02 Nov 2023 18:57:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1689,7 +1689,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d46fbae9-596d-4883-8df1-3af17570b250
+      - ce127dde-d24c-4241-afe2-9deda85df069
     status: 200 OK
     code: 200
     duration: ""
@@ -1700,19 +1700,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=ab57ef3c-d677-49cf-b04c-1651cd3fa9b7&name=test_backup_datasource&order_by=created_at_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=d663eb0a-fb6a-46fa-9cbc-9d926862b8cb&name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "471"
+      - "457"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:44 GMT
+      - Thu, 02 Nov 2023 18:57:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1722,7 +1722,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4ddca9d-d993-488c-ab7c-e8d9992094c9
+      - a2562298-accd-45a0-8dec-1f78c2a952fd
     status: 200 OK
     code: 200
     duration: ""
@@ -1736,16 +1736,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "471"
+      - "457"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:44 GMT
+      - Thu, 02 Nov 2023 18:57:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1755,7 +1755,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3baf24a-c83f-4cc4-83b8-8abf085674b5
+      - 249f8d56-bd10-4b87-8bb2-3723780dc564
     status: 200 OK
     code: 200
     duration: ""
@@ -1766,19 +1766,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}'
+    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
     headers:
       Content-Length:
-      - "431"
+      - "418"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:44 GMT
+      - Thu, 02 Nov 2023 18:57:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1788,7 +1788,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c5c32b8-7f48-48bb-b4b3-f628ee9fac92
+      - 0f2003df-8b5c-4c43-a78e-10f4118b883c
     status: 200 OK
     code: 200
     duration: ""
@@ -1799,19 +1799,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}'
+    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
     headers:
       Content-Length:
-      - "431"
+      - "418"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:44 GMT
+      - Thu, 02 Nov 2023 18:57:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1821,7 +1821,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43504ea3-caec-46e6-bf26-82473d642e75
+      - 74362be1-be86-4bd0-85e1-771e7640b013
     status: 200 OK
     code: 200
     duration: ""
@@ -1832,19 +1832,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}'
+    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
     headers:
       Content-Length:
-      - "431"
+      - "418"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:45 GMT
+      - Thu, 02 Nov 2023 18:57:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1854,7 +1854,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c483db05-4f9a-478f-9825-eb599429e711
+      - 24359e26-1d01-4d92-ac00-2478fc1d22e5
     status: 200 OK
     code: 200
     duration: ""
@@ -1865,19 +1865,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=ab57ef3c-d677-49cf-b04c-1651cd3fa9b7&name=test_backup_datasource&order_by=created_at_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=d663eb0a-fb6a-46fa-9cbc-9d926862b8cb&name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "471"
+      - "457"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:45 GMT
+      - Thu, 02 Nov 2023 18:57:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1887,7 +1887,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5736ccd7-8bee-4e24-a462-c4ac0971766f
+      - 9bc4f984-550a-41be-bd89-c3760f2ca65d
     status: 200 OK
     code: 200
     duration: ""
@@ -1901,16 +1901,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "471"
+      - "457"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:45 GMT
+      - Thu, 02 Nov 2023 18:57:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1920,7 +1920,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b31374d-efc5-492a-912f-d119081a12a4
+      - 7619bf53-c85c-4805-8cc8-97c80590e687
     status: 200 OK
     code: 200
     duration: ""
@@ -1931,19 +1931,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}'
+    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
     headers:
       Content-Length:
-      - "431"
+      - "418"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:48 GMT
+      - Thu, 02 Nov 2023 18:57:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1953,7 +1953,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84ec3fea-0f4d-40c3-8429-fec1ee0bb4a9
+      - e158fd20-e7cc-4ca0-955f-c7d0782550d7
     status: 200 OK
     code: 200
     duration: ""
@@ -1964,19 +1964,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}'
+    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
     headers:
       Content-Length:
-      - "431"
+      - "418"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:49 GMT
+      - Thu, 02 Nov 2023 18:57:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1986,7 +1986,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ae5996f-4c5f-427c-af83-e87cc608d729
+      - b5ad3aba-a8a6-4078-8c70-4ca47052c19e
     status: 200 OK
     code: 200
     duration: ""
@@ -1997,19 +1997,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-10-20T16:01:13.314022Z"}'
+    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
     headers:
       Content-Length:
-      - "431"
+      - "418"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:50 GMT
+      - Thu, 02 Nov 2023 18:57:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2019,7 +2019,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97820421-22e2-436f-ba34-08016230bc78
+      - 04487ca1-0ee7-446f-b8c8-8f7c0dd2da57
     status: 200 OK
     code: 200
     duration: ""
@@ -2030,19 +2030,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: DELETE
   response:
-    body: '{"created_at":"2023-10-20T16:01:11.404683Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","instance_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"deleting","updated_at":"2023-10-20T16:01:13.314022Z"}'
+    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"deleting","updated_at":"2023-11-02T18:56:28.848960Z"}'
     headers:
       Content-Length:
-      - "434"
+      - "421"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:50 GMT
+      - Thu, 02 Nov 2023 18:57:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2052,7 +2052,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63f475c9-b561-4d54-80c9-44bc932b2fa1
+      - 448fb487-4e0d-44e5-8df2-2fc978c57a35
     status: 200 OK
     code: 200
     duration: ""
@@ -2063,10 +2063,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2075,7 +2075,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:50 GMT
+      - Thu, 02 Nov 2023 18:57:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2085,7 +2085,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d1999c3-c1a5-41e5-8a11-42a7e8a01372
+      - 24c52f27-dfbf-466c-9fc7-c69710276ab7
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2096,19 +2096,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:58:35.775036Z","retention":7},"created_at":"2023-10-20T15:58:35.775036Z","endpoint":{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015},"endpoints":[{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015}],"engine":"PostgreSQL-15","id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:50 GMT
+      - Thu, 02 Nov 2023 18:57:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2118,7 +2118,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cff0de26-90ba-4974-a0c1-84711f6b0721
+      - d7e9e8e5-90f5-4641-a223-76c0090ae17e
     status: 200 OK
     code: 200
     duration: ""
@@ -2129,7 +2129,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7/databases/test-terraform
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/databases/test-terraform
     method: DELETE
   response:
     body: ""
@@ -2139,7 +2139,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:51 GMT
+      - Thu, 02 Nov 2023 18:57:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2149,7 +2149,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80919e6b-001a-45be-aaf5-87d73814d8ef
+      - e525a7db-b9df-4097-9845-01474285b101
     status: 204 No Content
     code: 204
     duration: ""
@@ -2160,19 +2160,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:58:35.775036Z","retention":7},"created_at":"2023-10-20T15:58:35.775036Z","endpoint":{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015},"endpoints":[{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015}],"engine":"PostgreSQL-15","id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:51 GMT
+      - Thu, 02 Nov 2023 18:57:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2182,7 +2182,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2935ce14-8e69-40b3-ba88-04fb4ff7130a
+      - b8dc8839-fff6-4327-a584-dced6ca2d56e
     status: 200 OK
     code: 200
     duration: ""
@@ -2193,19 +2193,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:58:35.775036Z","retention":7},"created_at":"2023-10-20T15:58:35.775036Z","endpoint":{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015},"endpoints":[{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015}],"engine":"PostgreSQL-15","id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:51 GMT
+      - Thu, 02 Nov 2023 18:57:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2215,7 +2215,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67e66ea1-b8cb-4576-a5d7-549365bcba93
+      - cef145a2-79c5-4085-8fc8-36f4e83b8109
     status: 200 OK
     code: 200
     duration: ""
@@ -2226,19 +2226,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:58:35.775036Z","retention":7},"created_at":"2023-10-20T15:58:35.775036Z","endpoint":{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015},"endpoints":[{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015}],"engine":"PostgreSQL-15","id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1252"
+      - "1206"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:51 GMT
+      - Thu, 02 Nov 2023 18:57:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2248,7 +2248,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76f679d6-74b6-4dc8-a0e4-734b8299c062
+      - b4a2ef95-3e50-4d01-a41d-55dfe96aa8d5
     status: 200 OK
     code: 200
     duration: ""
@@ -2259,19 +2259,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:58:35.775036Z","retention":7},"created_at":"2023-10-20T15:58:35.775036Z","endpoint":{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015},"endpoints":[{"id":"6786f88e-ef95-4172-8c17-3585ee888bba","ip":"51.159.26.148","load_balancer":{},"name":null,"port":19015}],"engine":"PostgreSQL-15","id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1252"
+      - "1206"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:52 GMT
+      - Thu, 02 Nov 2023 18:57:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2281,7 +2281,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1827264f-96e2-4387-bd15-1c6cdab423e8
+      - a71dd2ca-879b-43a5-9af3-aad4b579fdf8
     status: 200 OK
     code: 200
     duration: ""
@@ -2292,10 +2292,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2304,7 +2304,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:22 GMT
+      - Thu, 02 Nov 2023 18:57:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2314,7 +2314,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c49b0df4-fd82-459c-a977-980220e2d43e
+      - 52bdc3c2-9d6e-45b5-b470-9d9fd453e645
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2325,10 +2325,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab57ef3c-d677-49cf-b04c-1651cd3fa9b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"ab57ef3c-d677-49cf-b04c-1651cd3fa9b7","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2337,7 +2337,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:22 GMT
+      - Thu, 02 Nov 2023 18:57:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2347,7 +2347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d3f88d4-af88-4c9c-b8a6-8ab5590a9bc4
+      - afb8d553-4f29-4ff1-a326-9eee364875f6
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2358,10 +2358,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2370,7 +2370,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:22 GMT
+      - Thu, 02 Nov 2023 18:57:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2380,7 +2380,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be49a932-86ef-44f5-836f-c1ef2fe7482a
+      - 4fcaf535-6756-4c1e-83c4-2f6c8bc428a8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2391,10 +2391,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2403,7 +2403,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:22 GMT
+      - Thu, 02 Nov 2023 18:57:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2413,7 +2413,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07f59e50-d95d-4d0a-9b50-0d57c242c53b
+      - 25f509e5-335d-4e6a-b655-1bbe39b0878f
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2424,10 +2424,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2436,7 +2436,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:22 GMT
+      - Thu, 02 Nov 2023 18:57:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2446,7 +2446,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9091e9f2-9a31-49a2-abfa-b7203da2e26b
+      - f22d7df6-9db7-49ef-9629-3a10cff9e437
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2457,10 +2457,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/881d0a92-40f8-4f40-9e4c-0adbd6558867
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"881d0a92-40f8-4f40-9e4c-0adbd6558867","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2469,7 +2469,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:22 GMT
+      - Thu, 02 Nov 2023 18:57:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2479,7 +2479,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1fa3b757-5f7d-4823-8305-e3b21550da27
+      - 7dfb0d0e-f5b5-4c23-9ee1-82ed8a2c2b59
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-rdb-database-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-rdb-database-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:03 GMT
+      - Thu, 02 Nov 2023 18:46:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b368610b-a067-4e65-8c67-f535bf7bb342
+      - 139ca6d2-3a33-402d-ad8c-b61a44c1c164
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-terraform","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-terraform","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:06.561937Z","retention":7},"created_at":"2023-10-20T15:55:06.561937Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"eb90cf12-4068-4268-8c7d-43f70318cd0f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "757"
+      - "730"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:06 GMT
+      - Thu, 02 Nov 2023 18:50:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc922a85-3e49-43b1-9ed5-e28b72d22b75
+      - 4a024e5c-5527-439c-a0e4-d13458e20a9f
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:06.561937Z","retention":7},"created_at":"2023-10-20T15:55:06.561937Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"eb90cf12-4068-4268-8c7d-43f70318cd0f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "757"
+      - "730"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:07 GMT
+      - Thu, 02 Nov 2023 18:50:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf50eab0-0a9f-4012-b48f-cdd17fd1a0d9
+      - 42add12a-5e5b-4868-8b53-bf8ed331c0b1
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:06.561937Z","retention":7},"created_at":"2023-10-20T15:55:06.561937Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"eb90cf12-4068-4268-8c7d-43f70318cd0f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "757"
+      - "730"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:37 GMT
+      - Thu, 02 Nov 2023 18:50:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ab25f6e-7c64-4321-9aeb-88dd692c4e94
+      - 1c0fef40-31e4-4dc2-9420-497bee9d7ad7
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:06.561937Z","retention":7},"created_at":"2023-10-20T15:55:06.561937Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"eb90cf12-4068-4268-8c7d-43f70318cd0f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "757"
+      - "730"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:56:07 GMT
+      - Thu, 02 Nov 2023 18:51:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb2438f9-6b76-4835-a099-4c65fabc489f
+      - 203f7e2e-8705-4c70-bbea-35bbad6b65ec
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:06.561937Z","retention":7},"created_at":"2023-10-20T15:55:06.561937Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"eb90cf12-4068-4268-8c7d-43f70318cd0f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "757"
+      - "730"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:56:37 GMT
+      - Thu, 02 Nov 2023 18:51:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ddf3a27-5b77-4f70-96e0-d7234f0787a5
+      - aad07b65-a527-4e1c-a4a4-e7139117ab8d
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:06.561937Z","retention":7},"created_at":"2023-10-20T15:55:06.561937Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"eb90cf12-4068-4268-8c7d-43f70318cd0f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "757"
+      - "730"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:08 GMT
+      - Thu, 02 Nov 2023 18:52:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d7f31ef-1752-4f92-a5a0-4ec5f2debdb4
+      - c38163d4-2a2e-4233-bf1c-b651166c259c
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:06.561937Z","retention":7},"created_at":"2023-10-20T15:55:06.561937Z","endpoint":{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051},"endpoints":[{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051}],"engine":"PostgreSQL-15","id":"eb90cf12-4068-4268-8c7d-43f70318cd0f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:38 GMT
+      - Thu, 02 Nov 2023 18:52:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,12 +561,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b87137bd-73ec-43d4-b95e-3894517d2fae
+      - df0627a0-b537-4e56-900e-8f7d27826111
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"backup_schedule_frequency":null,"backup_schedule_retention":null,"is_backup_schedule_disabled":false,"name":null,"tags":null,"logs_policy":null,"backup_same_region":false,"backup_schedule_start_hour":null}'
+    body: '{"is_backup_schedule_disabled":false,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -574,19 +574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:06.561937Z","retention":7},"created_at":"2023-10-20T15:55:06.561937Z","endpoint":{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051},"endpoints":[{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051}],"engine":"PostgreSQL-15","id":"eb90cf12-4068-4268-8c7d-43f70318cd0f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:38 GMT
+      - Thu, 02 Nov 2023 18:52:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7417f310-58fb-4166-b837-fcfae0cfcc9d
+      - 96b12304-5c2f-4fdc-ade4-c5911d33272e
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:06.561937Z","retention":7},"created_at":"2023-10-20T15:55:06.561937Z","endpoint":{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051},"endpoints":[{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051}],"engine":"PostgreSQL-15","id":"eb90cf12-4068-4268-8c7d-43f70318cd0f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:38 GMT
+      - Thu, 02 Nov 2023 18:52:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0cd8aaf4-8f8d-4af7-9e6d-4105de134427
+      - 2b3318c8-1503-43a3-bc1d-3cafbbe06287
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVQW12QlU3OUkveGRYbGNvNWQwTmlxbXIxTXNvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5UUTFXaGNOTXpNeE1ERTNNVFUxTlRRMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1BelkvMnRqVGlQOG1BTkY1YzRqNDVOTXFBQ3BXM2tVK0YvRU1lVTh1bEtxbkF4WmxaRmpRMkUKR24rQ0hCNmt6d1VQZTN2WU9uMzJGRXBXV0Q3UGw5YnlnR2pvRzVWMW5MWVoxcTMrOUtVWDVPODZLZ2FNYkNKWQpOQ2ZLVlVYNWpPQks5TDN5OTNlNE9aWWViSGM2c0Q1NFRHTnNnOXh0ZWExNHR3TlRGa2hUQlJuT00wcFZ5aWJZCmJmbUdVem9Oei82OGNCYzlNVjRrTmc1RkRMNi9DbUZDWlZydUJObVZIckdPM2FTOXQ0V21aTGFxeFgvQ2tGa20KRmZxT0pzL0YvRGl6eWVKRmtkeG53VnduVkNDNVYzUFlaQThGT2lmYVFFODRaTWN0Szd4V3hydXlpRGhhWURKdgpZU3NRbUZHUzlyZmswMmZaZHh2RzAycXJLTHJpMDZjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0WldJNU1HTm1NVEl0TkRBMk9DMDBNalk0TFRoak4yUXRORE5tTnpBek1UaGoKWkRCbUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm41dmh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQTdhNVNkVWVQazF1bkQvenI4aUNsbFRWK2JIR2F5SVdURlNwbkJzejRrU1d2a1hxbXJ0Z2RIClBXNTNRSnlEeHE3Q1FMNTFTcXUxU2xWcFZkZHRJMXpYR3dFSWlLMlcvVXVMcHhIemNPRlYxTWRRN2xVazVFZkoKL1lRKzFxM01DYmZHcEZEQnJnemtRS3NOZDRBSFZFT2hLcjdFTEsxYjFacG5qZFUxQzU1MkFsQzZJS254MW1OQQp4N3RzQ0NzSVQ0NFFNNkZoN0ZIanJwak5sT3FIb0FDYzFEcjZWTUo0bUNRd2tnWjRneUlyMlNDZkJFbDU4dWdGCm40L2xkY1dHa1BEaDlNbGtxZXdNZ1FwSkF6WVl4QlJ4b1hQeWkrSmxNZ1hiTTMweDE5VGpZRFE3NmlJQ01rMjkKM0VuR3dPQ01IaTZFMFpackcrV3VZelBTWEdZbE5jejcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVRTlwRzhjdWRaTnhmQy9FRG9FWGVQRWlMWWI4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURVdU1URTFNQjRYCkRUSXpNVEV3TWpFNE5UQTFORm9YRFRNek1UQXpNREU0TlRBMU5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRFV1TVRFMU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXU5VllmRnNveXBESWtLekkvVXBwMHoxOFE4ZldxakdYTUpXYTlDRXJsTVJzMG5INEh0SWcKbExXNFpyd3lxbm1YZGhTZjhpNEJvMitaSjM0eUlmRktsUGdtcWFvYk1keCs4MlRoVFFNek9NUE96TFJzWTdoNApWdDJja2hsZ2RzTy9IOVg4Ti8yb1k5aGt5cklCZzAxRlk5dXFEZTMzaU9iTittTm50djcrSGU3RmZ1RGhGcThCClpPY0t0bGlEU3dYVEc4SEp6a29XTWRWVDBoSzhkUUpoWXlGamFERlpwdEQrYXpMcjB0L3A5amZYL05WZHZHREwKaVdsQmhIZVRSRXpKd1UyeWY3YkJud25oaU9jM0o0NVR5M1JPK2RieVRrZTFrRlMrSTdoSnIxNXJZY0NscDFMQQpGODZEVE1ZSzZRdWxlQ05sWnF1LzdLM1prbkRJNmpKTjF3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBMUxqRXhOWUk4Y25jdE1HVTNaVGM0TldJdE5Ea3pNeTAwTnpJd0xUa3pNVGN0TkRBeE56SXkKTnpjeE9XVXlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJMSllod1F6bjgxek1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUFIbW1iOFgyc2x0RU1TU1dFU2FBYk54M1hWayszRXBaNGRSZVJmNHpWeWNiODNYUDZhCjB5aFErS1F5UURxL0M0QXNyUzZ2M2ZYeTk4VmhDdUFWMDJlMlEvSTB1eGVhWEdLVHdrd005R0dRR3czQVdIdHUKY3hseXltd043QmF6cjZSU1g0SndtUUdxajdsd3R2WElvUTNjeHV1WUFzMjRmbnJGZDJVY2E0MnBodUIxQWZQagpqeitORmxyNDZESmVLdXRIbmt5Q1ZsZ0hrNkE3Z0laQXFXL05sR2hDWXRTK21xYVovL0NCeGNVdkNJWlNmYnEyClBPQ3FYd0hib0RaSWllNmlhY1IrUEdmUGxTWTFVT1Y5MWE3Y2FGb1ZxTzN1b1BFeWZhVHp1Rm5pYkc0cVNhVjIKQWlyalJYMndUMVZWMzBMY1pTVGMzUGRxeFZwTnZoZlB5S1o4Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1847"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:38 GMT
+      - Thu, 02 Nov 2023 18:52:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50f2c747-e066-4984-a3ed-adb7632c6d30
+      - c151b1f7-0502-43d1-8b48-c7a7ddb11b3d
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:06.561937Z","retention":7},"created_at":"2023-10-20T15:55:06.561937Z","endpoint":{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051},"endpoints":[{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051}],"engine":"PostgreSQL-15","id":"eb90cf12-4068-4268-8c7d-43f70318cd0f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:38 GMT
+      - Thu, 02 Nov 2023 18:52:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8afc523-dc67-4701-a571-8ae2b93873c8
+      - b70b958c-48b7-429f-8ad0-7387fa911fd6
     status: 200 OK
     code: 200
     duration: ""
@@ -708,19 +708,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases
     method: POST
   response:
     body: '{"managed":true,"name":"test-terraform","owner":"","size":0}'
     headers:
       Content-Length:
-      - "63"
+      - "60"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:39 GMT
+      - Thu, 02 Nov 2023 18:52:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -730,7 +730,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a90eb4d-ed3b-45ad-aa11-91e9909b0002
+      - 9dab7091-9f51-4d16-9ea6-b292045e141b
     status: 200 OK
     code: 200
     duration: ""
@@ -741,19 +741,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:06.561937Z","retention":7},"created_at":"2023-10-20T15:55:06.561937Z","endpoint":{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051},"endpoints":[{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051}],"engine":"PostgreSQL-15","id":"eb90cf12-4068-4268-8c7d-43f70318cd0f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:39 GMT
+      - Thu, 02 Nov 2023 18:52:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +763,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32c0143d-6499-4e2e-b8ca-912dac3b003c
+      - 3ba4e098-7157-4bdc-95a0-dde4f3f633d2
     status: 200 OK
     code: 200
     duration: ""
@@ -774,118 +774,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f/databases?name=test-terraform&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "117"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:57:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dbc77aa0-b5be-4c0e-a443-d6e3e5b7df03
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:06.561937Z","retention":7},"created_at":"2023-10-20T15:55:06.561937Z","endpoint":{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051},"endpoints":[{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051}],"engine":"PostgreSQL-15","id":"eb90cf12-4068-4268-8c7d-43f70318cd0f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1249"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:57:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5e04b410-8389-46d0-b9b9-d9e585c48b7f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVQW12QlU3OUkveGRYbGNvNWQwTmlxbXIxTXNvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5UUTFXaGNOTXpNeE1ERTNNVFUxTlRRMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1BelkvMnRqVGlQOG1BTkY1YzRqNDVOTXFBQ3BXM2tVK0YvRU1lVTh1bEtxbkF4WmxaRmpRMkUKR24rQ0hCNmt6d1VQZTN2WU9uMzJGRXBXV0Q3UGw5YnlnR2pvRzVWMW5MWVoxcTMrOUtVWDVPODZLZ2FNYkNKWQpOQ2ZLVlVYNWpPQks5TDN5OTNlNE9aWWViSGM2c0Q1NFRHTnNnOXh0ZWExNHR3TlRGa2hUQlJuT00wcFZ5aWJZCmJmbUdVem9Oei82OGNCYzlNVjRrTmc1RkRMNi9DbUZDWlZydUJObVZIckdPM2FTOXQ0V21aTGFxeFgvQ2tGa20KRmZxT0pzL0YvRGl6eWVKRmtkeG53VnduVkNDNVYzUFlaQThGT2lmYVFFODRaTWN0Szd4V3hydXlpRGhhWURKdgpZU3NRbUZHUzlyZmswMmZaZHh2RzAycXJLTHJpMDZjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0WldJNU1HTm1NVEl0TkRBMk9DMDBNalk0TFRoak4yUXRORE5tTnpBek1UaGoKWkRCbUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm41dmh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQTdhNVNkVWVQazF1bkQvenI4aUNsbFRWK2JIR2F5SVdURlNwbkJzejRrU1d2a1hxbXJ0Z2RIClBXNTNRSnlEeHE3Q1FMNTFTcXUxU2xWcFZkZHRJMXpYR3dFSWlLMlcvVXVMcHhIemNPRlYxTWRRN2xVazVFZkoKL1lRKzFxM01DYmZHcEZEQnJnemtRS3NOZDRBSFZFT2hLcjdFTEsxYjFacG5qZFUxQzU1MkFsQzZJS254MW1OQQp4N3RzQ0NzSVQ0NFFNNkZoN0ZIanJwak5sT3FIb0FDYzFEcjZWTUo0bUNRd2tnWjRneUlyMlNDZkJFbDU4dWdGCm40L2xkY1dHa1BEaDlNbGtxZXdNZ1FwSkF6WVl4QlJ4b1hQeWkrSmxNZ1hiTTMweDE5VGpZRFE3NmlJQ01rMjkKM0VuR3dPQ01IaTZFMFpackcrV3VZelBTWEdZbE5jejcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1845"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:57:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 408d494a-d310-425b-8b3c-fdb0864de51b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "117"
+      - "113"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:40 GMT
+      - Thu, 02 Nov 2023 18:52:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 236d56a3-2363-4e16-8552-176fb05d71ee
+      - 3112f254-3bd9-4910-86ff-41b956ec678d
     status: 200 OK
     code: 200
     duration: ""
@@ -906,19 +807,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:06.561937Z","retention":7},"created_at":"2023-10-20T15:55:06.561937Z","endpoint":{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051},"endpoints":[{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051}],"engine":"PostgreSQL-15","id":"eb90cf12-4068-4268-8c7d-43f70318cd0f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:40 GMT
+      - Thu, 02 Nov 2023 18:52:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73fe2066-dfaa-4d5c-b951-62cd8561ff8e
+      - a73f134f-4d0a-4dde-ae7f-ff491cc4fd9e
     status: 200 OK
     code: 200
     duration: ""
@@ -939,19 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVQW12QlU3OUkveGRYbGNvNWQwTmlxbXIxTXNvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5UUTFXaGNOTXpNeE1ERTNNVFUxTlRRMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1BelkvMnRqVGlQOG1BTkY1YzRqNDVOTXFBQ3BXM2tVK0YvRU1lVTh1bEtxbkF4WmxaRmpRMkUKR24rQ0hCNmt6d1VQZTN2WU9uMzJGRXBXV0Q3UGw5YnlnR2pvRzVWMW5MWVoxcTMrOUtVWDVPODZLZ2FNYkNKWQpOQ2ZLVlVYNWpPQks5TDN5OTNlNE9aWWViSGM2c0Q1NFRHTnNnOXh0ZWExNHR3TlRGa2hUQlJuT00wcFZ5aWJZCmJmbUdVem9Oei82OGNCYzlNVjRrTmc1RkRMNi9DbUZDWlZydUJObVZIckdPM2FTOXQ0V21aTGFxeFgvQ2tGa20KRmZxT0pzL0YvRGl6eWVKRmtkeG53VnduVkNDNVYzUFlaQThGT2lmYVFFODRaTWN0Szd4V3hydXlpRGhhWURKdgpZU3NRbUZHUzlyZmswMmZaZHh2RzAycXJLTHJpMDZjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0WldJNU1HTm1NVEl0TkRBMk9DMDBNalk0TFRoak4yUXRORE5tTnpBek1UaGoKWkRCbUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm41dmh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQTdhNVNkVWVQazF1bkQvenI4aUNsbFRWK2JIR2F5SVdURlNwbkJzejRrU1d2a1hxbXJ0Z2RIClBXNTNRSnlEeHE3Q1FMNTFTcXUxU2xWcFZkZHRJMXpYR3dFSWlLMlcvVXVMcHhIemNPRlYxTWRRN2xVazVFZkoKL1lRKzFxM01DYmZHcEZEQnJnemtRS3NOZDRBSFZFT2hLcjdFTEsxYjFacG5qZFUxQzU1MkFsQzZJS254MW1OQQp4N3RzQ0NzSVQ0NFFNNkZoN0ZIanJwak5sT3FIb0FDYzFEcjZWTUo0bUNRd2tnWjRneUlyMlNDZkJFbDU4dWdGCm40L2xkY1dHa1BEaDlNbGtxZXdNZ1FwSkF6WVl4QlJ4b1hQeWkrSmxNZ1hiTTMweDE5VGpZRFE3NmlJQ01rMjkKM0VuR3dPQ01IaTZFMFpackcrV3VZelBTWEdZbE5jejcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVRTlwRzhjdWRaTnhmQy9FRG9FWGVQRWlMWWI4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURVdU1URTFNQjRYCkRUSXpNVEV3TWpFNE5UQTFORm9YRFRNek1UQXpNREU0TlRBMU5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRFV1TVRFMU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXU5VllmRnNveXBESWtLekkvVXBwMHoxOFE4ZldxakdYTUpXYTlDRXJsTVJzMG5INEh0SWcKbExXNFpyd3lxbm1YZGhTZjhpNEJvMitaSjM0eUlmRktsUGdtcWFvYk1keCs4MlRoVFFNek9NUE96TFJzWTdoNApWdDJja2hsZ2RzTy9IOVg4Ti8yb1k5aGt5cklCZzAxRlk5dXFEZTMzaU9iTittTm50djcrSGU3RmZ1RGhGcThCClpPY0t0bGlEU3dYVEc4SEp6a29XTWRWVDBoSzhkUUpoWXlGamFERlpwdEQrYXpMcjB0L3A5amZYL05WZHZHREwKaVdsQmhIZVRSRXpKd1UyeWY3YkJud25oaU9jM0o0NVR5M1JPK2RieVRrZTFrRlMrSTdoSnIxNXJZY0NscDFMQQpGODZEVE1ZSzZRdWxlQ05sWnF1LzdLM1prbkRJNmpKTjF3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBMUxqRXhOWUk4Y25jdE1HVTNaVGM0TldJdE5Ea3pNeTAwTnpJd0xUa3pNVGN0TkRBeE56SXkKTnpjeE9XVXlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJMSllod1F6bjgxek1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUFIbW1iOFgyc2x0RU1TU1dFU2FBYk54M1hWayszRXBaNGRSZVJmNHpWeWNiODNYUDZhCjB5aFErS1F5UURxL0M0QXNyUzZ2M2ZYeTk4VmhDdUFWMDJlMlEvSTB1eGVhWEdLVHdrd005R0dRR3czQVdIdHUKY3hseXltd043QmF6cjZSU1g0SndtUUdxajdsd3R2WElvUTNjeHV1WUFzMjRmbnJGZDJVY2E0MnBodUIxQWZQagpqeitORmxyNDZESmVLdXRIbmt5Q1ZsZ0hrNkE3Z0laQXFXL05sR2hDWXRTK21xYVovL0NCeGNVdkNJWlNmYnEyClBPQ3FYd0hib0RaSWllNmlhY1IrUEdmUGxTWTFVT1Y5MWE3Y2FGb1ZxTzN1b1BFeWZhVHp1Rm5pYkc0cVNhVjIKQWlyalJYMndUMVZWMzBMY1pTVGMzUGRxeFZwTnZoZlB5S1o4Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1847"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:40 GMT
+      - Thu, 02 Nov 2023 18:52:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb9c21de-4ce7-4816-b286-ac5c18968ef5
+      - 7836318a-f770-4ba4-984d-67241c48e84d
     status: 200 OK
     code: 200
     duration: ""
@@ -972,52 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f/databases?name=test-terraform&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "117"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:57:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cd787975-2ff8-41cc-9b9a-c0693fe68fdd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "117"
+      - "113"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:41 GMT
+      - Thu, 02 Nov 2023 18:52:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9bccf87-feb2-4513-8fb4-e06e8e0e1e37
+      - e451fe12-4390-4365-8b08-3eda3bb26637
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +906,85 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1203"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:52:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 89ad0fba-c494-4276-9246-4b1552a613d0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVRTlwRzhjdWRaTnhmQy9FRG9FWGVQRWlMWWI4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURVdU1URTFNQjRYCkRUSXpNVEV3TWpFNE5UQTFORm9YRFRNek1UQXpNREU0TlRBMU5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRFV1TVRFMU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXU5VllmRnNveXBESWtLekkvVXBwMHoxOFE4ZldxakdYTUpXYTlDRXJsTVJzMG5INEh0SWcKbExXNFpyd3lxbm1YZGhTZjhpNEJvMitaSjM0eUlmRktsUGdtcWFvYk1keCs4MlRoVFFNek9NUE96TFJzWTdoNApWdDJja2hsZ2RzTy9IOVg4Ti8yb1k5aGt5cklCZzAxRlk5dXFEZTMzaU9iTittTm50djcrSGU3RmZ1RGhGcThCClpPY0t0bGlEU3dYVEc4SEp6a29XTWRWVDBoSzhkUUpoWXlGamFERlpwdEQrYXpMcjB0L3A5amZYL05WZHZHREwKaVdsQmhIZVRSRXpKd1UyeWY3YkJud25oaU9jM0o0NVR5M1JPK2RieVRrZTFrRlMrSTdoSnIxNXJZY0NscDFMQQpGODZEVE1ZSzZRdWxlQ05sWnF1LzdLM1prbkRJNmpKTjF3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBMUxqRXhOWUk4Y25jdE1HVTNaVGM0TldJdE5Ea3pNeTAwTnpJd0xUa3pNVGN0TkRBeE56SXkKTnpjeE9XVXlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJMSllod1F6bjgxek1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUFIbW1iOFgyc2x0RU1TU1dFU2FBYk54M1hWayszRXBaNGRSZVJmNHpWeWNiODNYUDZhCjB5aFErS1F5UURxL0M0QXNyUzZ2M2ZYeTk4VmhDdUFWMDJlMlEvSTB1eGVhWEdLVHdrd005R0dRR3czQVdIdHUKY3hseXltd043QmF6cjZSU1g0SndtUUdxajdsd3R2WElvUTNjeHV1WUFzMjRmbnJGZDJVY2E0MnBodUIxQWZQagpqeitORmxyNDZESmVLdXRIbmt5Q1ZsZ0hrNkE3Z0laQXFXL05sR2hDWXRTK21xYVovL0NCeGNVdkNJWlNmYnEyClBPQ3FYd0hib0RaSWllNmlhY1IrUEdmUGxTWTFVT1Y5MWE3Y2FGb1ZxTzN1b1BFeWZhVHp1Rm5pYkc0cVNhVjIKQWlyalJYMndUMVZWMzBMY1pTVGMzUGRxeFZwTnZoZlB5S1o4Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1847"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 77b4755f-ecd7-4296-9bdf-2e0841dbf915
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "117"
+      - "113"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:42 GMT
+      - Thu, 02 Nov 2023 18:53:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d882509-f383-43bc-a814-13e4f277a54d
+      - 3d0a4a83-32a3-4a60-9c42-f693084ff1c7
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +1005,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "117"
+      - "113"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:42 GMT
+      - Thu, 02 Nov 2023 18:53:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9463057f-119a-49cf-9396-b82e0b45b525
+      - 1bc8af99-95eb-4504-822c-9f24f41c88fc
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,19 +1038,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "117"
+      - "113"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:42 GMT
+      - Thu, 02 Nov 2023 18:53:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f4c0b8a-1b58-4100-8380-004627b814c8
+      - 82fc0f66-e0f0-4042-834f-3db4c3736d5f
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,85 +1071,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:06.561937Z","retention":7},"created_at":"2023-10-20T15:55:06.561937Z","endpoint":{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051},"endpoints":[{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051}],"engine":"PostgreSQL-15","id":"eb90cf12-4068-4268-8c7d-43f70318cd0f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1249"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:57:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d709de5d-18f9-48e9-ac18-dfbb059ac941
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVQW12QlU3OUkveGRYbGNvNWQwTmlxbXIxTXNvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5UUTFXaGNOTXpNeE1ERTNNVFUxTlRRMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1BelkvMnRqVGlQOG1BTkY1YzRqNDVOTXFBQ3BXM2tVK0YvRU1lVTh1bEtxbkF4WmxaRmpRMkUKR24rQ0hCNmt6d1VQZTN2WU9uMzJGRXBXV0Q3UGw5YnlnR2pvRzVWMW5MWVoxcTMrOUtVWDVPODZLZ2FNYkNKWQpOQ2ZLVlVYNWpPQks5TDN5OTNlNE9aWWViSGM2c0Q1NFRHTnNnOXh0ZWExNHR3TlRGa2hUQlJuT00wcFZ5aWJZCmJmbUdVem9Oei82OGNCYzlNVjRrTmc1RkRMNi9DbUZDWlZydUJObVZIckdPM2FTOXQ0V21aTGFxeFgvQ2tGa20KRmZxT0pzL0YvRGl6eWVKRmtkeG53VnduVkNDNVYzUFlaQThGT2lmYVFFODRaTWN0Szd4V3hydXlpRGhhWURKdgpZU3NRbUZHUzlyZmswMmZaZHh2RzAycXJLTHJpMDZjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0WldJNU1HTm1NVEl0TkRBMk9DMDBNalk0TFRoak4yUXRORE5tTnpBek1UaGoKWkRCbUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm41dmh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQTdhNVNkVWVQazF1bkQvenI4aUNsbFRWK2JIR2F5SVdURlNwbkJzejRrU1d2a1hxbXJ0Z2RIClBXNTNRSnlEeHE3Q1FMNTFTcXUxU2xWcFZkZHRJMXpYR3dFSWlLMlcvVXVMcHhIemNPRlYxTWRRN2xVazVFZkoKL1lRKzFxM01DYmZHcEZEQnJnemtRS3NOZDRBSFZFT2hLcjdFTEsxYjFacG5qZFUxQzU1MkFsQzZJS254MW1OQQp4N3RzQ0NzSVQ0NFFNNkZoN0ZIanJwak5sT3FIb0FDYzFEcjZWTUo0bUNRd2tnWjRneUlyMlNDZkJFbDU4dWdGCm40L2xkY1dHa1BEaDlNbGtxZXdNZ1FwSkF6WVl4QlJ4b1hQeWkrSmxNZ1hiTTMweDE5VGpZRFE3NmlJQ01rMjkKM0VuR3dPQ01IaTZFMFpackcrV3VZelBTWEdZbE5jejcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1845"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:57:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f2f7bd4c-99c0-4bde-ba8f-8e076492088b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "117"
+      - "113"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:43 GMT
+      - Thu, 02 Nov 2023 18:53:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bd86222-5fed-4269-bd5d-02688fc39b27
+      - c43217be-cbb2-490e-ab93-98b4902d067f
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,19 +1104,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "117"
+      - "113"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:43 GMT
+      - Thu, 02 Nov 2023 18:53:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f28299d-1144-4d88-a757-6f18a77992d7
+      - 20bd7850-995a-4e5a-9b64-8dbbc3384321
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,19 +1137,85 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1203"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b22ae59d-3581-4f58-8d90-4b028136bbef
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVRTlwRzhjdWRaTnhmQy9FRG9FWGVQRWlMWWI4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURVdU1URTFNQjRYCkRUSXpNVEV3TWpFNE5UQTFORm9YRFRNek1UQXpNREU0TlRBMU5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRFV1TVRFMU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXU5VllmRnNveXBESWtLekkvVXBwMHoxOFE4ZldxakdYTUpXYTlDRXJsTVJzMG5INEh0SWcKbExXNFpyd3lxbm1YZGhTZjhpNEJvMitaSjM0eUlmRktsUGdtcWFvYk1keCs4MlRoVFFNek9NUE96TFJzWTdoNApWdDJja2hsZ2RzTy9IOVg4Ti8yb1k5aGt5cklCZzAxRlk5dXFEZTMzaU9iTittTm50djcrSGU3RmZ1RGhGcThCClpPY0t0bGlEU3dYVEc4SEp6a29XTWRWVDBoSzhkUUpoWXlGamFERlpwdEQrYXpMcjB0L3A5amZYL05WZHZHREwKaVdsQmhIZVRSRXpKd1UyeWY3YkJud25oaU9jM0o0NVR5M1JPK2RieVRrZTFrRlMrSTdoSnIxNXJZY0NscDFMQQpGODZEVE1ZSzZRdWxlQ05sWnF1LzdLM1prbkRJNmpKTjF3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBMUxqRXhOWUk4Y25jdE1HVTNaVGM0TldJdE5Ea3pNeTAwTnpJd0xUa3pNVGN0TkRBeE56SXkKTnpjeE9XVXlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJMSllod1F6bjgxek1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUFIbW1iOFgyc2x0RU1TU1dFU2FBYk54M1hWayszRXBaNGRSZVJmNHpWeWNiODNYUDZhCjB5aFErS1F5UURxL0M0QXNyUzZ2M2ZYeTk4VmhDdUFWMDJlMlEvSTB1eGVhWEdLVHdrd005R0dRR3czQVdIdHUKY3hseXltd043QmF6cjZSU1g0SndtUUdxajdsd3R2WElvUTNjeHV1WUFzMjRmbnJGZDJVY2E0MnBodUIxQWZQagpqeitORmxyNDZESmVLdXRIbmt5Q1ZsZ0hrNkE3Z0laQXFXL05sR2hDWXRTK21xYVovL0NCeGNVdkNJWlNmYnEyClBPQ3FYd0hib0RaSWllNmlhY1IrUEdmUGxTWTFVT1Y5MWE3Y2FGb1ZxTzN1b1BFeWZhVHp1Rm5pYkc0cVNhVjIKQWlyalJYMndUMVZWMzBMY1pTVGMzUGRxeFZwTnZoZlB5S1o4Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1847"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6525194d-5b48-4e59-911b-4429dad8d06e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "117"
+      - "113"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:44 GMT
+      - Thu, 02 Nov 2023 18:53:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50ed559c-42fa-47b0-8d4a-43b8fb33ff30
+      - 5cee4006-9e68-4b0c-b19d-55fe1bd3a733
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,19 +1236,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:06.561937Z","retention":7},"created_at":"2023-10-20T15:55:06.561937Z","endpoint":{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051},"endpoints":[{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051}],"engine":"PostgreSQL-15","id":"eb90cf12-4068-4268-8c7d-43f70318cd0f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "1249"
+      - "113"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:44 GMT
+      - Thu, 02 Nov 2023 18:53:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c65f407-eec8-47c9-a664-c53d0ee9c95b
+      - 97503e49-e25f-4575-8246-b6bb9f75d1e5
     status: 200 OK
     code: 200
     duration: ""
@@ -1335,7 +1269,73 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f/databases/test-terraform
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases?name=test-terraform&order_by=name_asc
+    method: GET
+  response:
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "113"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3f1f887e-f119-4b69-8b65-7975bea5747d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1203"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d1355619-ff7f-4769-9ed7-d3c73df6895f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases/test-terraform
     method: DELETE
   response:
     body: ""
@@ -1345,7 +1345,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:45 GMT
+      - Thu, 02 Nov 2023 18:53:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1355,7 +1355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14106f5a-dc48-49fd-a239-a38feb6bf27e
+      - f089320e-d37d-4264-b557-0be624aab2d5
     status: 204 No Content
     code: 204
     duration: ""
@@ -1366,19 +1366,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:06.561937Z","retention":7},"created_at":"2023-10-20T15:55:06.561937Z","endpoint":{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051},"endpoints":[{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051}],"engine":"PostgreSQL-15","id":"eb90cf12-4068-4268-8c7d-43f70318cd0f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:45 GMT
+      - Thu, 02 Nov 2023 18:53:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1388,7 +1388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82102bde-8f90-4a8a-9987-95071edad583
+      - da5bf097-1705-4138-a53f-7314475993ae
     status: 200 OK
     code: 200
     duration: ""
@@ -1399,19 +1399,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:06.561937Z","retention":7},"created_at":"2023-10-20T15:55:06.561937Z","endpoint":{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051},"endpoints":[{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051}],"engine":"PostgreSQL-15","id":"eb90cf12-4068-4268-8c7d-43f70318cd0f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:45 GMT
+      - Thu, 02 Nov 2023 18:53:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1421,7 +1421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 743fea69-e5a9-4a9e-8328-b5f8e7c0be7f
+      - 0bad658a-f3b8-412d-b2b0-3fec900bcf0a
     status: 200 OK
     code: 200
     duration: ""
@@ -1432,19 +1432,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:06.561937Z","retention":7},"created_at":"2023-10-20T15:55:06.561937Z","endpoint":{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051},"endpoints":[{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051}],"engine":"PostgreSQL-15","id":"eb90cf12-4068-4268-8c7d-43f70318cd0f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1252"
+      - "1206"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:48 GMT
+      - Thu, 02 Nov 2023 18:53:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1454,7 +1454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 972e7a61-4a78-4af0-8e27-9835ae90aca3
+      - f68636c3-f62a-4d11-97be-3bb4dfabe02d
     status: 200 OK
     code: 200
     duration: ""
@@ -1465,19 +1465,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:06.561937Z","retention":7},"created_at":"2023-10-20T15:55:06.561937Z","endpoint":{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051},"endpoints":[{"id":"de140c85-dde4-45ba-b8f1-809bad63cca6","ip":"51.159.26.148","load_balancer":{},"name":null,"port":17051}],"engine":"PostgreSQL-15","id":"eb90cf12-4068-4268-8c7d-43f70318cd0f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1252"
+      - "1206"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:49 GMT
+      - Thu, 02 Nov 2023 18:53:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1487,7 +1487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cec03b21-6286-4bd9-a90d-05338e501e4d
+      - 4a937c0a-db78-496d-a8f2-6480c3a5df2b
     status: 200 OK
     code: 200
     duration: ""
@@ -1498,10 +1498,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"eb90cf12-4068-4268-8c7d-43f70318cd0f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"0e7e785b-4933-4720-9317-4017227719e2","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1510,7 +1510,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:19 GMT
+      - Thu, 02 Nov 2023 18:53:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1520,7 +1520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2cc51fb9-1229-4899-a36f-75da86569b33
+      - e76acd11-aaea-44e5-8cd6-2349d43942d8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1531,10 +1531,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb90cf12-4068-4268-8c7d-43f70318cd0f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"eb90cf12-4068-4268-8c7d-43f70318cd0f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"0e7e785b-4933-4720-9317-4017227719e2","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1543,7 +1543,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:19 GMT
+      - Thu, 02 Nov 2023 18:53:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1553,7 +1553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 856de907-b5ff-49f4-b49b-2699924344a3
+      - 0afd2d4a-eb53-44f1-9114-9a03f5287335
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-rdb-instance-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-rdb-instance-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:04 GMT
+      - Thu, 02 Nov 2023 18:46:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 773915b0-fc08-447b-a24a-eb11cc28d94d
+      - 3d7b48c3-380d-4f52-8c78-8030af5b58bd
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"data-rdb-test-terraform","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"data-rdb-test-terraform","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "766"
+      - "739"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:15 GMT
+      - Thu, 02 Nov 2023 18:50:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 529b76d7-a11f-493d-baa3-d1d51396cb45
+      - 123ae0f0-ebbf-4873-8332-9ce8bce0459e
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "766"
+      - "739"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:15 GMT
+      - Thu, 02 Nov 2023 18:50:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca5b8f58-48bb-4226-a2a6-d3c9da870c7b
+      - 108faad0-accd-4c46-bf4d-5a0bbdd2d669
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "766"
+      - "739"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:51 GMT
+      - Thu, 02 Nov 2023 18:51:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9aeb281d-71f9-4ebf-adbd-9db60002c94c
+      - af6854d2-448f-4d2e-883f-5ce01d6317b8
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "766"
+      - "739"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:56:21 GMT
+      - Thu, 02 Nov 2023 18:51:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08418986-07a9-4a99-8c3a-1f68f936653e
+      - 2af8ce14-0572-4715-8269-ea037b774c25
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "766"
+      - "739"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:56:51 GMT
+      - Thu, 02 Nov 2023 18:52:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2db56de8-7b5d-4dd3-a71d-b18f1673b444
+      - d4811541-9aff-44ee-9850-77bcebe946d9
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "766"
+      - "739"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:21 GMT
+      - Thu, 02 Nov 2023 18:52:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a468f42-a525-4c25-9263-c6b6036a0da9
+      - 74b78798-5d30-4c8e-8c9c-444579ea1fae
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762},"endpoints":[{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762}],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1258"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:51 GMT
+      - Thu, 02 Nov 2023 18:53:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,12 +561,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc7ee61a-32f2-4ddc-a48e-3b272144efad
+      - ee00230f-62c7-4c9d-8be2-317acb023e05
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"backup_schedule_frequency":null,"backup_schedule_retention":null,"is_backup_schedule_disabled":false,"name":null,"tags":null,"logs_policy":null,"backup_same_region":false,"backup_schedule_start_hour":null}'
+    body: '{"is_backup_schedule_disabled":false,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -574,19 +574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762},"endpoints":[{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762}],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1258"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:52 GMT
+      - Thu, 02 Nov 2023 18:53:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80e64267-7ebb-43f7-8f90-f51b7cc9f3df
+      - 05f3754d-0f6d-4b1a-ba99-d9ed39da4960
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762},"endpoints":[{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762}],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1258"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:52 GMT
+      - Thu, 02 Nov 2023 18:53:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a3e52bd-49c8-46c2-beca-7b2a9d4a739b
+      - fc9cbc48-b0c1-4831-bc51-2523ec03e249
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVYnJXTk9hYUYwTmY0dmtVM2YrdWxLVk1KUFdNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5UVTBXaGNOTXpNeE1ERTNNVFUxTlRVMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxyc0dIZTNxdlRHWXRueVEySWpUL0ErQ0NlblRaMVVGREtkSVpRMEF1OUhlai9UOXdiQzBCc1YKUW5HSVpqSFd0bXQydWpNNDBITExsYmRxWXIwL2RYWUhYSk8vKzNDeWhFVGp6VW5xUGhZZTV5YmEvak5rNVJTUwo5TGpiNVZ1MUIyeFQxMFExeXhzMUtOckNLRGdDMWpDYzZkWnRVbHA1bU9PbHgxNWFxN2Q4RnZybVpXcDk4aXJoCmRDSUlFb1ZpTG9WdWt5R2s1NzhBcVNJNUQrZkE3UXk2M2VrbFozUERuQ21LWUE5Y04wMDl6VytIQTNnZWlCU2UKN0diRUhrd1Z0dm1ScmY3NlpTTE9PWVVBNENWdXcvOTFhWnhlbkxMWFRyWXVkTjJqMXVpaWh5aW80Z2R6aTNoTApqSk9rMkdteDlCYUJGZ004ekVxSEtBSlhHL09KbjFrQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0TmpVMFpETXlNR1F0WTJZeFppMDBOV05sTFRneE1EVXRNemsxTUdGbVpURXgKTURsaExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhaYWh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXhGSUZlb0pubUpCVlFWcW5PMWFqcjlDd0RyU0hDbERHSmxIZk1hSVFvaHpDeElZV3BvOUk0CmdLcXVwcWN0L2NyZ3VoSUFpeUp0VnluNmhXRzdFR2tKLzV4SG1pUlZod2NVUS9GMGtuSmR5aHpmbkw4bnU4KzIKOXFzYllHMFoxbzFQS0Z4ejNPdjFkZGxCejB2RFpuK3Erb1pGRU9YMnhTTnJaRTBuTkFyTTg3RHkrTksrU085awpuTnVKL0EvajB6TzFqNlZzVWlpMlZMZk1aSDdRVFI5Rmx4TGo1NHhWMFBtbjFiaHFvU0RFb3FaV3o1Mlp3d21JCm1pdjlaak5HdzNJRXoyYnBjMVNFNDkvZ0NkdFlVSno2Y3pEd2tycUdmbnV5aGplVFJLWXBJNzJzQ1dSNHNHdDkKUXN0VmJBd2gxRkNKUU9qS21XeWlrOXRLeWxUMGs3ZjcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXZ6VzlCVjlNWFIwOVk4VldORVE4OHl0SUc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1URXhXaGNOTXpNeE1ETXdNVGcxTVRFeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtyREQrU1J1cVZSUVVpUXhScVNRa29NSmVmZkYzWDdTOVM2STJoNFFZUldNN1RQRGo3cTJCaVQKWjZKcFF4bU5XY1ZzcXNPZ3J5Y3dYMDBLbWhhQjJEeENkZU8rbWF0M0ptNlVOcEFYYkZzSnZ3R3R2TmF2OHorUwpaY2hhM1UzTitZYXp0Myt4MWhiam1OcHF5OXhqVHlYblliR0hvVE5qT1pyS3F1MHZZTnlydzBkMjFmRXhYRkh2CkgyQTN1Q3B2RDBUUVdnSnBoRnpCeVRraFNFY3V4Q21iZnNyclU2U3NLc0J2S1JsTTNjQzBSdEZkR1pJc2NDSSsKTE5ReVRUdFV3aXpMV1RIbklmYThzandxeks1bDROSUxITnNvY0UwdG5aUUtpbEp3MVR2T1QzckQrZDNzR3hiTwo2Si9CdWd3K0pOdXl6T2dpaXVhSkNIa1RYZ2xFUG1rQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0Tm1RNE56Qm1OR010TUdZMVl5MDBPVFEwTFRrMllqQXRNelprTXpreE5HRmkKWkROakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtWNWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lqRjBsSlNkb05CdWlscDYvNXEzZk1lZUd4cGtZTm5LWlJ4a3lJMENVVHB6ZUt4eW1jOS9qClYwL2RBRy9RTXlIckp4RjNXQ0E4aHdYQzd0QlR4TkZFV29VVFFjNkFIUy9wenRkLy9KdjJQbkFvRS9XajdXWVcKVWFpcklNaitjSnNMaW9KTVlnWVQ4dS9jTS9vWGpJOHcrNmFlTjI1Ylp6eVRQN1A2SFRlQ1FQOUlYaDdWdjY1aApyWTBXUWxuUEhwTlRENDNzWkRlUDRXK0xqNGNLQWpBNWFZakhZZ2FvbmNvQlY0SUQ4TDZ0d2lweE9Mem9WcjR2CnZLRUhtNm5WWHRKZW5EbEt4N3FNK21ybVEzQTlFNG5QTlZBeDJGNG5WTEFONGJtdlM0RU85WU1YeHlOT0V4QVUKL1BGTzlrcCtLTE5HN0ZRYnN5ZVdSYzhpUDB4K0V5Ti8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:52 GMT
+      - Thu, 02 Nov 2023 18:53:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8a039f4-769c-4e76-9e07-e0e7a82c0a5f
+      - 70ce0716-f987-4cd3-8407-507ce7636723
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762},"endpoints":[{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762}],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1258"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:52 GMT
+      - Thu, 02 Nov 2023 18:53:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8272b19-60b8-4594-a4c6-142632df2b00
+      - 5403608a-1bc6-4675-99f2-c921757305fc
     status: 200 OK
     code: 200
     duration: ""
@@ -709,16 +709,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?name=data-rdb-test-terraform&order_by=created_at_asc
     method: GET
   response:
-    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762},"endpoints":[{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762}],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
     headers:
       Content-Length:
-      - "1291"
+      - "1244"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:52 GMT
+      - Thu, 02 Nov 2023 18:53:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52646fc8-fe9b-424f-af18-c32491ad588b
+      - 69c321bf-ddad-47fc-9edf-d5d80544e7b5
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVYnJXTk9hYUYwTmY0dmtVM2YrdWxLVk1KUFdNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5UVTBXaGNOTXpNeE1ERTNNVFUxTlRVMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxyc0dIZTNxdlRHWXRueVEySWpUL0ErQ0NlblRaMVVGREtkSVpRMEF1OUhlai9UOXdiQzBCc1YKUW5HSVpqSFd0bXQydWpNNDBITExsYmRxWXIwL2RYWUhYSk8vKzNDeWhFVGp6VW5xUGhZZTV5YmEvak5rNVJTUwo5TGpiNVZ1MUIyeFQxMFExeXhzMUtOckNLRGdDMWpDYzZkWnRVbHA1bU9PbHgxNWFxN2Q4RnZybVpXcDk4aXJoCmRDSUlFb1ZpTG9WdWt5R2s1NzhBcVNJNUQrZkE3UXk2M2VrbFozUERuQ21LWUE5Y04wMDl6VytIQTNnZWlCU2UKN0diRUhrd1Z0dm1ScmY3NlpTTE9PWVVBNENWdXcvOTFhWnhlbkxMWFRyWXVkTjJqMXVpaWh5aW80Z2R6aTNoTApqSk9rMkdteDlCYUJGZ004ekVxSEtBSlhHL09KbjFrQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0TmpVMFpETXlNR1F0WTJZeFppMDBOV05sTFRneE1EVXRNemsxTUdGbVpURXgKTURsaExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhaYWh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXhGSUZlb0pubUpCVlFWcW5PMWFqcjlDd0RyU0hDbERHSmxIZk1hSVFvaHpDeElZV3BvOUk0CmdLcXVwcWN0L2NyZ3VoSUFpeUp0VnluNmhXRzdFR2tKLzV4SG1pUlZod2NVUS9GMGtuSmR5aHpmbkw4bnU4KzIKOXFzYllHMFoxbzFQS0Z4ejNPdjFkZGxCejB2RFpuK3Erb1pGRU9YMnhTTnJaRTBuTkFyTTg3RHkrTksrU085awpuTnVKL0EvajB6TzFqNlZzVWlpMlZMZk1aSDdRVFI5Rmx4TGo1NHhWMFBtbjFiaHFvU0RFb3FaV3o1Mlp3d21JCm1pdjlaak5HdzNJRXoyYnBjMVNFNDkvZ0NkdFlVSno2Y3pEd2tycUdmbnV5aGplVFJLWXBJNzJzQ1dSNHNHdDkKUXN0VmJBd2gxRkNKUU9qS21XeWlrOXRLeWxUMGs3ZjcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXZ6VzlCVjlNWFIwOVk4VldORVE4OHl0SUc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1URXhXaGNOTXpNeE1ETXdNVGcxTVRFeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtyREQrU1J1cVZSUVVpUXhScVNRa29NSmVmZkYzWDdTOVM2STJoNFFZUldNN1RQRGo3cTJCaVQKWjZKcFF4bU5XY1ZzcXNPZ3J5Y3dYMDBLbWhhQjJEeENkZU8rbWF0M0ptNlVOcEFYYkZzSnZ3R3R2TmF2OHorUwpaY2hhM1UzTitZYXp0Myt4MWhiam1OcHF5OXhqVHlYblliR0hvVE5qT1pyS3F1MHZZTnlydzBkMjFmRXhYRkh2CkgyQTN1Q3B2RDBUUVdnSnBoRnpCeVRraFNFY3V4Q21iZnNyclU2U3NLc0J2S1JsTTNjQzBSdEZkR1pJc2NDSSsKTE5ReVRUdFV3aXpMV1RIbklmYThzandxeks1bDROSUxITnNvY0UwdG5aUUtpbEp3MVR2T1QzckQrZDNzR3hiTwo2Si9CdWd3K0pOdXl6T2dpaXVhSkNIa1RYZ2xFUG1rQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0Tm1RNE56Qm1OR010TUdZMVl5MDBPVFEwTFRrMllqQXRNelprTXpreE5HRmkKWkROakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtWNWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lqRjBsSlNkb05CdWlscDYvNXEzZk1lZUd4cGtZTm5LWlJ4a3lJMENVVHB6ZUt4eW1jOS9qClYwL2RBRy9RTXlIckp4RjNXQ0E4aHdYQzd0QlR4TkZFV29VVFFjNkFIUy9wenRkLy9KdjJQbkFvRS9XajdXWVcKVWFpcklNaitjSnNMaW9KTVlnWVQ4dS9jTS9vWGpJOHcrNmFlTjI1Ylp6eVRQN1A2SFRlQ1FQOUlYaDdWdjY1aApyWTBXUWxuUEhwTlRENDNzWkRlUDRXK0xqNGNLQWpBNWFZakhZZ2FvbmNvQlY0SUQ4TDZ0d2lweE9Mem9WcjR2CnZLRUhtNm5WWHRKZW5EbEt4N3FNK21ybVEzQTlFNG5QTlZBeDJGNG5WTEFONGJtdlM0RU85WU1YeHlOT0V4QVUKL1BGTzlrcCtLTE5HN0ZRYnN5ZVdSYzhpUDB4K0V5Ti8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:52 GMT
+      - Thu, 02 Nov 2023 18:53:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9a3c957-af15-4e21-bc74-ca5889012896
+      - 721a4009-fbf0-4a18-957f-e902e63bc0d2
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762},"endpoints":[{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762}],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1258"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:52 GMT
+      - Thu, 02 Nov 2023 18:53:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f773988-eea0-416b-b92a-d5e7e6bef64f
+      - e3d44bc9-a9d8-4796-b852-c3200504c03f
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVYnJXTk9hYUYwTmY0dmtVM2YrdWxLVk1KUFdNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5UVTBXaGNOTXpNeE1ERTNNVFUxTlRVMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxyc0dIZTNxdlRHWXRueVEySWpUL0ErQ0NlblRaMVVGREtkSVpRMEF1OUhlai9UOXdiQzBCc1YKUW5HSVpqSFd0bXQydWpNNDBITExsYmRxWXIwL2RYWUhYSk8vKzNDeWhFVGp6VW5xUGhZZTV5YmEvak5rNVJTUwo5TGpiNVZ1MUIyeFQxMFExeXhzMUtOckNLRGdDMWpDYzZkWnRVbHA1bU9PbHgxNWFxN2Q4RnZybVpXcDk4aXJoCmRDSUlFb1ZpTG9WdWt5R2s1NzhBcVNJNUQrZkE3UXk2M2VrbFozUERuQ21LWUE5Y04wMDl6VytIQTNnZWlCU2UKN0diRUhrd1Z0dm1ScmY3NlpTTE9PWVVBNENWdXcvOTFhWnhlbkxMWFRyWXVkTjJqMXVpaWh5aW80Z2R6aTNoTApqSk9rMkdteDlCYUJGZ004ekVxSEtBSlhHL09KbjFrQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0TmpVMFpETXlNR1F0WTJZeFppMDBOV05sTFRneE1EVXRNemsxTUdGbVpURXgKTURsaExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhaYWh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXhGSUZlb0pubUpCVlFWcW5PMWFqcjlDd0RyU0hDbERHSmxIZk1hSVFvaHpDeElZV3BvOUk0CmdLcXVwcWN0L2NyZ3VoSUFpeUp0VnluNmhXRzdFR2tKLzV4SG1pUlZod2NVUS9GMGtuSmR5aHpmbkw4bnU4KzIKOXFzYllHMFoxbzFQS0Z4ejNPdjFkZGxCejB2RFpuK3Erb1pGRU9YMnhTTnJaRTBuTkFyTTg3RHkrTksrU085awpuTnVKL0EvajB6TzFqNlZzVWlpMlZMZk1aSDdRVFI5Rmx4TGo1NHhWMFBtbjFiaHFvU0RFb3FaV3o1Mlp3d21JCm1pdjlaak5HdzNJRXoyYnBjMVNFNDkvZ0NkdFlVSno2Y3pEd2tycUdmbnV5aGplVFJLWXBJNzJzQ1dSNHNHdDkKUXN0VmJBd2gxRkNKUU9qS21XeWlrOXRLeWxUMGs3ZjcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXZ6VzlCVjlNWFIwOVk4VldORVE4OHl0SUc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1URXhXaGNOTXpNeE1ETXdNVGcxTVRFeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtyREQrU1J1cVZSUVVpUXhScVNRa29NSmVmZkYzWDdTOVM2STJoNFFZUldNN1RQRGo3cTJCaVQKWjZKcFF4bU5XY1ZzcXNPZ3J5Y3dYMDBLbWhhQjJEeENkZU8rbWF0M0ptNlVOcEFYYkZzSnZ3R3R2TmF2OHorUwpaY2hhM1UzTitZYXp0Myt4MWhiam1OcHF5OXhqVHlYblliR0hvVE5qT1pyS3F1MHZZTnlydzBkMjFmRXhYRkh2CkgyQTN1Q3B2RDBUUVdnSnBoRnpCeVRraFNFY3V4Q21iZnNyclU2U3NLc0J2S1JsTTNjQzBSdEZkR1pJc2NDSSsKTE5ReVRUdFV3aXpMV1RIbklmYThzandxeks1bDROSUxITnNvY0UwdG5aUUtpbEp3MVR2T1QzckQrZDNzR3hiTwo2Si9CdWd3K0pOdXl6T2dpaXVhSkNIa1RYZ2xFUG1rQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0Tm1RNE56Qm1OR010TUdZMVl5MDBPVFEwTFRrMllqQXRNelprTXpreE5HRmkKWkROakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtWNWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lqRjBsSlNkb05CdWlscDYvNXEzZk1lZUd4cGtZTm5LWlJ4a3lJMENVVHB6ZUt4eW1jOS9qClYwL2RBRy9RTXlIckp4RjNXQ0E4aHdYQzd0QlR4TkZFV29VVFFjNkFIUy9wenRkLy9KdjJQbkFvRS9XajdXWVcKVWFpcklNaitjSnNMaW9KTVlnWVQ4dS9jTS9vWGpJOHcrNmFlTjI1Ylp6eVRQN1A2SFRlQ1FQOUlYaDdWdjY1aApyWTBXUWxuUEhwTlRENDNzWkRlUDRXK0xqNGNLQWpBNWFZakhZZ2FvbmNvQlY0SUQ4TDZ0d2lweE9Mem9WcjR2CnZLRUhtNm5WWHRKZW5EbEt4N3FNK21ybVEzQTlFNG5QTlZBeDJGNG5WTEFONGJtdlM0RU85WU1YeHlOT0V4QVUKL1BGTzlrcCtLTE5HN0ZRYnN5ZVdSYzhpUDB4K0V5Ti8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:52 GMT
+      - Thu, 02 Nov 2023 18:53:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abedc94c-0ea3-4f67-a218-668474dcb208
+      - 0634089c-09ef-4b68-a2ce-aa51fe8463c6
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762},"endpoints":[{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762}],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1258"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:53 GMT
+      - Thu, 02 Nov 2023 18:53:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 949b39df-0c7c-44ca-acf4-ece2fcdc58ce
+      - 031fbef5-7060-4e64-b4ed-1a5e126e4a58
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762},"endpoints":[{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762}],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1258"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:54 GMT
+      - Thu, 02 Nov 2023 18:53:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e659e26-b9ad-43a6-b7e5-ef6352d5d41c
+      - 6aef5e5d-c701-467b-9db1-acd3d025329f
     status: 200 OK
     code: 200
     duration: ""
@@ -907,16 +907,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?name=data-rdb-test-terraform&order_by=created_at_asc
     method: GET
   response:
-    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762},"endpoints":[{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762}],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
     headers:
       Content-Length:
-      - "1291"
+      - "1244"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:54 GMT
+      - Thu, 02 Nov 2023 18:53:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32fee511-a0ac-40a3-a5ba-b2e39ba426d1
+      - 1cad5df8-1ed9-4919-bb6e-2613bc588d71
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762},"endpoints":[{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762}],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXZ6VzlCVjlNWFIwOVk4VldORVE4OHl0SUc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1URXhXaGNOTXpNeE1ETXdNVGcxTVRFeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtyREQrU1J1cVZSUVVpUXhScVNRa29NSmVmZkYzWDdTOVM2STJoNFFZUldNN1RQRGo3cTJCaVQKWjZKcFF4bU5XY1ZzcXNPZ3J5Y3dYMDBLbWhhQjJEeENkZU8rbWF0M0ptNlVOcEFYYkZzSnZ3R3R2TmF2OHorUwpaY2hhM1UzTitZYXp0Myt4MWhiam1OcHF5OXhqVHlYblliR0hvVE5qT1pyS3F1MHZZTnlydzBkMjFmRXhYRkh2CkgyQTN1Q3B2RDBUUVdnSnBoRnpCeVRraFNFY3V4Q21iZnNyclU2U3NLc0J2S1JsTTNjQzBSdEZkR1pJc2NDSSsKTE5ReVRUdFV3aXpMV1RIbklmYThzandxeks1bDROSUxITnNvY0UwdG5aUUtpbEp3MVR2T1QzckQrZDNzR3hiTwo2Si9CdWd3K0pOdXl6T2dpaXVhSkNIa1RYZ2xFUG1rQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0Tm1RNE56Qm1OR010TUdZMVl5MDBPVFEwTFRrMllqQXRNelprTXpreE5HRmkKWkROakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtWNWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lqRjBsSlNkb05CdWlscDYvNXEzZk1lZUd4cGtZTm5LWlJ4a3lJMENVVHB6ZUt4eW1jOS9qClYwL2RBRy9RTXlIckp4RjNXQ0E4aHdYQzd0QlR4TkZFV29VVFFjNkFIUy9wenRkLy9KdjJQbkFvRS9XajdXWVcKVWFpcklNaitjSnNMaW9KTVlnWVQ4dS9jTS9vWGpJOHcrNmFlTjI1Ylp6eVRQN1A2SFRlQ1FQOUlYaDdWdjY1aApyWTBXUWxuUEhwTlRENDNzWkRlUDRXK0xqNGNLQWpBNWFZakhZZ2FvbmNvQlY0SUQ4TDZ0d2lweE9Mem9WcjR2CnZLRUhtNm5WWHRKZW5EbEt4N3FNK21ybVEzQTlFNG5QTlZBeDJGNG5WTEFONGJtdlM0RU85WU1YeHlOT0V4QVUKL1BGTzlrcCtLTE5HN0ZRYnN5ZVdSYzhpUDB4K0V5Ti8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1258"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:54 GMT
+      - Thu, 02 Nov 2023 18:53:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bd8e113-ca31-4b9c-a193-23199c006801
+      - 144aec37-1738-42d5-8e8c-d025ea5ce16d
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVYnJXTk9hYUYwTmY0dmtVM2YrdWxLVk1KUFdNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5UVTBXaGNOTXpNeE1ERTNNVFUxTlRVMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxyc0dIZTNxdlRHWXRueVEySWpUL0ErQ0NlblRaMVVGREtkSVpRMEF1OUhlai9UOXdiQzBCc1YKUW5HSVpqSFd0bXQydWpNNDBITExsYmRxWXIwL2RYWUhYSk8vKzNDeWhFVGp6VW5xUGhZZTV5YmEvak5rNVJTUwo5TGpiNVZ1MUIyeFQxMFExeXhzMUtOckNLRGdDMWpDYzZkWnRVbHA1bU9PbHgxNWFxN2Q4RnZybVpXcDk4aXJoCmRDSUlFb1ZpTG9WdWt5R2s1NzhBcVNJNUQrZkE3UXk2M2VrbFozUERuQ21LWUE5Y04wMDl6VytIQTNnZWlCU2UKN0diRUhrd1Z0dm1ScmY3NlpTTE9PWVVBNENWdXcvOTFhWnhlbkxMWFRyWXVkTjJqMXVpaWh5aW80Z2R6aTNoTApqSk9rMkdteDlCYUJGZ004ekVxSEtBSlhHL09KbjFrQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0TmpVMFpETXlNR1F0WTJZeFppMDBOV05sTFRneE1EVXRNemsxTUdGbVpURXgKTURsaExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhaYWh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXhGSUZlb0pubUpCVlFWcW5PMWFqcjlDd0RyU0hDbERHSmxIZk1hSVFvaHpDeElZV3BvOUk0CmdLcXVwcWN0L2NyZ3VoSUFpeUp0VnluNmhXRzdFR2tKLzV4SG1pUlZod2NVUS9GMGtuSmR5aHpmbkw4bnU4KzIKOXFzYllHMFoxbzFQS0Z4ejNPdjFkZGxCejB2RFpuK3Erb1pGRU9YMnhTTnJaRTBuTkFyTTg3RHkrTksrU085awpuTnVKL0EvajB6TzFqNlZzVWlpMlZMZk1aSDdRVFI5Rmx4TGo1NHhWMFBtbjFiaHFvU0RFb3FaV3o1Mlp3d21JCm1pdjlaak5HdzNJRXoyYnBjMVNFNDkvZ0NkdFlVSno2Y3pEd2tycUdmbnV5aGplVFJLWXBJNzJzQ1dSNHNHdDkKUXN0VmJBd2gxRkNKUU9qS21XeWlrOXRLeWxUMGs3ZjcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1845"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:54 GMT
+      - Thu, 02 Nov 2023 18:53:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3644a02b-3af8-478e-a570-9c8f870baa1b
+      - 5015b28a-07f0-4c81-835c-be3f5fdca524
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,19 +1003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVYnJXTk9hYUYwTmY0dmtVM2YrdWxLVk1KUFdNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5UVTBXaGNOTXpNeE1ERTNNVFUxTlRVMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxyc0dIZTNxdlRHWXRueVEySWpUL0ErQ0NlblRaMVVGREtkSVpRMEF1OUhlai9UOXdiQzBCc1YKUW5HSVpqSFd0bXQydWpNNDBITExsYmRxWXIwL2RYWUhYSk8vKzNDeWhFVGp6VW5xUGhZZTV5YmEvak5rNVJTUwo5TGpiNVZ1MUIyeFQxMFExeXhzMUtOckNLRGdDMWpDYzZkWnRVbHA1bU9PbHgxNWFxN2Q4RnZybVpXcDk4aXJoCmRDSUlFb1ZpTG9WdWt5R2s1NzhBcVNJNUQrZkE3UXk2M2VrbFozUERuQ21LWUE5Y04wMDl6VytIQTNnZWlCU2UKN0diRUhrd1Z0dm1ScmY3NlpTTE9PWVVBNENWdXcvOTFhWnhlbkxMWFRyWXVkTjJqMXVpaWh5aW80Z2R6aTNoTApqSk9rMkdteDlCYUJGZ004ekVxSEtBSlhHL09KbjFrQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0TmpVMFpETXlNR1F0WTJZeFppMDBOV05sTFRneE1EVXRNemsxTUdGbVpURXgKTURsaExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhaYWh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXhGSUZlb0pubUpCVlFWcW5PMWFqcjlDd0RyU0hDbERHSmxIZk1hSVFvaHpDeElZV3BvOUk0CmdLcXVwcWN0L2NyZ3VoSUFpeUp0VnluNmhXRzdFR2tKLzV4SG1pUlZod2NVUS9GMGtuSmR5aHpmbkw4bnU4KzIKOXFzYllHMFoxbzFQS0Z4ejNPdjFkZGxCejB2RFpuK3Erb1pGRU9YMnhTTnJaRTBuTkFyTTg3RHkrTksrU085awpuTnVKL0EvajB6TzFqNlZzVWlpMlZMZk1aSDdRVFI5Rmx4TGo1NHhWMFBtbjFiaHFvU0RFb3FaV3o1Mlp3d21JCm1pdjlaak5HdzNJRXoyYnBjMVNFNDkvZ0NkdFlVSno2Y3pEd2tycUdmbnV5aGplVFJLWXBJNzJzQ1dSNHNHdDkKUXN0VmJBd2gxRkNKUU9qS21XeWlrOXRLeWxUMGs3ZjcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXZ6VzlCVjlNWFIwOVk4VldORVE4OHl0SUc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1URXhXaGNOTXpNeE1ETXdNVGcxTVRFeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtyREQrU1J1cVZSUVVpUXhScVNRa29NSmVmZkYzWDdTOVM2STJoNFFZUldNN1RQRGo3cTJCaVQKWjZKcFF4bU5XY1ZzcXNPZ3J5Y3dYMDBLbWhhQjJEeENkZU8rbWF0M0ptNlVOcEFYYkZzSnZ3R3R2TmF2OHorUwpaY2hhM1UzTitZYXp0Myt4MWhiam1OcHF5OXhqVHlYblliR0hvVE5qT1pyS3F1MHZZTnlydzBkMjFmRXhYRkh2CkgyQTN1Q3B2RDBUUVdnSnBoRnpCeVRraFNFY3V4Q21iZnNyclU2U3NLc0J2S1JsTTNjQzBSdEZkR1pJc2NDSSsKTE5ReVRUdFV3aXpMV1RIbklmYThzandxeks1bDROSUxITnNvY0UwdG5aUUtpbEp3MVR2T1QzckQrZDNzR3hiTwo2Si9CdWd3K0pOdXl6T2dpaXVhSkNIa1RYZ2xFUG1rQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0Tm1RNE56Qm1OR010TUdZMVl5MDBPVFEwTFRrMllqQXRNelprTXpreE5HRmkKWkROakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtWNWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lqRjBsSlNkb05CdWlscDYvNXEzZk1lZUd4cGtZTm5LWlJ4a3lJMENVVHB6ZUt4eW1jOS9qClYwL2RBRy9RTXlIckp4RjNXQ0E4aHdYQzd0QlR4TkZFV29VVFFjNkFIUy9wenRkLy9KdjJQbkFvRS9XajdXWVcKVWFpcklNaitjSnNMaW9KTVlnWVQ4dS9jTS9vWGpJOHcrNmFlTjI1Ylp6eVRQN1A2SFRlQ1FQOUlYaDdWdjY1aApyWTBXUWxuUEhwTlRENDNzWkRlUDRXK0xqNGNLQWpBNWFZakhZZ2FvbmNvQlY0SUQ4TDZ0d2lweE9Mem9WcjR2CnZLRUhtNm5WWHRKZW5EbEt4N3FNK21ybVEzQTlFNG5QTlZBeDJGNG5WTEFONGJtdlM0RU85WU1YeHlOT0V4QVUKL1BGTzlrcCtLTE5HN0ZRYnN5ZVdSYzhpUDB4K0V5Ti8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:54 GMT
+      - Thu, 02 Nov 2023 18:53:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3b86643-09bb-40f9-907a-c1acc15451ab
+      - b963aaec-c452-4866-a0ff-4dc7eadc2e27
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,19 +1036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762},"endpoints":[{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762}],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1258"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:54 GMT
+      - Thu, 02 Nov 2023 18:53:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1058,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9216a885-090e-4613-aa28-b66e62c56179
+      - 9163f2a2-e268-40c1-9958-253788a31490
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,19 +1069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVYnJXTk9hYUYwTmY0dmtVM2YrdWxLVk1KUFdNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5UVTBXaGNOTXpNeE1ERTNNVFUxTlRVMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxyc0dIZTNxdlRHWXRueVEySWpUL0ErQ0NlblRaMVVGREtkSVpRMEF1OUhlai9UOXdiQzBCc1YKUW5HSVpqSFd0bXQydWpNNDBITExsYmRxWXIwL2RYWUhYSk8vKzNDeWhFVGp6VW5xUGhZZTV5YmEvak5rNVJTUwo5TGpiNVZ1MUIyeFQxMFExeXhzMUtOckNLRGdDMWpDYzZkWnRVbHA1bU9PbHgxNWFxN2Q4RnZybVpXcDk4aXJoCmRDSUlFb1ZpTG9WdWt5R2s1NzhBcVNJNUQrZkE3UXk2M2VrbFozUERuQ21LWUE5Y04wMDl6VytIQTNnZWlCU2UKN0diRUhrd1Z0dm1ScmY3NlpTTE9PWVVBNENWdXcvOTFhWnhlbkxMWFRyWXVkTjJqMXVpaWh5aW80Z2R6aTNoTApqSk9rMkdteDlCYUJGZ004ekVxSEtBSlhHL09KbjFrQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0TmpVMFpETXlNR1F0WTJZeFppMDBOV05sTFRneE1EVXRNemsxTUdGbVpURXgKTURsaExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhaYWh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXhGSUZlb0pubUpCVlFWcW5PMWFqcjlDd0RyU0hDbERHSmxIZk1hSVFvaHpDeElZV3BvOUk0CmdLcXVwcWN0L2NyZ3VoSUFpeUp0VnluNmhXRzdFR2tKLzV4SG1pUlZod2NVUS9GMGtuSmR5aHpmbkw4bnU4KzIKOXFzYllHMFoxbzFQS0Z4ejNPdjFkZGxCejB2RFpuK3Erb1pGRU9YMnhTTnJaRTBuTkFyTTg3RHkrTksrU085awpuTnVKL0EvajB6TzFqNlZzVWlpMlZMZk1aSDdRVFI5Rmx4TGo1NHhWMFBtbjFiaHFvU0RFb3FaV3o1Mlp3d21JCm1pdjlaak5HdzNJRXoyYnBjMVNFNDkvZ0NkdFlVSno2Y3pEd2tycUdmbnV5aGplVFJLWXBJNzJzQ1dSNHNHdDkKUXN0VmJBd2gxRkNKUU9qS21XeWlrOXRLeWxUMGs3ZjcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXZ6VzlCVjlNWFIwOVk4VldORVE4OHl0SUc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1URXhXaGNOTXpNeE1ETXdNVGcxTVRFeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtyREQrU1J1cVZSUVVpUXhScVNRa29NSmVmZkYzWDdTOVM2STJoNFFZUldNN1RQRGo3cTJCaVQKWjZKcFF4bU5XY1ZzcXNPZ3J5Y3dYMDBLbWhhQjJEeENkZU8rbWF0M0ptNlVOcEFYYkZzSnZ3R3R2TmF2OHorUwpaY2hhM1UzTitZYXp0Myt4MWhiam1OcHF5OXhqVHlYblliR0hvVE5qT1pyS3F1MHZZTnlydzBkMjFmRXhYRkh2CkgyQTN1Q3B2RDBUUVdnSnBoRnpCeVRraFNFY3V4Q21iZnNyclU2U3NLc0J2S1JsTTNjQzBSdEZkR1pJc2NDSSsKTE5ReVRUdFV3aXpMV1RIbklmYThzandxeks1bDROSUxITnNvY0UwdG5aUUtpbEp3MVR2T1QzckQrZDNzR3hiTwo2Si9CdWd3K0pOdXl6T2dpaXVhSkNIa1RYZ2xFUG1rQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0Tm1RNE56Qm1OR010TUdZMVl5MDBPVFEwTFRrMllqQXRNelprTXpreE5HRmkKWkROakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtWNWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lqRjBsSlNkb05CdWlscDYvNXEzZk1lZUd4cGtZTm5LWlJ4a3lJMENVVHB6ZUt4eW1jOS9qClYwL2RBRy9RTXlIckp4RjNXQ0E4aHdYQzd0QlR4TkZFV29VVFFjNkFIUy9wenRkLy9KdjJQbkFvRS9XajdXWVcKVWFpcklNaitjSnNMaW9KTVlnWVQ4dS9jTS9vWGpJOHcrNmFlTjI1Ylp6eVRQN1A2SFRlQ1FQOUlYaDdWdjY1aApyWTBXUWxuUEhwTlRENDNzWkRlUDRXK0xqNGNLQWpBNWFZakhZZ2FvbmNvQlY0SUQ4TDZ0d2lweE9Mem9WcjR2CnZLRUhtNm5WWHRKZW5EbEt4N3FNK21ybVEzQTlFNG5QTlZBeDJGNG5WTEFONGJtdlM0RU85WU1YeHlOT0V4QVUKL1BGTzlrcCtLTE5HN0ZRYnN5ZVdSYzhpUDB4K0V5Ti8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:54 GMT
+      - Thu, 02 Nov 2023 18:53:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1091,7 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31b16f32-38a0-43b1-8f80-bc6d5736ab84
+      - 0da8c841-4930-4761-abc7-635248e97757
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,19 +1102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762},"endpoints":[{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762}],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1258"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:55 GMT
+      - Thu, 02 Nov 2023 18:53:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1124,7 +1124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3285662e-3f43-4c79-b114-d36a08ad7bb0
+      - 696e6819-3470-431e-a9fd-b81e8d7877f6
     status: 200 OK
     code: 200
     duration: ""
@@ -1138,16 +1138,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?name=data-rdb-test-terraform&order_by=created_at_asc
     method: GET
   response:
-    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762},"endpoints":[{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762}],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
     headers:
       Content-Length:
-      - "1291"
+      - "1244"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:55 GMT
+      - Thu, 02 Nov 2023 18:53:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1157,7 +1157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 457cb739-5955-4f7e-bda3-8c436d910049
+      - c692e147-0887-467c-abe0-2f451064e86c
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,19 +1168,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762},"endpoints":[{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762}],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXZ6VzlCVjlNWFIwOVk4VldORVE4OHl0SUc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1URXhXaGNOTXpNeE1ETXdNVGcxTVRFeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtyREQrU1J1cVZSUVVpUXhScVNRa29NSmVmZkYzWDdTOVM2STJoNFFZUldNN1RQRGo3cTJCaVQKWjZKcFF4bU5XY1ZzcXNPZ3J5Y3dYMDBLbWhhQjJEeENkZU8rbWF0M0ptNlVOcEFYYkZzSnZ3R3R2TmF2OHorUwpaY2hhM1UzTitZYXp0Myt4MWhiam1OcHF5OXhqVHlYblliR0hvVE5qT1pyS3F1MHZZTnlydzBkMjFmRXhYRkh2CkgyQTN1Q3B2RDBUUVdnSnBoRnpCeVRraFNFY3V4Q21iZnNyclU2U3NLc0J2S1JsTTNjQzBSdEZkR1pJc2NDSSsKTE5ReVRUdFV3aXpMV1RIbklmYThzandxeks1bDROSUxITnNvY0UwdG5aUUtpbEp3MVR2T1QzckQrZDNzR3hiTwo2Si9CdWd3K0pOdXl6T2dpaXVhSkNIa1RYZ2xFUG1rQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0Tm1RNE56Qm1OR010TUdZMVl5MDBPVFEwTFRrMllqQXRNelprTXpreE5HRmkKWkROakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtWNWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lqRjBsSlNkb05CdWlscDYvNXEzZk1lZUd4cGtZTm5LWlJ4a3lJMENVVHB6ZUt4eW1jOS9qClYwL2RBRy9RTXlIckp4RjNXQ0E4aHdYQzd0QlR4TkZFV29VVFFjNkFIUy9wenRkLy9KdjJQbkFvRS9XajdXWVcKVWFpcklNaitjSnNMaW9KTVlnWVQ4dS9jTS9vWGpJOHcrNmFlTjI1Ylp6eVRQN1A2SFRlQ1FQOUlYaDdWdjY1aApyWTBXUWxuUEhwTlRENDNzWkRlUDRXK0xqNGNLQWpBNWFZakhZZ2FvbmNvQlY0SUQ4TDZ0d2lweE9Mem9WcjR2CnZLRUhtNm5WWHRKZW5EbEt4N3FNK21ybVEzQTlFNG5QTlZBeDJGNG5WTEFONGJtdlM0RU85WU1YeHlOT0V4QVUKL1BGTzlrcCtLTE5HN0ZRYnN5ZVdSYzhpUDB4K0V5Ti8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1258"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:57 GMT
+      - Thu, 02 Nov 2023 18:53:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +1190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 638917ae-e267-4c84-9927-a30392d50da3
+      - 4da73567-2424-43a8-a125-d103f22ce8e2
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,19 +1201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVYnJXTk9hYUYwTmY0dmtVM2YrdWxLVk1KUFdNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5UVTBXaGNOTXpNeE1ERTNNVFUxTlRVMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxyc0dIZTNxdlRHWXRueVEySWpUL0ErQ0NlblRaMVVGREtkSVpRMEF1OUhlai9UOXdiQzBCc1YKUW5HSVpqSFd0bXQydWpNNDBITExsYmRxWXIwL2RYWUhYSk8vKzNDeWhFVGp6VW5xUGhZZTV5YmEvak5rNVJTUwo5TGpiNVZ1MUIyeFQxMFExeXhzMUtOckNLRGdDMWpDYzZkWnRVbHA1bU9PbHgxNWFxN2Q4RnZybVpXcDk4aXJoCmRDSUlFb1ZpTG9WdWt5R2s1NzhBcVNJNUQrZkE3UXk2M2VrbFozUERuQ21LWUE5Y04wMDl6VytIQTNnZWlCU2UKN0diRUhrd1Z0dm1ScmY3NlpTTE9PWVVBNENWdXcvOTFhWnhlbkxMWFRyWXVkTjJqMXVpaWh5aW80Z2R6aTNoTApqSk9rMkdteDlCYUJGZ004ekVxSEtBSlhHL09KbjFrQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0TmpVMFpETXlNR1F0WTJZeFppMDBOV05sTFRneE1EVXRNemsxTUdGbVpURXgKTURsaExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhaYWh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXhGSUZlb0pubUpCVlFWcW5PMWFqcjlDd0RyU0hDbERHSmxIZk1hSVFvaHpDeElZV3BvOUk0CmdLcXVwcWN0L2NyZ3VoSUFpeUp0VnluNmhXRzdFR2tKLzV4SG1pUlZod2NVUS9GMGtuSmR5aHpmbkw4bnU4KzIKOXFzYllHMFoxbzFQS0Z4ejNPdjFkZGxCejB2RFpuK3Erb1pGRU9YMnhTTnJaRTBuTkFyTTg3RHkrTksrU085awpuTnVKL0EvajB6TzFqNlZzVWlpMlZMZk1aSDdRVFI5Rmx4TGo1NHhWMFBtbjFiaHFvU0RFb3FaV3o1Mlp3d21JCm1pdjlaak5HdzNJRXoyYnBjMVNFNDkvZ0NkdFlVSno2Y3pEd2tycUdmbnV5aGplVFJLWXBJNzJzQ1dSNHNHdDkKUXN0VmJBd2gxRkNKUU9qS21XeWlrOXRLeWxUMGs3ZjcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1845"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:57 GMT
+      - Thu, 02 Nov 2023 18:53:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f46e8bec-adc6-4e2e-a606-112578629308
+      - 76bdf95e-d59e-4c3a-bd07-2f4f72b86f70
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,19 +1234,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVYnJXTk9hYUYwTmY0dmtVM2YrdWxLVk1KUFdNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5UVTBXaGNOTXpNeE1ERTNNVFUxTlRVMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxyc0dIZTNxdlRHWXRueVEySWpUL0ErQ0NlblRaMVVGREtkSVpRMEF1OUhlai9UOXdiQzBCc1YKUW5HSVpqSFd0bXQydWpNNDBITExsYmRxWXIwL2RYWUhYSk8vKzNDeWhFVGp6VW5xUGhZZTV5YmEvak5rNVJTUwo5TGpiNVZ1MUIyeFQxMFExeXhzMUtOckNLRGdDMWpDYzZkWnRVbHA1bU9PbHgxNWFxN2Q4RnZybVpXcDk4aXJoCmRDSUlFb1ZpTG9WdWt5R2s1NzhBcVNJNUQrZkE3UXk2M2VrbFozUERuQ21LWUE5Y04wMDl6VytIQTNnZWlCU2UKN0diRUhrd1Z0dm1ScmY3NlpTTE9PWVVBNENWdXcvOTFhWnhlbkxMWFRyWXVkTjJqMXVpaWh5aW80Z2R6aTNoTApqSk9rMkdteDlCYUJGZ004ekVxSEtBSlhHL09KbjFrQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0TmpVMFpETXlNR1F0WTJZeFppMDBOV05sTFRneE1EVXRNemsxTUdGbVpURXgKTURsaExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhaYWh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXhGSUZlb0pubUpCVlFWcW5PMWFqcjlDd0RyU0hDbERHSmxIZk1hSVFvaHpDeElZV3BvOUk0CmdLcXVwcWN0L2NyZ3VoSUFpeUp0VnluNmhXRzdFR2tKLzV4SG1pUlZod2NVUS9GMGtuSmR5aHpmbkw4bnU4KzIKOXFzYllHMFoxbzFQS0Z4ejNPdjFkZGxCejB2RFpuK3Erb1pGRU9YMnhTTnJaRTBuTkFyTTg3RHkrTksrU085awpuTnVKL0EvajB6TzFqNlZzVWlpMlZMZk1aSDdRVFI5Rmx4TGo1NHhWMFBtbjFiaHFvU0RFb3FaV3o1Mlp3d21JCm1pdjlaak5HdzNJRXoyYnBjMVNFNDkvZ0NkdFlVSno2Y3pEd2tycUdmbnV5aGplVFJLWXBJNzJzQ1dSNHNHdDkKUXN0VmJBd2gxRkNKUU9qS21XeWlrOXRLeWxUMGs3ZjcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXZ6VzlCVjlNWFIwOVk4VldORVE4OHl0SUc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1URXhXaGNOTXpNeE1ETXdNVGcxTVRFeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtyREQrU1J1cVZSUVVpUXhScVNRa29NSmVmZkYzWDdTOVM2STJoNFFZUldNN1RQRGo3cTJCaVQKWjZKcFF4bU5XY1ZzcXNPZ3J5Y3dYMDBLbWhhQjJEeENkZU8rbWF0M0ptNlVOcEFYYkZzSnZ3R3R2TmF2OHorUwpaY2hhM1UzTitZYXp0Myt4MWhiam1OcHF5OXhqVHlYblliR0hvVE5qT1pyS3F1MHZZTnlydzBkMjFmRXhYRkh2CkgyQTN1Q3B2RDBUUVdnSnBoRnpCeVRraFNFY3V4Q21iZnNyclU2U3NLc0J2S1JsTTNjQzBSdEZkR1pJc2NDSSsKTE5ReVRUdFV3aXpMV1RIbklmYThzandxeks1bDROSUxITnNvY0UwdG5aUUtpbEp3MVR2T1QzckQrZDNzR3hiTwo2Si9CdWd3K0pOdXl6T2dpaXVhSkNIa1RYZ2xFUG1rQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0Tm1RNE56Qm1OR010TUdZMVl5MDBPVFEwTFRrMllqQXRNelprTXpreE5HRmkKWkROakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtWNWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lqRjBsSlNkb05CdWlscDYvNXEzZk1lZUd4cGtZTm5LWlJ4a3lJMENVVHB6ZUt4eW1jOS9qClYwL2RBRy9RTXlIckp4RjNXQ0E4aHdYQzd0QlR4TkZFV29VVFFjNkFIUy9wenRkLy9KdjJQbkFvRS9XajdXWVcKVWFpcklNaitjSnNMaW9KTVlnWVQ4dS9jTS9vWGpJOHcrNmFlTjI1Ylp6eVRQN1A2SFRlQ1FQOUlYaDdWdjY1aApyWTBXUWxuUEhwTlRENDNzWkRlUDRXK0xqNGNLQWpBNWFZakhZZ2FvbmNvQlY0SUQ4TDZ0d2lweE9Mem9WcjR2CnZLRUhtNm5WWHRKZW5EbEt4N3FNK21ybVEzQTlFNG5QTlZBeDJGNG5WTEFONGJtdlM0RU85WU1YeHlOT0V4QVUKL1BGTzlrcCtLTE5HN0ZRYnN5ZVdSYzhpUDB4K0V5Ti8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:02 GMT
+      - Thu, 02 Nov 2023 18:53:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1256,40 +1256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69844e8c-76e3-46b0-9730-d89aa086ae06
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762},"endpoints":[{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762}],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1258"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8f86930e-4681-459f-b878-0c6123518117
+      - d035f577-5cff-4bc6-9c05-efaca8475262
     status: 200 OK
     code: 200
     duration: ""
@@ -1303,16 +1270,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?name=data-rdb-test-terraform&order_by=created_at_asc
     method: GET
   response:
-    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762},"endpoints":[{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762}],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
     headers:
       Content-Length:
-      - "1291"
+      - "1244"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:02 GMT
+      - Thu, 02 Nov 2023 18:53:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1322,7 +1289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 883a0283-a8ed-4320-a08e-31b6456b8f30
+      - a3b1b3d4-63b5-4825-a282-ed86068b671b
     status: 200 OK
     code: 200
     duration: ""
@@ -1333,19 +1300,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVYnJXTk9hYUYwTmY0dmtVM2YrdWxLVk1KUFdNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5UVTBXaGNOTXpNeE1ERTNNVFUxTlRVMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxyc0dIZTNxdlRHWXRueVEySWpUL0ErQ0NlblRaMVVGREtkSVpRMEF1OUhlai9UOXdiQzBCc1YKUW5HSVpqSFd0bXQydWpNNDBITExsYmRxWXIwL2RYWUhYSk8vKzNDeWhFVGp6VW5xUGhZZTV5YmEvak5rNVJTUwo5TGpiNVZ1MUIyeFQxMFExeXhzMUtOckNLRGdDMWpDYzZkWnRVbHA1bU9PbHgxNWFxN2Q4RnZybVpXcDk4aXJoCmRDSUlFb1ZpTG9WdWt5R2s1NzhBcVNJNUQrZkE3UXk2M2VrbFozUERuQ21LWUE5Y04wMDl6VytIQTNnZWlCU2UKN0diRUhrd1Z0dm1ScmY3NlpTTE9PWVVBNENWdXcvOTFhWnhlbkxMWFRyWXVkTjJqMXVpaWh5aW80Z2R6aTNoTApqSk9rMkdteDlCYUJGZ004ekVxSEtBSlhHL09KbjFrQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0TmpVMFpETXlNR1F0WTJZeFppMDBOV05sTFRneE1EVXRNemsxTUdGbVpURXgKTURsaExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhaYWh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXhGSUZlb0pubUpCVlFWcW5PMWFqcjlDd0RyU0hDbERHSmxIZk1hSVFvaHpDeElZV3BvOUk0CmdLcXVwcWN0L2NyZ3VoSUFpeUp0VnluNmhXRzdFR2tKLzV4SG1pUlZod2NVUS9GMGtuSmR5aHpmbkw4bnU4KzIKOXFzYllHMFoxbzFQS0Z4ejNPdjFkZGxCejB2RFpuK3Erb1pGRU9YMnhTTnJaRTBuTkFyTTg3RHkrTksrU085awpuTnVKL0EvajB6TzFqNlZzVWlpMlZMZk1aSDdRVFI5Rmx4TGo1NHhWMFBtbjFiaHFvU0RFb3FaV3o1Mlp3d21JCm1pdjlaak5HdzNJRXoyYnBjMVNFNDkvZ0NkdFlVSno2Y3pEd2tycUdmbnV5aGplVFJLWXBJNzJzQ1dSNHNHdDkKUXN0VmJBd2gxRkNKUU9qS21XeWlrOXRLeWxUMGs3ZjcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1845"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:02 GMT
+      - Thu, 02 Nov 2023 18:53:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1355,7 +1322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0bf2bef-e49d-4bf3-859b-cb4c602f6f33
+      - af2099ba-e9d6-4c8c-a09e-c216503343c6
     status: 200 OK
     code: 200
     duration: ""
@@ -1366,19 +1333,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762},"endpoints":[{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762}],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1258"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:02 GMT
+      - Thu, 02 Nov 2023 18:53:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1388,7 +1355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5feac6dd-9f4f-499d-9e7e-77ad8ad68e0a
+      - 0e564304-fc23-4860-9261-7c17143c1062
     status: 200 OK
     code: 200
     duration: ""
@@ -1399,19 +1366,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVYnJXTk9hYUYwTmY0dmtVM2YrdWxLVk1KUFdNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5UVTBXaGNOTXpNeE1ERTNNVFUxTlRVMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxyc0dIZTNxdlRHWXRueVEySWpUL0ErQ0NlblRaMVVGREtkSVpRMEF1OUhlai9UOXdiQzBCc1YKUW5HSVpqSFd0bXQydWpNNDBITExsYmRxWXIwL2RYWUhYSk8vKzNDeWhFVGp6VW5xUGhZZTV5YmEvak5rNVJTUwo5TGpiNVZ1MUIyeFQxMFExeXhzMUtOckNLRGdDMWpDYzZkWnRVbHA1bU9PbHgxNWFxN2Q4RnZybVpXcDk4aXJoCmRDSUlFb1ZpTG9WdWt5R2s1NzhBcVNJNUQrZkE3UXk2M2VrbFozUERuQ21LWUE5Y04wMDl6VytIQTNnZWlCU2UKN0diRUhrd1Z0dm1ScmY3NlpTTE9PWVVBNENWdXcvOTFhWnhlbkxMWFRyWXVkTjJqMXVpaWh5aW80Z2R6aTNoTApqSk9rMkdteDlCYUJGZ004ekVxSEtBSlhHL09KbjFrQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0TmpVMFpETXlNR1F0WTJZeFppMDBOV05sTFRneE1EVXRNemsxTUdGbVpURXgKTURsaExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhaYWh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXhGSUZlb0pubUpCVlFWcW5PMWFqcjlDd0RyU0hDbERHSmxIZk1hSVFvaHpDeElZV3BvOUk0CmdLcXVwcWN0L2NyZ3VoSUFpeUp0VnluNmhXRzdFR2tKLzV4SG1pUlZod2NVUS9GMGtuSmR5aHpmbkw4bnU4KzIKOXFzYllHMFoxbzFQS0Z4ejNPdjFkZGxCejB2RFpuK3Erb1pGRU9YMnhTTnJaRTBuTkFyTTg3RHkrTksrU085awpuTnVKL0EvajB6TzFqNlZzVWlpMlZMZk1aSDdRVFI5Rmx4TGo1NHhWMFBtbjFiaHFvU0RFb3FaV3o1Mlp3d21JCm1pdjlaak5HdzNJRXoyYnBjMVNFNDkvZ0NkdFlVSno2Y3pEd2tycUdmbnV5aGplVFJLWXBJNzJzQ1dSNHNHdDkKUXN0VmJBd2gxRkNKUU9qS21XeWlrOXRLeWxUMGs3ZjcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXZ6VzlCVjlNWFIwOVk4VldORVE4OHl0SUc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1URXhXaGNOTXpNeE1ETXdNVGcxTVRFeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtyREQrU1J1cVZSUVVpUXhScVNRa29NSmVmZkYzWDdTOVM2STJoNFFZUldNN1RQRGo3cTJCaVQKWjZKcFF4bU5XY1ZzcXNPZ3J5Y3dYMDBLbWhhQjJEeENkZU8rbWF0M0ptNlVOcEFYYkZzSnZ3R3R2TmF2OHorUwpaY2hhM1UzTitZYXp0Myt4MWhiam1OcHF5OXhqVHlYblliR0hvVE5qT1pyS3F1MHZZTnlydzBkMjFmRXhYRkh2CkgyQTN1Q3B2RDBUUVdnSnBoRnpCeVRraFNFY3V4Q21iZnNyclU2U3NLc0J2S1JsTTNjQzBSdEZkR1pJc2NDSSsKTE5ReVRUdFV3aXpMV1RIbklmYThzandxeks1bDROSUxITnNvY0UwdG5aUUtpbEp3MVR2T1QzckQrZDNzR3hiTwo2Si9CdWd3K0pOdXl6T2dpaXVhSkNIa1RYZ2xFUG1rQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0Tm1RNE56Qm1OR010TUdZMVl5MDBPVFEwTFRrMllqQXRNelprTXpreE5HRmkKWkROakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtWNWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lqRjBsSlNkb05CdWlscDYvNXEzZk1lZUd4cGtZTm5LWlJ4a3lJMENVVHB6ZUt4eW1jOS9qClYwL2RBRy9RTXlIckp4RjNXQ0E4aHdYQzd0QlR4TkZFV29VVFFjNkFIUy9wenRkLy9KdjJQbkFvRS9XajdXWVcKVWFpcklNaitjSnNMaW9KTVlnWVQ4dS9jTS9vWGpJOHcrNmFlTjI1Ylp6eVRQN1A2SFRlQ1FQOUlYaDdWdjY1aApyWTBXUWxuUEhwTlRENDNzWkRlUDRXK0xqNGNLQWpBNWFZakhZZ2FvbmNvQlY0SUQ4TDZ0d2lweE9Mem9WcjR2CnZLRUhtNm5WWHRKZW5EbEt4N3FNK21ybVEzQTlFNG5QTlZBeDJGNG5WTEFONGJtdlM0RU85WU1YeHlOT0V4QVUKL1BGTzlrcCtLTE5HN0ZRYnN5ZVdSYzhpUDB4K0V5Ti8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:02 GMT
+      - Thu, 02 Nov 2023 18:53:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1421,7 +1388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df00b49d-7c61-4597-ad19-a0fbc2b35382
+      - c132b900-4eb0-4651-a2c4-a1ce78d82776
     status: 200 OK
     code: 200
     duration: ""
@@ -1432,19 +1399,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762},"endpoints":[{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762}],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXZ6VzlCVjlNWFIwOVk4VldORVE4OHl0SUc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1URXhXaGNOTXpNeE1ETXdNVGcxTVRFeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtyREQrU1J1cVZSUVVpUXhScVNRa29NSmVmZkYzWDdTOVM2STJoNFFZUldNN1RQRGo3cTJCaVQKWjZKcFF4bU5XY1ZzcXNPZ3J5Y3dYMDBLbWhhQjJEeENkZU8rbWF0M0ptNlVOcEFYYkZzSnZ3R3R2TmF2OHorUwpaY2hhM1UzTitZYXp0Myt4MWhiam1OcHF5OXhqVHlYblliR0hvVE5qT1pyS3F1MHZZTnlydzBkMjFmRXhYRkh2CkgyQTN1Q3B2RDBUUVdnSnBoRnpCeVRraFNFY3V4Q21iZnNyclU2U3NLc0J2S1JsTTNjQzBSdEZkR1pJc2NDSSsKTE5ReVRUdFV3aXpMV1RIbklmYThzandxeks1bDROSUxITnNvY0UwdG5aUUtpbEp3MVR2T1QzckQrZDNzR3hiTwo2Si9CdWd3K0pOdXl6T2dpaXVhSkNIa1RYZ2xFUG1rQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0Tm1RNE56Qm1OR010TUdZMVl5MDBPVFEwTFRrMllqQXRNelprTXpreE5HRmkKWkROakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtWNWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lqRjBsSlNkb05CdWlscDYvNXEzZk1lZUd4cGtZTm5LWlJ4a3lJMENVVHB6ZUt4eW1jOS9qClYwL2RBRy9RTXlIckp4RjNXQ0E4aHdYQzd0QlR4TkZFV29VVFFjNkFIUy9wenRkLy9KdjJQbkFvRS9XajdXWVcKVWFpcklNaitjSnNMaW9KTVlnWVQ4dS9jTS9vWGpJOHcrNmFlTjI1Ylp6eVRQN1A2SFRlQ1FQOUlYaDdWdjY1aApyWTBXUWxuUEhwTlRENDNzWkRlUDRXK0xqNGNLQWpBNWFZakhZZ2FvbmNvQlY0SUQ4TDZ0d2lweE9Mem9WcjR2CnZLRUhtNm5WWHRKZW5EbEt4N3FNK21ybVEzQTlFNG5QTlZBeDJGNG5WTEFONGJtdlM0RU85WU1YeHlOT0V4QVUKL1BGTzlrcCtLTE5HN0ZRYnN5ZVdSYzhpUDB4K0V5Ti8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1258"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:04 GMT
+      - Thu, 02 Nov 2023 18:53:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1454,7 +1421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90bc848d-f17a-47e5-99c6-0628a0ce128b
+      - 3def92ed-456f-4f07-9d9b-32d8bdd5f5b3
     status: 200 OK
     code: 200
     duration: ""
@@ -1465,19 +1432,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1212"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3ab059d3-4ada-4ffa-a322-4eef4c257122
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762},"endpoints":[{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762}],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1261"
+      - "1215"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:04 GMT
+      - Thu, 02 Nov 2023 18:53:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1487,7 +1487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c1ccfc6-73a6-435f-a31b-7354ae674730
+      - d3b7d94b-caf1-4828-9a43-592d8999508e
     status: 200 OK
     code: 200
     duration: ""
@@ -1498,19 +1498,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.587072Z","retention":7},"created_at":"2023-10-20T15:55:15.587072Z","endpoint":{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762},"endpoints":[{"id":"88059a39-5af4-41f7-bc98-d295d80020c0","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25762}],"engine":"PostgreSQL-15","id":"654d320d-cf1f-45ce-8105-3950afe1109a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1261"
+      - "1215"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:04 GMT
+      - Thu, 02 Nov 2023 18:53:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1520,7 +1520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52ca557c-6c68-4a47-a7ce-efe77916f2f9
+      - bbbd34ca-21b5-4a71-a6a8-943bcdd28042
     status: 200 OK
     code: 200
     duration: ""
@@ -1531,10 +1531,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"654d320d-cf1f-45ce-8105-3950afe1109a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1543,7 +1543,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:34 GMT
+      - Thu, 02 Nov 2023 18:53:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1553,7 +1553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1a76cbe-70eb-4347-b2f2-c03e76cddcb0
+      - dbe08f97-2e51-4cb9-8a29-b354fe976f6c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1564,10 +1564,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"654d320d-cf1f-45ce-8105-3950afe1109a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1576,7 +1576,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:34 GMT
+      - Thu, 02 Nov 2023 18:53:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1586,7 +1586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a19d90d7-afc6-4f57-a321-465448c76b66
+      - 43c68981-c40c-45b6-94ee-e3048429cc5b
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1597,10 +1597,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"654d320d-cf1f-45ce-8105-3950afe1109a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1609,7 +1609,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:34 GMT
+      - Thu, 02 Nov 2023 18:53:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1619,7 +1619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 507221f4-45e5-49d6-a519-3c7a3d1c2ef2
+      - af3507e5-e254-41d1-8012-5277c7ed3a9e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1630,10 +1630,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/654d320d-cf1f-45ce-8105-3950afe1109a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"654d320d-cf1f-45ce-8105-3950afe1109a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1642,7 +1642,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:34 GMT
+      - Thu, 02 Nov 2023 18:53:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1652,7 +1652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c538eb37-a784-4b6a-9fa1-14139bedc7be
+      - a3ec1565-2051-4eb1-9981-c49e8474780f
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-rdb-privilege-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-rdb-privilege-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:04 GMT
+      - Thu, 02 Nov 2023 18:46:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8aff5b2-f4e7-4690-b9ff-8d6eba538df7
+      - bc80d19f-2b05-4828-93dd-03da7d36902c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-privilege","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-privilege","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "805"
+      - "776"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:10 GMT
+      - Thu, 02 Nov 2023 18:46:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20a8549a-c143-4ea9-963c-62a7b4f0872f
+      - 20de9f06-bec3-4d2a-a40e-e8ff74a60dba
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "805"
+      - "776"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:10 GMT
+      - Thu, 02 Nov 2023 18:46:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b93e1152-622b-41b4-a3e5-22cb0af11ef0
+      - baa4ee0c-a3fa-46c3-9cb3-69f45b2ca4d6
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "805"
+      - "776"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:40 GMT
+      - Thu, 02 Nov 2023 18:47:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87bf2c7b-9462-4c49-8044-a260cafc4479
+      - 88fe1a9d-a3f4-4920-b0b4-6072672f6c42
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "805"
+      - "776"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:52:10 GMT
+      - Thu, 02 Nov 2023 18:47:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5baa0856-9062-499b-8af9-b0647abbd9eb
+      - 244c99a4-7895-4c31-8610-91dd894eeac1
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "805"
+      - "776"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:52:41 GMT
+      - Thu, 02 Nov 2023 18:48:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19bd4ba8-5660-4d32-904e-9bb207705cd3
+      - e5d5d53e-c52f-4024-b1bd-03a223ab0a21
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "805"
+      - "776"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:53:11 GMT
+      - Thu, 02 Nov 2023 18:48:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b55ff41-5591-45cc-947d-e68f0d8a3026
+      - 2680bc39-6052-4e1c-bd7c-500a732e2942
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "805"
+      - "776"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:53:41 GMT
+      - Thu, 02 Nov 2023 18:49:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33645d80-c4ae-4b4c-bb97-d9ae0887fb4b
+      - 3d2439c2-f3b0-48cb-9b40-1282ed4d4090
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,12 +594,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08f81280-4ae2-46d1-941b-7e1bea5cfa45
+      - 647b5174-e8c5-4f8c-803d-e03ca4ac091d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"backup_schedule_frequency":null,"backup_schedule_retention":null,"is_backup_schedule_disabled":false,"name":null,"tags":null,"logs_policy":null,"backup_same_region":false,"backup_schedule_start_hour":null}'
+    body: '{"is_backup_schedule_disabled":false,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -607,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 590a79b7-b2b4-4423-92b3-d7bf369662b2
+      - 4f38eec2-694c-43f4-8c8a-0fbe86f036eb
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b324bad-4df3-4972-b693-56e7ea663daa
+      - 4196021c-8712-4fc8-8c25-0b99f8b0cf02
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVV0xFWTNTdzZhMWp4T0tOY0JMS1FJSExEUlRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU9Gb1hEVE16TVRBeE56RTFOVEUxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFucnFoT3NmdDc5WDM1amVaeU15OXJiMEZtc05hR2JzUEhCRTdhT1VqSzF4TUZQR1BENjJIVUJ6WGswd1YKSGNhczVIVVZYWHpBZnVDL29VL3pVbE1vcUtsbktFM2NIKzIxMkg0eWtNekJ3Z0tOMzBRTTF2RENweTk5U0R4QwpTdHB1b0RHanQzejZoN050Wk9aSXBoem5EeVFGYjhyQ0NSZjlmczAxbmI2Q1dOR1J5TWlRK2pXTjR2eERqc0hSCjVyOVZZZkxIS1RKbzJoVzE5cUhya2h3elpPazJQcWJxWGxzRjkxOXQvNGZpWElLOG10bkE5MHNPT25NeWdCQ0QKTDhYMS9zVnhHUS81d0JNN1FIYjEwbUJWME9mN0NKRUpxSnkzWFhpOU9qTWlPcVdxRTF4K1NlS0JzU3FWUU9seQpNbVY2VmEvdnpNelZuVXJOcEZHV2FOb1ZYd0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdE9UVTRPVFF6WVRFdE1ETTBOUzAwWm1FeExUa3dNRGt0TTJFNFl6YzROV1kzTnpnekxuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrMUtod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUJrWkU3TmEvcW1lVGkrQjl3UTFsbGI0Q2FWeW9uTnd2UzFXMVBwVklVRmhKL2pBMW9DTEhBRHduRU5ud3JiCjJSTmVER3FGOG1XWDcxcWtueVNlejVtbzVXcGdsYVRnMGlFNVcrb1NHOWxSWFEwdHJEeUdQQkFhZEt6cFBPT3MKeksyaHBJaXUrL2JiNTZxUXUwRDZXOGlyOTNZQTgyUjM5QXJjYkF3MzlneEIvOWpxSFhFWHJmTHNYRG53NVYydApoUk5Sb2wzcGpocGFRNkI0aUtFWXVwNXA4QSt3TWl6VGxJQ3N6d2ZVdmFFTENVcmsrVnVJaThkV1lwVmxLQW5wCm02bVRLM1N6ZnJyMEcvQ3lEMWp4bHZoZUZKOVlaaEhGWVlYTE91bmk0Unhid0xHeDVCb1ZTQXlnSVpDQWN4TVgKa1ArM3JFaXh3VEFmQXdhWjJEak5FK0xTCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:12 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 401cc135-5a16-4768-9db0-e68a7cf29e7d
+      - 2387ae3c-ac81-4514-b42d-4b3e7b6911e4
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:12 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ed77122-804f-4a67-9db7-8f184c804c08
+      - 052c4813-5840-4f0e-aa09-30002cb20522
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVV0xFWTNTdzZhMWp4T0tOY0JMS1FJSExEUlRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU9Gb1hEVE16TVRBeE56RTFOVEUxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFucnFoT3NmdDc5WDM1amVaeU15OXJiMEZtc05hR2JzUEhCRTdhT1VqSzF4TUZQR1BENjJIVUJ6WGswd1YKSGNhczVIVVZYWHpBZnVDL29VL3pVbE1vcUtsbktFM2NIKzIxMkg0eWtNekJ3Z0tOMzBRTTF2RENweTk5U0R4QwpTdHB1b0RHanQzejZoN050Wk9aSXBoem5EeVFGYjhyQ0NSZjlmczAxbmI2Q1dOR1J5TWlRK2pXTjR2eERqc0hSCjVyOVZZZkxIS1RKbzJoVzE5cUhya2h3elpPazJQcWJxWGxzRjkxOXQvNGZpWElLOG10bkE5MHNPT25NeWdCQ0QKTDhYMS9zVnhHUS81d0JNN1FIYjEwbUJWME9mN0NKRUpxSnkzWFhpOU9qTWlPcVdxRTF4K1NlS0JzU3FWUU9seQpNbVY2VmEvdnpNelZuVXJOcEZHV2FOb1ZYd0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdE9UVTRPVFF6WVRFdE1ETTBOUzAwWm1FeExUa3dNRGt0TTJFNFl6YzROV1kzTnpnekxuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrMUtod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUJrWkU3TmEvcW1lVGkrQjl3UTFsbGI0Q2FWeW9uTnd2UzFXMVBwVklVRmhKL2pBMW9DTEhBRHduRU5ud3JiCjJSTmVER3FGOG1XWDcxcWtueVNlejVtbzVXcGdsYVRnMGlFNVcrb1NHOWxSWFEwdHJEeUdQQkFhZEt6cFBPT3MKeksyaHBJaXUrL2JiNTZxUXUwRDZXOGlyOTNZQTgyUjM5QXJjYkF3MzlneEIvOWpxSFhFWHJmTHNYRG53NVYydApoUk5Sb2wzcGpocGFRNkI0aUtFWXVwNXA4QSt3TWl6VGxJQ3N6d2ZVdmFFTENVcmsrVnVJaThkV1lwVmxLQW5wCm02bVRLM1N6ZnJyMEcvQ3lEMWp4bHZoZUZKOVlaaEhGWVlYTE91bmk0Unhid0xHeDVCb1ZTQXlnSVpDQWN4TVgKa1ArM3JFaXh3VEFmQXdhWjJEak5FK0xTCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:12 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a67c342-a9de-4933-834b-8487ebb1e27c
+      - 99cec5e1-c5e8-4d24-99ef-c02bf87e9496
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:12 GMT
+      - Thu, 02 Nov 2023 18:49:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27788e54-e3c9-48e6-8bdc-1f6201950bd2
+      - 421e05fa-7ef3-43c3-b8c3-0a9550db4ae4
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVV0xFWTNTdzZhMWp4T0tOY0JMS1FJSExEUlRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU9Gb1hEVE16TVRBeE56RTFOVEUxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFucnFoT3NmdDc5WDM1amVaeU15OXJiMEZtc05hR2JzUEhCRTdhT1VqSzF4TUZQR1BENjJIVUJ6WGswd1YKSGNhczVIVVZYWHpBZnVDL29VL3pVbE1vcUtsbktFM2NIKzIxMkg0eWtNekJ3Z0tOMzBRTTF2RENweTk5U0R4QwpTdHB1b0RHanQzejZoN050Wk9aSXBoem5EeVFGYjhyQ0NSZjlmczAxbmI2Q1dOR1J5TWlRK2pXTjR2eERqc0hSCjVyOVZZZkxIS1RKbzJoVzE5cUhya2h3elpPazJQcWJxWGxzRjkxOXQvNGZpWElLOG10bkE5MHNPT25NeWdCQ0QKTDhYMS9zVnhHUS81d0JNN1FIYjEwbUJWME9mN0NKRUpxSnkzWFhpOU9qTWlPcVdxRTF4K1NlS0JzU3FWUU9seQpNbVY2VmEvdnpNelZuVXJOcEZHV2FOb1ZYd0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdE9UVTRPVFF6WVRFdE1ETTBOUzAwWm1FeExUa3dNRGt0TTJFNFl6YzROV1kzTnpnekxuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrMUtod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUJrWkU3TmEvcW1lVGkrQjl3UTFsbGI0Q2FWeW9uTnd2UzFXMVBwVklVRmhKL2pBMW9DTEhBRHduRU5ud3JiCjJSTmVER3FGOG1XWDcxcWtueVNlejVtbzVXcGdsYVRnMGlFNVcrb1NHOWxSWFEwdHJEeUdQQkFhZEt6cFBPT3MKeksyaHBJaXUrL2JiNTZxUXUwRDZXOGlyOTNZQTgyUjM5QXJjYkF3MzlneEIvOWpxSFhFWHJmTHNYRG53NVYydApoUk5Sb2wzcGpocGFRNkI0aUtFWXVwNXA4QSt3TWl6VGxJQ3N6d2ZVdmFFTENVcmsrVnVJaThkV1lwVmxLQW5wCm02bVRLM1N6ZnJyMEcvQ3lEMWp4bHZoZUZKOVlaaEhGWVlYTE91bmk0Unhid0xHeDVCb1ZTQXlnSVpDQWN4TVgKa1ArM3JFaXh3VEFmQXdhWjJEak5FK0xTCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:13 GMT
+      - Thu, 02 Nov 2023 18:49:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc8cb46d-444c-471c-80d5-605d16925d35
+      - d18e89f5-67f8-451b-aa73-735a77d22e0c
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:13 GMT
+      - Thu, 02 Nov 2023 18:49:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75bdce62-0e58-45a4-a2b9-c67824d4faeb
+      - 103bd751-f2b9-4165-9e5a-957606d1ba10
     status: 200 OK
     code: 200
     duration: ""
@@ -873,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases
     method: POST
   response:
     body: '{"managed":true,"name":"foo","owner":"","size":0}'
     headers:
       Content-Length:
-      - "52"
+      - "49"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:13 GMT
+      - Thu, 02 Nov 2023 18:49:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c53e6b6b-ba13-4097-ba93-20ebeb57cda4
+      - 6497d74b-28a9-47ed-aad2-82adf04103c6
     status: 200 OK
     code: 200
     duration: ""
@@ -906,19 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 18:49:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c3dd094-f7f8-4173-a8bf-9421af722c82
+      - 48a84a43-c084-41a0-a07c-1b5b8b85e980
     status: 200 OK
     code: 200
     duration: ""
@@ -939,118 +939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/databases?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "106"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 336dab56-25d9-4fb6-bdf9-e19bcc79cf1f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1293"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - becbcae7-f1cf-4609-84ea-535793bea09e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVV0xFWTNTdzZhMWp4T0tOY0JMS1FJSExEUlRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU9Gb1hEVE16TVRBeE56RTFOVEUxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFucnFoT3NmdDc5WDM1amVaeU15OXJiMEZtc05hR2JzUEhCRTdhT1VqSzF4TUZQR1BENjJIVUJ6WGswd1YKSGNhczVIVVZYWHpBZnVDL29VL3pVbE1vcUtsbktFM2NIKzIxMkg0eWtNekJ3Z0tOMzBRTTF2RENweTk5U0R4QwpTdHB1b0RHanQzejZoN050Wk9aSXBoem5EeVFGYjhyQ0NSZjlmczAxbmI2Q1dOR1J5TWlRK2pXTjR2eERqc0hSCjVyOVZZZkxIS1RKbzJoVzE5cUhya2h3elpPazJQcWJxWGxzRjkxOXQvNGZpWElLOG10bkE5MHNPT25NeWdCQ0QKTDhYMS9zVnhHUS81d0JNN1FIYjEwbUJWME9mN0NKRUpxSnkzWFhpOU9qTWlPcVdxRTF4K1NlS0JzU3FWUU9seQpNbVY2VmEvdnpNelZuVXJOcEZHV2FOb1ZYd0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdE9UVTRPVFF6WVRFdE1ETTBOUzAwWm1FeExUa3dNRGt0TTJFNFl6YzROV1kzTnpnekxuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrMUtod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUJrWkU3TmEvcW1lVGkrQjl3UTFsbGI0Q2FWeW9uTnd2UzFXMVBwVklVRmhKL2pBMW9DTEhBRHduRU5ud3JiCjJSTmVER3FGOG1XWDcxcWtueVNlejVtbzVXcGdsYVRnMGlFNVcrb1NHOWxSWFEwdHJEeUdQQkFhZEt6cFBPT3MKeksyaHBJaXUrL2JiNTZxUXUwRDZXOGlyOTNZQTgyUjM5QXJjYkF3MzlneEIvOWpxSFhFWHJmTHNYRG53NVYydApoUk5Sb2wzcGpocGFRNkI0aUtFWXVwNXA4QSt3TWl6VGxJQ3N6d2ZVdmFFTENVcmsrVnVJaThkV1lwVmxLQW5wCm02bVRLM1N6ZnJyMEcvQ3lEMWp4bHZoZUZKOVlaaEhGWVlYTE91bmk0Unhid0xHeDVCb1ZTQXlnSVpDQWN4TVgKa1ArM3JFaXh3VEFmQXdhWjJEak5FK0xTCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1833"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d03fb550-9d22-42d5-b8ef-a72d936a1975
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 18:49:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4cf4045f-2622-4156-80ee-f2113aa298ab
+      - 775366ad-244b-40a5-8228-db73514205df
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +972,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:15 GMT
+      - Thu, 02 Nov 2023 18:49:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2e0c3ec-2fd0-4e0b-bcfa-da96c31cc970
+      - ecb62343-e1b1-49ef-b18b-60e9d6ae1563
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,19 +1005,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVV0xFWTNTdzZhMWp4T0tOY0JMS1FJSExEUlRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU9Gb1hEVE16TVRBeE56RTFOVEUxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFucnFoT3NmdDc5WDM1amVaeU15OXJiMEZtc05hR2JzUEhCRTdhT1VqSzF4TUZQR1BENjJIVUJ6WGswd1YKSGNhczVIVVZYWHpBZnVDL29VL3pVbE1vcUtsbktFM2NIKzIxMkg0eWtNekJ3Z0tOMzBRTTF2RENweTk5U0R4QwpTdHB1b0RHanQzejZoN050Wk9aSXBoem5EeVFGYjhyQ0NSZjlmczAxbmI2Q1dOR1J5TWlRK2pXTjR2eERqc0hSCjVyOVZZZkxIS1RKbzJoVzE5cUhya2h3elpPazJQcWJxWGxzRjkxOXQvNGZpWElLOG10bkE5MHNPT25NeWdCQ0QKTDhYMS9zVnhHUS81d0JNN1FIYjEwbUJWME9mN0NKRUpxSnkzWFhpOU9qTWlPcVdxRTF4K1NlS0JzU3FWUU9seQpNbVY2VmEvdnpNelZuVXJOcEZHV2FOb1ZYd0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdE9UVTRPVFF6WVRFdE1ETTBOUzAwWm1FeExUa3dNRGt0TTJFNFl6YzROV1kzTnpnekxuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrMUtod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUJrWkU3TmEvcW1lVGkrQjl3UTFsbGI0Q2FWeW9uTnd2UzFXMVBwVklVRmhKL2pBMW9DTEhBRHduRU5ud3JiCjJSTmVER3FGOG1XWDcxcWtueVNlejVtbzVXcGdsYVRnMGlFNVcrb1NHOWxSWFEwdHJEeUdQQkFhZEt6cFBPT3MKeksyaHBJaXUrL2JiNTZxUXUwRDZXOGlyOTNZQTgyUjM5QXJjYkF3MzlneEIvOWpxSFhFWHJmTHNYRG53NVYydApoUk5Sb2wzcGpocGFRNkI0aUtFWXVwNXA4QSt3TWl6VGxJQ3N6d2ZVdmFFTENVcmsrVnVJaThkV1lwVmxLQW5wCm02bVRLM1N6ZnJyMEcvQ3lEMWp4bHZoZUZKOVlaaEhGWVlYTE91bmk0Unhid0xHeDVCb1ZTQXlnSVpDQWN4TVgKa1ArM3JFaXh3VEFmQXdhWjJEak5FK0xTCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:15 GMT
+      - Thu, 02 Nov 2023 18:49:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ecf92ad5-996a-443d-a097-95f4b9ec82ff
+      - 0cbc4032-0c5d-4e17-b499-e9fa6f72b283
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,19 +1038,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:15 GMT
+      - Thu, 02 Nov 2023 18:49:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b747f78-4d84-48bc-90ab-181737a6b0a3
+      - 3880fbe9-02cf-4a13-9a8c-6cc88c5d01be
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,19 +1071,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:16 GMT
+      - Thu, 02 Nov 2023 18:49:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1093,106 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8b4b653-7e10-405a-8908-e397e04dc502
+      - aa75e92d-8242-40d1-a042-c294af4a8bc6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1843"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:49:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8caf14aa-fd55-4080-bff7-9933b9ff4818
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "102"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:49:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 953662e6-411b-45c6-bf04-c57454885a62
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1249"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:49:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ec0ef2a8-90a2-477d-8f80-0cd7fbfbe469
     status: 200 OK
     code: 200
     duration: ""
@@ -1205,19 +1205,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users
     method: POST
   response:
     body: '{"is_admin":false,"name":"foo"}'
     headers:
       Content-Length:
-      - "32"
+      - "31"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:16 GMT
+      - Thu, 02 Nov 2023 18:49:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1227,7 +1227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5495c78-0e3a-42ed-be7a-98b0ff40da9e
+      - 052b851c-f736-4f41-b559-d546ce39775a
     status: 200 OK
     code: 200
     duration: ""
@@ -1238,19 +1238,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:16 GMT
+      - Thu, 02 Nov 2023 18:49:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1260,7 +1260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2abb97b3-5568-4c78-8bfa-93313a49b3de
+      - 69971be0-3be2-491a-a4b2-3b7caae1d79e
     status: 200 OK
     code: 200
     duration: ""
@@ -1271,19 +1271,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:16 GMT
+      - Thu, 02 Nov 2023 18:49:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1293,7 +1293,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62b8273e-2526-4b02-a256-fbf64b5f4275
+      - 35508168-3428-4ea0-8f2f-f6ea9a4e5ed5
     status: 200 OK
     code: 200
     duration: ""
@@ -1304,19 +1304,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:17 GMT
+      - Thu, 02 Nov 2023 18:49:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1326,7 +1326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02df18b1-666f-42e3-af23-a9745c7ee7a9
+      - 218f011a-c911-439c-a6c7-a36bcb83209c
     status: 200 OK
     code: 200
     duration: ""
@@ -1337,19 +1337,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVV0xFWTNTdzZhMWp4T0tOY0JMS1FJSExEUlRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU9Gb1hEVE16TVRBeE56RTFOVEUxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFucnFoT3NmdDc5WDM1amVaeU15OXJiMEZtc05hR2JzUEhCRTdhT1VqSzF4TUZQR1BENjJIVUJ6WGswd1YKSGNhczVIVVZYWHpBZnVDL29VL3pVbE1vcUtsbktFM2NIKzIxMkg0eWtNekJ3Z0tOMzBRTTF2RENweTk5U0R4QwpTdHB1b0RHanQzejZoN050Wk9aSXBoem5EeVFGYjhyQ0NSZjlmczAxbmI2Q1dOR1J5TWlRK2pXTjR2eERqc0hSCjVyOVZZZkxIS1RKbzJoVzE5cUhya2h3elpPazJQcWJxWGxzRjkxOXQvNGZpWElLOG10bkE5MHNPT25NeWdCQ0QKTDhYMS9zVnhHUS81d0JNN1FIYjEwbUJWME9mN0NKRUpxSnkzWFhpOU9qTWlPcVdxRTF4K1NlS0JzU3FWUU9seQpNbVY2VmEvdnpNelZuVXJOcEZHV2FOb1ZYd0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdE9UVTRPVFF6WVRFdE1ETTBOUzAwWm1FeExUa3dNRGt0TTJFNFl6YzROV1kzTnpnekxuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrMUtod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUJrWkU3TmEvcW1lVGkrQjl3UTFsbGI0Q2FWeW9uTnd2UzFXMVBwVklVRmhKL2pBMW9DTEhBRHduRU5ud3JiCjJSTmVER3FGOG1XWDcxcWtueVNlejVtbzVXcGdsYVRnMGlFNVcrb1NHOWxSWFEwdHJEeUdQQkFhZEt6cFBPT3MKeksyaHBJaXUrL2JiNTZxUXUwRDZXOGlyOTNZQTgyUjM5QXJjYkF3MzlneEIvOWpxSFhFWHJmTHNYRG53NVYydApoUk5Sb2wzcGpocGFRNkI0aUtFWXVwNXA4QSt3TWl6VGxJQ3N6d2ZVdmFFTENVcmsrVnVJaThkV1lwVmxLQW5wCm02bVRLM1N6ZnJyMEcvQ3lEMWp4bHZoZUZKOVlaaEhGWVlYTE91bmk0Unhid0xHeDVCb1ZTQXlnSVpDQWN4TVgKa1ArM3JFaXh3VEFmQXdhWjJEak5FK0xTCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:17 GMT
+      - Thu, 02 Nov 2023 18:49:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1359,7 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a21af8ed-67bc-4058-adde-8e54e4a4eb8e
+      - 13ee0704-7215-4081-a97d-7ae86269bce7
     status: 200 OK
     code: 200
     duration: ""
@@ -1370,52 +1370,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1293"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b6132967-a2ac-49bd-b491-3ea5d79403d9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:17 GMT
+      - Thu, 02 Nov 2023 18:49:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1425,7 +1392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ecfe627d-90f6-4f36-88e0-8f808a1f7905
+      - f1e02a51-7b15-47eb-ac4b-963afc2cd24c
     status: 200 OK
     code: 200
     duration: ""
@@ -1436,19 +1403,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1249"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:49:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 223c87f1-2de0-4e06-9011-cf28ff73318c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:17 GMT
+      - Thu, 02 Nov 2023 18:49:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1458,7 +1458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ed1054b-c949-4b1e-a38c-00007aa23786
+      - 7b963dc8-1ee4-4d1d-85d7-22212f8cf0e5
     status: 200 OK
     code: 200
     duration: ""
@@ -1469,19 +1469,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:18 GMT
+      - Thu, 02 Nov 2023 18:49:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1491,7 +1491,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d551df9e-74b8-4ece-ac63-5b9e0382fd76
+      - 9a37f46c-ce73-4be0-91af-f153e12e2629
     status: 200 OK
     code: 200
     duration: ""
@@ -1502,19 +1502,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVV0xFWTNTdzZhMWp4T0tOY0JMS1FJSExEUlRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU9Gb1hEVE16TVRBeE56RTFOVEUxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFucnFoT3NmdDc5WDM1amVaeU15OXJiMEZtc05hR2JzUEhCRTdhT1VqSzF4TUZQR1BENjJIVUJ6WGswd1YKSGNhczVIVVZYWHpBZnVDL29VL3pVbE1vcUtsbktFM2NIKzIxMkg0eWtNekJ3Z0tOMzBRTTF2RENweTk5U0R4QwpTdHB1b0RHanQzejZoN050Wk9aSXBoem5EeVFGYjhyQ0NSZjlmczAxbmI2Q1dOR1J5TWlRK2pXTjR2eERqc0hSCjVyOVZZZkxIS1RKbzJoVzE5cUhya2h3elpPazJQcWJxWGxzRjkxOXQvNGZpWElLOG10bkE5MHNPT25NeWdCQ0QKTDhYMS9zVnhHUS81d0JNN1FIYjEwbUJWME9mN0NKRUpxSnkzWFhpOU9qTWlPcVdxRTF4K1NlS0JzU3FWUU9seQpNbVY2VmEvdnpNelZuVXJOcEZHV2FOb1ZYd0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdE9UVTRPVFF6WVRFdE1ETTBOUzAwWm1FeExUa3dNRGt0TTJFNFl6YzROV1kzTnpnekxuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrMUtod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUJrWkU3TmEvcW1lVGkrQjl3UTFsbGI0Q2FWeW9uTnd2UzFXMVBwVklVRmhKL2pBMW9DTEhBRHduRU5ud3JiCjJSTmVER3FGOG1XWDcxcWtueVNlejVtbzVXcGdsYVRnMGlFNVcrb1NHOWxSWFEwdHJEeUdQQkFhZEt6cFBPT3MKeksyaHBJaXUrL2JiNTZxUXUwRDZXOGlyOTNZQTgyUjM5QXJjYkF3MzlneEIvOWpxSFhFWHJmTHNYRG53NVYydApoUk5Sb2wzcGpocGFRNkI0aUtFWXVwNXA4QSt3TWl6VGxJQ3N6d2ZVdmFFTENVcmsrVnVJaThkV1lwVmxLQW5wCm02bVRLM1N6ZnJyMEcvQ3lEMWp4bHZoZUZKOVlaaEhGWVlYTE91bmk0Unhid0xHeDVCb1ZTQXlnSVpDQWN4TVgKa1ArM3JFaXh3VEFmQXdhWjJEak5FK0xTCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:18 GMT
+      - Thu, 02 Nov 2023 18:49:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1524,7 +1524,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2f09cff-3c9b-41c6-afeb-211a34f85041
+      - 2d9bdc91-204a-478f-824b-4511073a4e89
     status: 200 OK
     code: 200
     duration: ""
@@ -1535,19 +1535,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:18 GMT
+      - Thu, 02 Nov 2023 18:49:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1557,7 +1557,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17004feb-d272-4d85-aaf6-de7e672f9a7d
+      - 7462b0f2-6427-4b82-890c-8f9d93687e85
     status: 200 OK
     code: 200
     duration: ""
@@ -1568,19 +1568,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:18 GMT
+      - Thu, 02 Nov 2023 18:49:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1590,7 +1590,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f1775df-ef15-4df6-9169-1c986e9bda6b
+      - ac1896aa-279d-4e31-af3a-b591f103f17f
     status: 200 OK
     code: 200
     duration: ""
@@ -1601,19 +1601,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:18 GMT
+      - Thu, 02 Nov 2023 18:49:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1623,7 +1623,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a9418c7-75a9-4d08-9fe4-b20c920f5b04
+      - 5950dee4-d36c-46e3-8d73-dcf87dbe03a5
     status: 200 OK
     code: 200
     duration: ""
@@ -1634,19 +1634,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:19 GMT
+      - Thu, 02 Nov 2023 18:49:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1656,7 +1656,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d610561-08e8-4ee0-979d-34d8ca31d129
+      - ee8220f3-1566-4816-b8ae-8efeaa44941f
     status: 200 OK
     code: 200
     duration: ""
@@ -1669,19 +1669,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"all","user_name":"foo"}'
     headers:
       Content-Length:
-      - "62"
+      - "60"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:19 GMT
+      - Thu, 02 Nov 2023 18:49:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1691,7 +1691,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8106b8de-40a6-447c-b05b-7c9f1148059d
+      - b60b03e5-25a6-4169-a10b-a68163c6f4e3
     status: 200 OK
     code: 200
     duration: ""
@@ -1702,19 +1702,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:19 GMT
+      - Thu, 02 Nov 2023 18:49:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1724,7 +1724,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c88ba3e2-e534-4d23-acfd-d5b8d00e7533
+      - b1eafcce-6ca6-4bda-9b07-3793126ada42
     status: 200 OK
     code: 200
     duration: ""
@@ -1735,19 +1735,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:20 GMT
+      - Thu, 02 Nov 2023 18:49:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1757,7 +1757,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75fc4f2b-18bc-439a-841e-a9897f998c7f
+      - 0defcfd7-c5fd-462e-96ca-50e9055e546b
     status: 200 OK
     code: 200
     duration: ""
@@ -1768,19 +1768,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:20 GMT
+      - Thu, 02 Nov 2023 18:49:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1790,7 +1790,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 141a5c70-4aaf-46b1-baf8-6076f1161d1d
+      - d9e13a1d-5964-45ff-9daa-20b05a7b61f0
     status: 200 OK
     code: 200
     duration: ""
@@ -1801,19 +1801,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
     headers:
       Content-Length:
-      - "96"
+      - "93"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:20 GMT
+      - Thu, 02 Nov 2023 18:49:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1823,7 +1823,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fe907bf-1f20-43f9-bb1a-b5a756f1bf65
+      - 9392a0fa-9f2e-44ff-a3fa-4d784fcdb3fa
     status: 200 OK
     code: 200
     duration: ""
@@ -1834,19 +1834,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:21 GMT
+      - Thu, 02 Nov 2023 18:50:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1856,7 +1856,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e60c384c-0dd3-4fb7-acb6-6a4ee1f17567
+      - a64afa8f-5254-4fcd-9aa5-4430dd1a37b1
     status: 200 OK
     code: 200
     duration: ""
@@ -1867,19 +1867,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVV0xFWTNTdzZhMWp4T0tOY0JMS1FJSExEUlRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU9Gb1hEVE16TVRBeE56RTFOVEUxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFucnFoT3NmdDc5WDM1amVaeU15OXJiMEZtc05hR2JzUEhCRTdhT1VqSzF4TUZQR1BENjJIVUJ6WGswd1YKSGNhczVIVVZYWHpBZnVDL29VL3pVbE1vcUtsbktFM2NIKzIxMkg0eWtNekJ3Z0tOMzBRTTF2RENweTk5U0R4QwpTdHB1b0RHanQzejZoN050Wk9aSXBoem5EeVFGYjhyQ0NSZjlmczAxbmI2Q1dOR1J5TWlRK2pXTjR2eERqc0hSCjVyOVZZZkxIS1RKbzJoVzE5cUhya2h3elpPazJQcWJxWGxzRjkxOXQvNGZpWElLOG10bkE5MHNPT25NeWdCQ0QKTDhYMS9zVnhHUS81d0JNN1FIYjEwbUJWME9mN0NKRUpxSnkzWFhpOU9qTWlPcVdxRTF4K1NlS0JzU3FWUU9seQpNbVY2VmEvdnpNelZuVXJOcEZHV2FOb1ZYd0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdE9UVTRPVFF6WVRFdE1ETTBOUzAwWm1FeExUa3dNRGt0TTJFNFl6YzROV1kzTnpnekxuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrMUtod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUJrWkU3TmEvcW1lVGkrQjl3UTFsbGI0Q2FWeW9uTnd2UzFXMVBwVklVRmhKL2pBMW9DTEhBRHduRU5ud3JiCjJSTmVER3FGOG1XWDcxcWtueVNlejVtbzVXcGdsYVRnMGlFNVcrb1NHOWxSWFEwdHJEeUdQQkFhZEt6cFBPT3MKeksyaHBJaXUrL2JiNTZxUXUwRDZXOGlyOTNZQTgyUjM5QXJjYkF3MzlneEIvOWpxSFhFWHJmTHNYRG53NVYydApoUk5Sb2wzcGpocGFRNkI0aUtFWXVwNXA4QSt3TWl6VGxJQ3N6d2ZVdmFFTENVcmsrVnVJaThkV1lwVmxLQW5wCm02bVRLM1N6ZnJyMEcvQ3lEMWp4bHZoZUZKOVlaaEhGWVlYTE91bmk0Unhid0xHeDVCb1ZTQXlnSVpDQWN4TVgKa1ArM3JFaXh3VEFmQXdhWjJEak5FK0xTCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:21 GMT
+      - Thu, 02 Nov 2023 18:50:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1889,7 +1889,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c16f8219-9b2f-48f7-b44e-a5357918db70
+      - 047109d0-2f75-41a3-89d1-4f2852751452
     status: 200 OK
     code: 200
     duration: ""
@@ -1900,19 +1900,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:21 GMT
+      - Thu, 02 Nov 2023 18:50:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1922,7 +1922,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc171233-bb02-4d4b-9514-a414a99970dc
+      - 803c634a-0917-4503-83d8-43360820af5d
     status: 200 OK
     code: 200
     duration: ""
@@ -1933,19 +1933,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:21 GMT
+      - Thu, 02 Nov 2023 18:50:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1955,7 +1955,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4599054c-3b23-4eaa-8a7a-0f0aeafcba43
+      - 24974366-e934-46fc-80e7-7b028b6e7333
     status: 200 OK
     code: 200
     duration: ""
@@ -1966,19 +1966,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:21 GMT
+      - Thu, 02 Nov 2023 18:50:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1988,7 +1988,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 932d20a3-b8ec-499a-87df-8ae9e58569d2
+      - b428f2e4-1dd8-433e-b4d6-bfde2c97f035
     status: 200 OK
     code: 200
     duration: ""
@@ -1999,19 +1999,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:21 GMT
+      - Thu, 02 Nov 2023 18:50:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2021,7 +2021,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6edfb5aa-f5d0-4b38-8bef-ce444ab97199
+      - d4d7eac9-5077-43e8-8c3b-d2796ec12851
     status: 200 OK
     code: 200
     duration: ""
@@ -2032,19 +2032,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:21 GMT
+      - Thu, 02 Nov 2023 18:50:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2054,7 +2054,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d0aac80-843d-4dff-94fb-5121f4c9c399
+      - f150469f-e335-40d0-bf8b-51de33467a26
     status: 200 OK
     code: 200
     duration: ""
@@ -2065,19 +2065,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
     headers:
       Content-Length:
-      - "96"
+      - "93"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:22 GMT
+      - Thu, 02 Nov 2023 18:50:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2087,7 +2087,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c358965-3eb3-4eb5-8b90-ab44c7eb9d7d
+      - c789adc7-4886-42dc-92c8-32036f17b24f
     status: 200 OK
     code: 200
     duration: ""
@@ -2098,19 +2098,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:23 GMT
+      - Thu, 02 Nov 2023 18:50:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2120,7 +2120,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c332c6db-9a6b-4a3d-ba64-005f21152002
+      - 68ff2f95-3944-4a1e-95ef-a5b16990219b
     status: 200 OK
     code: 200
     duration: ""
@@ -2131,19 +2131,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVV0xFWTNTdzZhMWp4T0tOY0JMS1FJSExEUlRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU9Gb1hEVE16TVRBeE56RTFOVEUxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFucnFoT3NmdDc5WDM1amVaeU15OXJiMEZtc05hR2JzUEhCRTdhT1VqSzF4TUZQR1BENjJIVUJ6WGswd1YKSGNhczVIVVZYWHpBZnVDL29VL3pVbE1vcUtsbktFM2NIKzIxMkg0eWtNekJ3Z0tOMzBRTTF2RENweTk5U0R4QwpTdHB1b0RHanQzejZoN050Wk9aSXBoem5EeVFGYjhyQ0NSZjlmczAxbmI2Q1dOR1J5TWlRK2pXTjR2eERqc0hSCjVyOVZZZkxIS1RKbzJoVzE5cUhya2h3elpPazJQcWJxWGxzRjkxOXQvNGZpWElLOG10bkE5MHNPT25NeWdCQ0QKTDhYMS9zVnhHUS81d0JNN1FIYjEwbUJWME9mN0NKRUpxSnkzWFhpOU9qTWlPcVdxRTF4K1NlS0JzU3FWUU9seQpNbVY2VmEvdnpNelZuVXJOcEZHV2FOb1ZYd0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdE9UVTRPVFF6WVRFdE1ETTBOUzAwWm1FeExUa3dNRGt0TTJFNFl6YzROV1kzTnpnekxuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrMUtod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUJrWkU3TmEvcW1lVGkrQjl3UTFsbGI0Q2FWeW9uTnd2UzFXMVBwVklVRmhKL2pBMW9DTEhBRHduRU5ud3JiCjJSTmVER3FGOG1XWDcxcWtueVNlejVtbzVXcGdsYVRnMGlFNVcrb1NHOWxSWFEwdHJEeUdQQkFhZEt6cFBPT3MKeksyaHBJaXUrL2JiNTZxUXUwRDZXOGlyOTNZQTgyUjM5QXJjYkF3MzlneEIvOWpxSFhFWHJmTHNYRG53NVYydApoUk5Sb2wzcGpocGFRNkI0aUtFWXVwNXA4QSt3TWl6VGxJQ3N6d2ZVdmFFTENVcmsrVnVJaThkV1lwVmxLQW5wCm02bVRLM1N6ZnJyMEcvQ3lEMWp4bHZoZUZKOVlaaEhGWVlYTE91bmk0Unhid0xHeDVCb1ZTQXlnSVpDQWN4TVgKa1ArM3JFaXh3VEFmQXdhWjJEak5FK0xTCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:23 GMT
+      - Thu, 02 Nov 2023 18:50:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2153,7 +2153,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44910fa0-5bbb-459e-8231-9ca066c551a4
+      - 8063f116-debf-411b-9ab0-98726a219d4a
     status: 200 OK
     code: 200
     duration: ""
@@ -2164,19 +2164,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:23 GMT
+      - Thu, 02 Nov 2023 18:50:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2186,7 +2186,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bec25df-424f-43aa-ba68-c7949dec17b3
+      - a7273bb0-e715-4995-bbfc-5292759f5e52
     status: 200 OK
     code: 200
     duration: ""
@@ -2197,19 +2197,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:23 GMT
+      - Thu, 02 Nov 2023 18:50:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2219,7 +2219,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5948e0da-679b-4eef-97ed-108fb9cc2c53
+      - 4f748ef4-0ebc-4a58-b8f0-d7abd01575a9
     status: 200 OK
     code: 200
     duration: ""
@@ -2230,19 +2230,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:23 GMT
+      - Thu, 02 Nov 2023 18:50:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2252,7 +2252,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07fd7cc0-59f4-4415-b461-59dabe9a565b
+      - fba4b080-4069-4742-a79b-5161213bd164
     status: 200 OK
     code: 200
     duration: ""
@@ -2263,19 +2263,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:23 GMT
+      - Thu, 02 Nov 2023 18:50:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2285,7 +2285,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b752eb8c-df30-437c-b725-5199fd612e71
+      - 18470a76-4ace-4dfb-8a73-e8736244a038
     status: 200 OK
     code: 200
     duration: ""
@@ -2296,19 +2296,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:23 GMT
+      - Thu, 02 Nov 2023 18:50:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2318,7 +2318,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78f27b5b-05f5-4ac3-a310-51d2e8fa9f25
+      - 8717a2fc-0fa3-4d1f-9c97-f0b61b27de92
     status: 200 OK
     code: 200
     duration: ""
@@ -2329,52 +2329,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "61"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6a822ccc-66af-41f6-aec3-49b5a2db9fd0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:23 GMT
+      - Thu, 02 Nov 2023 18:50:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2384,7 +2351,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2104b986-53cb-4c27-ae87-fbfecaa44f01
+      - 1b1ba518-344b-47ee-b784-75f53d887f5e
     status: 200 OK
     code: 200
     duration: ""
@@ -2395,19 +2362,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:50:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 25904353-d491-4ff4-a430-c90d1a98875c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
     headers:
       Content-Length:
-      - "96"
+      - "93"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:23 GMT
+      - Thu, 02 Nov 2023 18:50:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2417,7 +2417,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e875e7e-4eb1-421f-8a6f-2501ee9d1b4d
+      - a87c95a3-54e2-4210-b8e9-b6ce8dcef767
     status: 200 OK
     code: 200
     duration: ""
@@ -2428,19 +2428,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
     headers:
       Content-Length:
-      - "96"
+      - "93"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:24 GMT
+      - Thu, 02 Nov 2023 18:50:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2450,7 +2450,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1f52c1b-89ae-4a75-88cf-2c7c1fd03aaa
+      - a0a4eda5-5526-4ad5-a397-f6ffeae9612f
     status: 200 OK
     code: 200
     duration: ""
@@ -2461,19 +2461,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:24 GMT
+      - Thu, 02 Nov 2023 18:50:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2483,7 +2483,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0aaaa599-3067-4503-87b3-2eae5590feb5
+      - c5f0d9e9-641d-4605-910b-b935a964eab9
     status: 200 OK
     code: 200
     duration: ""
@@ -2494,19 +2494,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:24 GMT
+      - Thu, 02 Nov 2023 18:50:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2516,7 +2516,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36255f17-d1e9-4e00-8e7d-99668a6a9d44
+      - 289fefc7-36a5-492e-bd50-7bf82b849ec4
     status: 200 OK
     code: 200
     duration: ""
@@ -2527,19 +2527,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
     headers:
       Content-Length:
-      - "96"
+      - "93"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:25 GMT
+      - Thu, 02 Nov 2023 18:50:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2549,7 +2549,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14d025bc-8558-4168-9137-9ac94670f7da
+      - b122eeed-aee0-4e82-83d8-7ea934920265
     status: 200 OK
     code: 200
     duration: ""
@@ -2560,19 +2560,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:25 GMT
+      - Thu, 02 Nov 2023 18:50:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2582,7 +2582,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1feeed9f-c8a2-42bc-9b8d-5b8bc8273c5e
+      - 19ace607-160d-4279-b202-d9c8c7d45015
     status: 200 OK
     code: 200
     duration: ""
@@ -2593,19 +2593,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:26 GMT
+      - Thu, 02 Nov 2023 18:50:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2615,7 +2615,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50b1159f-c859-44cd-a2cd-d4e89bb56830
+      - cf1bef2a-d634-4ac2-b2f5-5cbd2b4ce352
     status: 200 OK
     code: 200
     duration: ""
@@ -2626,19 +2626,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:26 GMT
+      - Thu, 02 Nov 2023 18:50:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2648,7 +2648,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d35d6013-3f5e-458c-8425-39fb5cf5a37a
+      - 40f03bb3-6881-4f3c-ad36-69fb86eff057
     status: 200 OK
     code: 200
     duration: ""
@@ -2659,19 +2659,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
     headers:
       Content-Length:
-      - "96"
+      - "93"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:26 GMT
+      - Thu, 02 Nov 2023 18:50:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2681,7 +2681,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d5e74ab-3bff-4e81-91ac-96b60d816232
+      - a69265b5-1e00-4d59-9710-1728760feab2
     status: 200 OK
     code: 200
     duration: ""
@@ -2692,19 +2692,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:27 GMT
+      - Thu, 02 Nov 2023 18:50:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2714,7 +2714,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32505a5e-72f9-4164-a226-0cfebac74797
+      - b8756540-b0c3-47d5-9138-45ca295ecf53
     status: 200 OK
     code: 200
     duration: ""
@@ -2725,19 +2725,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVV0xFWTNTdzZhMWp4T0tOY0JMS1FJSExEUlRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU9Gb1hEVE16TVRBeE56RTFOVEUxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFucnFoT3NmdDc5WDM1amVaeU15OXJiMEZtc05hR2JzUEhCRTdhT1VqSzF4TUZQR1BENjJIVUJ6WGswd1YKSGNhczVIVVZYWHpBZnVDL29VL3pVbE1vcUtsbktFM2NIKzIxMkg0eWtNekJ3Z0tOMzBRTTF2RENweTk5U0R4QwpTdHB1b0RHanQzejZoN050Wk9aSXBoem5EeVFGYjhyQ0NSZjlmczAxbmI2Q1dOR1J5TWlRK2pXTjR2eERqc0hSCjVyOVZZZkxIS1RKbzJoVzE5cUhya2h3elpPazJQcWJxWGxzRjkxOXQvNGZpWElLOG10bkE5MHNPT25NeWdCQ0QKTDhYMS9zVnhHUS81d0JNN1FIYjEwbUJWME9mN0NKRUpxSnkzWFhpOU9qTWlPcVdxRTF4K1NlS0JzU3FWUU9seQpNbVY2VmEvdnpNelZuVXJOcEZHV2FOb1ZYd0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdE9UVTRPVFF6WVRFdE1ETTBOUzAwWm1FeExUa3dNRGt0TTJFNFl6YzROV1kzTnpnekxuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrMUtod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUJrWkU3TmEvcW1lVGkrQjl3UTFsbGI0Q2FWeW9uTnd2UzFXMVBwVklVRmhKL2pBMW9DTEhBRHduRU5ud3JiCjJSTmVER3FGOG1XWDcxcWtueVNlejVtbzVXcGdsYVRnMGlFNVcrb1NHOWxSWFEwdHJEeUdQQkFhZEt6cFBPT3MKeksyaHBJaXUrL2JiNTZxUXUwRDZXOGlyOTNZQTgyUjM5QXJjYkF3MzlneEIvOWpxSFhFWHJmTHNYRG53NVYydApoUk5Sb2wzcGpocGFRNkI0aUtFWXVwNXA4QSt3TWl6VGxJQ3N6d2ZVdmFFTENVcmsrVnVJaThkV1lwVmxLQW5wCm02bVRLM1N6ZnJyMEcvQ3lEMWp4bHZoZUZKOVlaaEhGWVlYTE91bmk0Unhid0xHeDVCb1ZTQXlnSVpDQWN4TVgKa1ArM3JFaXh3VEFmQXdhWjJEak5FK0xTCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:27 GMT
+      - Thu, 02 Nov 2023 18:50:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2747,7 +2747,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c47bf37a-3b0f-4408-98bb-f2c6645b7d23
+      - 301bce45-44fb-4185-9e44-973ff0bf250b
     status: 200 OK
     code: 200
     duration: ""
@@ -2758,19 +2758,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1249"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:50:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8c2b9581-3d0d-4eb7-a7e1-8a7ca1daefbe
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:27 GMT
+      - Thu, 02 Nov 2023 18:50:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2780,7 +2813,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 034ddbc4-2a2e-4036-8467-43be1874b071
+      - 6b657519-a393-482c-a8c3-88bdd30a9049
     status: 200 OK
     code: 200
     duration: ""
@@ -2791,52 +2824,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1293"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 868bf35c-76bf-4e50-ae38-3cc857394763
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:27 GMT
+      - Thu, 02 Nov 2023 18:50:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2846,7 +2846,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ca16de6-a4bc-4301-8992-d9a111fc2ad5
+      - 9aa0dabe-ace0-412f-8bbf-428870f06f4b
     status: 200 OK
     code: 200
     duration: ""
@@ -2857,19 +2857,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:27 GMT
+      - Thu, 02 Nov 2023 18:50:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2879,7 +2879,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 208241a8-d91d-4e9f-9fb0-3ab2cae40667
+      - 3ce194c0-0fcd-4549-aa1d-2f267e3fdd0e
     status: 200 OK
     code: 200
     duration: ""
@@ -2890,19 +2890,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:27 GMT
+      - Thu, 02 Nov 2023 18:50:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2912,7 +2912,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d37fd56-feaa-40f6-8109-3fbc64d00809
+      - a5767f68-529f-436c-bd40-c80c3f5eb504
     status: 200 OK
     code: 200
     duration: ""
@@ -2923,52 +2923,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "61"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a3c581ba-baa9-4799-9b9b-7b79e5e72c5a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:27 GMT
+      - Thu, 02 Nov 2023 18:50:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2978,7 +2945,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c30809b3-fa17-4a22-8aaa-cc8aa9fb3518
+      - 1f6861ce-d559-4f88-a06e-1851dc9dd131
     status: 200 OK
     code: 200
     duration: ""
@@ -2989,19 +2956,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:50:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cd12b31a-f778-4966-920f-087080ecdcbd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
     headers:
       Content-Length:
-      - "96"
+      - "93"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:28 GMT
+      - Thu, 02 Nov 2023 18:50:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3011,7 +3011,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9476b1ad-4f31-44c6-b5d4-d5413e511565
+      - 997ea0ab-38a7-43fb-bef4-363b3d85c74c
     status: 200 OK
     code: 200
     duration: ""
@@ -3022,19 +3022,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
     headers:
       Content-Length:
-      - "96"
+      - "93"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:28 GMT
+      - Thu, 02 Nov 2023 18:50:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3044,7 +3044,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2023c3bd-4fca-4c73-af72-62ff4ab7da87
+      - 848b5878-91af-46bb-81e4-a9799be39f8c
     status: 200 OK
     code: 200
     duration: ""
@@ -3055,19 +3055,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:30 GMT
+      - Thu, 02 Nov 2023 18:50:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3077,7 +3077,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5dd66425-f448-4532-89b3-e1954a37a0b8
+      - e66e5f57-85ca-45f7-a554-6fd21b1a7f2c
     status: 200 OK
     code: 200
     duration: ""
@@ -3088,19 +3088,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:30 GMT
+      - Thu, 02 Nov 2023 18:50:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3110,7 +3110,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89c1399d-1b20-48cc-837d-8a91395119d7
+      - cabdbfe4-0391-4403-9aff-b3494de9a483
     status: 200 OK
     code: 200
     duration: ""
@@ -3121,19 +3121,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
     headers:
       Content-Length:
-      - "96"
+      - "93"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:31 GMT
+      - Thu, 02 Nov 2023 18:50:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3143,7 +3143,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f80a1bbf-d911-4aca-81af-b1d92b836073
+      - 6215ac89-8a74-4dd0-b348-85d6370c734b
     status: 200 OK
     code: 200
     duration: ""
@@ -3154,19 +3154,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:31 GMT
+      - Thu, 02 Nov 2023 18:50:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3176,7 +3176,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09a76248-52c4-4812-a425-9ebc541ae75e
+      - 58c5dc45-4cc3-4ba2-bbdf-c7e60ad5d1d8
     status: 200 OK
     code: 200
     duration: ""
@@ -3187,19 +3187,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:31 GMT
+      - Thu, 02 Nov 2023 18:50:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3209,7 +3209,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2e57613-5b97-449e-8089-762f3cd25b3f
+      - d8d6c64e-9ddc-4e59-ada4-078a37ba4e94
     status: 200 OK
     code: 200
     duration: ""
@@ -3220,19 +3220,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:31 GMT
+      - Thu, 02 Nov 2023 18:50:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3242,7 +3242,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c879d9fa-0139-4cf9-9d19-c4f237dd558c
+      - 014f7afd-e892-454e-addb-d8e7f8903d02
     status: 200 OK
     code: 200
     duration: ""
@@ -3253,19 +3253,85 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1843"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:50:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4fe3c77a-6f41-4749-a085-e450eaa66ac4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:50:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3def8308-f0a2-4bcc-a262-df09662c2bfb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:31 GMT
+      - Thu, 02 Nov 2023 18:50:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3275,7 +3341,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5dc6d86-4b79-45e0-ac8c-2dfb0bc057d0
+      - 96eae8d1-d7c4-407b-a089-8c47713bc6b5
     status: 200 OK
     code: 200
     duration: ""
@@ -3286,52 +3352,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVV0xFWTNTdzZhMWp4T0tOY0JMS1FJSExEUlRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU9Gb1hEVE16TVRBeE56RTFOVEUxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFucnFoT3NmdDc5WDM1amVaeU15OXJiMEZtc05hR2JzUEhCRTdhT1VqSzF4TUZQR1BENjJIVUJ6WGswd1YKSGNhczVIVVZYWHpBZnVDL29VL3pVbE1vcUtsbktFM2NIKzIxMkg0eWtNekJ3Z0tOMzBRTTF2RENweTk5U0R4QwpTdHB1b0RHanQzejZoN050Wk9aSXBoem5EeVFGYjhyQ0NSZjlmczAxbmI2Q1dOR1J5TWlRK2pXTjR2eERqc0hSCjVyOVZZZkxIS1RKbzJoVzE5cUhya2h3elpPazJQcWJxWGxzRjkxOXQvNGZpWElLOG10bkE5MHNPT25NeWdCQ0QKTDhYMS9zVnhHUS81d0JNN1FIYjEwbUJWME9mN0NKRUpxSnkzWFhpOU9qTWlPcVdxRTF4K1NlS0JzU3FWUU9seQpNbVY2VmEvdnpNelZuVXJOcEZHV2FOb1ZYd0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdE9UVTRPVFF6WVRFdE1ETTBOUzAwWm1FeExUa3dNRGt0TTJFNFl6YzROV1kzTnpnekxuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrMUtod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUJrWkU3TmEvcW1lVGkrQjl3UTFsbGI0Q2FWeW9uTnd2UzFXMVBwVklVRmhKL2pBMW9DTEhBRHduRU5ud3JiCjJSTmVER3FGOG1XWDcxcWtueVNlejVtbzVXcGdsYVRnMGlFNVcrb1NHOWxSWFEwdHJEeUdQQkFhZEt6cFBPT3MKeksyaHBJaXUrL2JiNTZxUXUwRDZXOGlyOTNZQTgyUjM5QXJjYkF3MzlneEIvOWpxSFhFWHJmTHNYRG53NVYydApoUk5Sb2wzcGpocGFRNkI0aUtFWXVwNXA4QSt3TWl6VGxJQ3N6d2ZVdmFFTENVcmsrVnVJaThkV1lwVmxLQW5wCm02bVRLM1N6ZnJyMEcvQ3lEMWp4bHZoZUZKOVlaaEhGWVlYTE91bmk0Unhid0xHeDVCb1ZTQXlnSVpDQWN4TVgKa1ArM3JFaXh3VEFmQXdhWjJEak5FK0xTCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1833"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 37f23a41-2cb5-4c79-af04-3b98909f3f96
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:31 GMT
+      - Thu, 02 Nov 2023 18:50:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3341,7 +3374,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3da616d-efbd-4028-83cc-d1d4f2ab907f
+      - 4aa57ef2-2ae3-4db2-8c78-60169c4f8b4c
     status: 200 OK
     code: 200
     duration: ""
@@ -3352,52 +3385,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "61"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a89046bf-9332-4bc4-83a4-2991335ee946
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
     headers:
       Content-Length:
-      - "96"
+      - "93"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:31 GMT
+      - Thu, 02 Nov 2023 18:50:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3407,7 +3407,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3538831-f7f5-44bd-ac64-abc626374779
+      - 0856befe-f176-4197-b2b1-018fb65d6b54
     status: 200 OK
     code: 200
     duration: ""
@@ -3418,19 +3418,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:32 GMT
+      - Thu, 02 Nov 2023 18:50:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3440,7 +3440,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36332d2f-4e3a-4fa6-9d9c-26d64cc9ddfa
+      - 248a6598-09e4-4125-ab63-530ad6386e54
     status: 200 OK
     code: 200
     duration: ""
@@ -3451,52 +3451,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "61"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 82f8e970-18dd-41bf-b2e0-d69d3111cf00
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:32 GMT
+      - Thu, 02 Nov 2023 18:50:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3506,7 +3473,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c40e287d-c998-4d77-be2b-074cb42b157f
+      - b3b9998e-5814-4fa6-8449-dd9fefb8de1d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:50:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5208305a-0344-46be-a5ee-480ac517270d
     status: 200 OK
     code: 200
     duration: ""
@@ -3519,19 +3519,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"none","user_name":"foo"}'
     headers:
       Content-Length:
-      - "63"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:33 GMT
+      - Thu, 02 Nov 2023 18:50:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3541,7 +3541,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b9e40b9-d87b-4d17-991c-82f2864643a1
+      - 4d587e0a-9a00-4bde-94e9-89c84c31a715
     status: 200 OK
     code: 200
     duration: ""
@@ -3552,19 +3552,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:33 GMT
+      - Thu, 02 Nov 2023 18:50:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3574,7 +3574,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8d4d275-729d-4101-98a3-e8c48e792737
+      - bc58aae7-4326-4fa4-925a-2775b5447f28
     status: 200 OK
     code: 200
     duration: ""
@@ -3585,19 +3585,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:33 GMT
+      - Thu, 02 Nov 2023 18:50:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3607,7 +3607,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 720bba91-29c7-4459-9a4c-3bcbc584eb54
+      - fbd04148-5931-453a-9775-e7d2c2217cd3
     status: 200 OK
     code: 200
     duration: ""
@@ -3618,19 +3618,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:33 GMT
+      - Thu, 02 Nov 2023 18:50:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3640,7 +3640,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 729637b6-8c3f-442c-ac51-c6b83faf04c8
+      - e3ce4354-6985-4f3f-8ae5-248b557acf78
     status: 200 OK
     code: 200
     duration: ""
@@ -3651,7 +3651,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/users/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users/foo
     method: DELETE
   response:
     body: ""
@@ -3661,7 +3661,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:33 GMT
+      - Thu, 02 Nov 2023 18:50:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3671,7 +3671,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ab394af-85bd-436e-a83a-bcd36c22a1d3
+      - fd04e034-0535-4af9-a7b2-c1c8ef96be41
     status: 204 No Content
     code: 204
     duration: ""
@@ -3682,7 +3682,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/databases/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases/foo
     method: DELETE
   response:
     body: ""
@@ -3692,7 +3692,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:33 GMT
+      - Thu, 02 Nov 2023 18:50:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3702,7 +3702,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6786815f-a948-4e69-b0db-b4aa4d041987
+      - 7202c3e0-a9db-4699-931f-0375b069b869
     status: 204 No Content
     code: 204
     duration: ""
@@ -3713,19 +3713,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:33 GMT
+      - Thu, 02 Nov 2023 18:50:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3735,7 +3735,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4c68fac-1ddd-4930-8cc8-f2fcb3eb4d09
+      - f8d96e93-bcf9-44f3-82f5-2c41fc69f950
     status: 200 OK
     code: 200
     duration: ""
@@ -3746,19 +3746,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:34 GMT
+      - Thu, 02 Nov 2023 18:50:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3768,7 +3768,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39c94c2b-6b26-4855-ae90-c81586e137a2
+      - 30b8e107-226f-42dd-ad3e-f40d8d798077
     status: 200 OK
     code: 200
     duration: ""
@@ -3779,19 +3779,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVV0xFWTNTdzZhMWp4T0tOY0JMS1FJSExEUlRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU9Gb1hEVE16TVRBeE56RTFOVEUxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFucnFoT3NmdDc5WDM1amVaeU15OXJiMEZtc05hR2JzUEhCRTdhT1VqSzF4TUZQR1BENjJIVUJ6WGswd1YKSGNhczVIVVZYWHpBZnVDL29VL3pVbE1vcUtsbktFM2NIKzIxMkg0eWtNekJ3Z0tOMzBRTTF2RENweTk5U0R4QwpTdHB1b0RHanQzejZoN050Wk9aSXBoem5EeVFGYjhyQ0NSZjlmczAxbmI2Q1dOR1J5TWlRK2pXTjR2eERqc0hSCjVyOVZZZkxIS1RKbzJoVzE5cUhya2h3elpPazJQcWJxWGxzRjkxOXQvNGZpWElLOG10bkE5MHNPT25NeWdCQ0QKTDhYMS9zVnhHUS81d0JNN1FIYjEwbUJWME9mN0NKRUpxSnkzWFhpOU9qTWlPcVdxRTF4K1NlS0JzU3FWUU9seQpNbVY2VmEvdnpNelZuVXJOcEZHV2FOb1ZYd0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdE9UVTRPVFF6WVRFdE1ETTBOUzAwWm1FeExUa3dNRGt0TTJFNFl6YzROV1kzTnpnekxuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrMUtod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUJrWkU3TmEvcW1lVGkrQjl3UTFsbGI0Q2FWeW9uTnd2UzFXMVBwVklVRmhKL2pBMW9DTEhBRHduRU5ud3JiCjJSTmVER3FGOG1XWDcxcWtueVNlejVtbzVXcGdsYVRnMGlFNVcrb1NHOWxSWFEwdHJEeUdQQkFhZEt6cFBPT3MKeksyaHBJaXUrL2JiNTZxUXUwRDZXOGlyOTNZQTgyUjM5QXJjYkF3MzlneEIvOWpxSFhFWHJmTHNYRG53NVYydApoUk5Sb2wzcGpocGFRNkI0aUtFWXVwNXA4QSt3TWl6VGxJQ3N6d2ZVdmFFTENVcmsrVnVJaThkV1lwVmxLQW5wCm02bVRLM1N6ZnJyMEcvQ3lEMWp4bHZoZUZKOVlaaEhGWVlYTE91bmk0Unhid0xHeDVCb1ZTQXlnSVpDQWN4TVgKa1ArM3JFaXh3VEFmQXdhWjJEak5FK0xTCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:34 GMT
+      - Thu, 02 Nov 2023 18:50:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3801,7 +3801,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e2d1651-6e9e-48eb-b5b5-581d4219b9d5
+      - d312b972-dfdb-4ce5-9bb7-d64b90e5ea0c
     status: 200 OK
     code: 200
     duration: ""
@@ -3812,19 +3812,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:34 GMT
+      - Thu, 02 Nov 2023 18:50:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3834,7 +3834,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b045249-880b-419b-a3d0-e6066f19e38f
+      - 5923aa19-66cc-4dac-9476-e8756d876873
     status: 200 OK
     code: 200
     duration: ""
@@ -3845,19 +3845,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1296"
+      - "1252"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:35 GMT
+      - Thu, 02 Nov 2023 18:50:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3867,7 +3867,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 749887bd-9e83-464a-8e69-0f466a217f2d
+      - ae9c0204-c999-4019-a15f-575333972af1
     status: 200 OK
     code: 200
     duration: ""
@@ -3878,19 +3878,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.286873Z","retention":7},"created_at":"2023-10-20T15:51:10.286873Z","endpoint":{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055},"endpoints":[{"id":"a0578e01-2032-4784-91ed-b926c2ebe674","ip":"51.159.9.88","load_balancer":{},"name":null,"port":16055}],"engine":"PostgreSQL-15","id":"958943a1-0345-4fa1-9009-3a8c785f7783","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1296"
+      - "1252"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:35 GMT
+      - Thu, 02 Nov 2023 18:50:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3900,7 +3900,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b57a90a4-5f48-4e7c-83ce-65eec225a7c9
+      - 884ec637-9576-42c8-92c6-63ba1ffdb656
     status: 200 OK
     code: 200
     duration: ""
@@ -3911,10 +3911,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"958943a1-0345-4fa1-9009-3a8c785f7783","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -3923,7 +3923,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:05 GMT
+      - Thu, 02 Nov 2023 18:50:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3933,7 +3933,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61977b9e-58af-43fa-91a2-faa34cbc227e
+      - cadd788c-0089-4fb3-b654-cefbcf50dfd2
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3944,10 +3944,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/958943a1-0345-4fa1-9009-3a8c785f7783
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"958943a1-0345-4fa1-9009-3a8c785f7783","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -3956,7 +3956,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:05 GMT
+      - Thu, 02 Nov 2023 18:50:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3966,7 +3966,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 916f2371-0c1c-463c-b836-890881f5b83f
+      - bc871571-81ee-4012-8c3b-d0aa9383d0a3
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-acl-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-acl-basic.cassette.yaml
@@ -6,7 +6,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/database-engines
     method: GET
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:50:22 GMT
+      - Thu, 02 Nov 2023 18:46:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,34 +328,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c894214-951a-4b6a-b47c-a0fd9e81a07e
+      - ea80fedc-ca63-4be4-9d25-e625a094b3f5
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    body: '{"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
     method: POST
   response:
-    body: '{"ip":{"address":"51.158.70.246","id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.15.211.1","id":"d3970f1f-ac85-4434-904d-760f78fef8f8","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "306"
+      - "304"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:50:23 GMT
+      - Thu, 02 Nov 2023 18:50:45 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/d3970f1f-ac85-4434-904d-760f78fef8f8
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -365,34 +365,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2f8db3e-65b0-4377-a2df-a8da64e32916
+      - b3f748ec-efda-4ff0-a574-d6056b5a514c
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    body: '{"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
     method: POST
   response:
-    body: '{"ip":{"address":"51.15.208.177","id":"6fbb59fb-11a0-4a50-abc4-bd81c4547c07","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"163.172.144.233","id":"fc60dd87-2665-43fb-82f7-37416e799532","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "306"
+      - "308"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:50:23 GMT
+      - Thu, 02 Nov 2023 18:50:45 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/6fbb59fb-11a0-4a50-abc4-bd81c4547c07
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fc60dd87-2665-43fb-82f7-37416e799532
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -402,23 +402,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef662835-10f5-47ea-b816-36c877390325
+      - 792c68a6-d11d-4596-b71a-63a2a4038932
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"rdb-acl-basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"rdb-acl-basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "729"
@@ -427,7 +427,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:50:23 GMT
+      - Thu, 02 Nov 2023 18:50:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -437,7 +437,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b9520bf-6127-4b17-a499-401ac63679fe
+      - 7d96b5bc-7509-4878-881d-a4c447794f49
     status: 200 OK
     code: 200
     duration: ""
@@ -446,21 +446,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fc60dd87-2665-43fb-82f7-37416e799532
     method: GET
   response:
-    body: '{"ip":{"address":"51.158.70.246","id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"163.172.144.233","id":"fc60dd87-2665-43fb-82f7-37416e799532","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "306"
+      - "308"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:50:24 GMT
+      - Thu, 02 Nov 2023 18:50:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -470,7 +470,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58365fe1-b9be-4fd2-990c-327d61963c1a
+      - b9a6d71e-36cd-4b17-a351-37e843a1e867
     status: 200 OK
     code: 200
     duration: ""
@@ -479,21 +479,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/6fbb59fb-11a0-4a50-abc4-bd81c4547c07
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/d3970f1f-ac85-4434-904d-760f78fef8f8
     method: GET
   response:
-    body: '{"ip":{"address":"51.15.208.177","id":"6fbb59fb-11a0-4a50-abc4-bd81c4547c07","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.15.211.1","id":"d3970f1f-ac85-4434-904d-760f78fef8f8","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "306"
+      - "304"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:50:24 GMT
+      - Thu, 02 Nov 2023 18:50:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -503,7 +503,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40177d0b-6aa2-4d46-8d8f-b9f9eb7d43d3
+      - 4a271c92-8e03-46a1-97c5-75a0e6df4ea6
     status: 200 OK
     code: 200
     duration: ""
@@ -512,45 +512,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "729"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:50:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 32b327e5-e907-4345-a60f-2b6382e2489d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "729"
@@ -559,7 +526,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:50:54 GMT
+      - Thu, 02 Nov 2023 18:50:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -569,7 +536,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e8d44ad-4435-4cee-a9de-785bb15ee7bd
+      - a7924cb6-42bd-49da-854c-e09abdcbafbb
     status: 200 OK
     code: 200
     duration: ""
@@ -578,12 +545,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "729"
@@ -592,7 +559,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:51:24 GMT
+      - Thu, 02 Nov 2023 18:51:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -602,7 +569,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d84b8553-d9d9-4d6c-8020-c38312c0386f
+      - 46c87017-620b-4cba-add6-35a28a44d90c
     status: 200 OK
     code: 200
     duration: ""
@@ -611,12 +578,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "729"
@@ -625,7 +592,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:51:55 GMT
+      - Thu, 02 Nov 2023 18:51:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -635,7 +602,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e31f6698-76dd-4afd-ab3d-f8fe3def606e
+      - 4fbb53cd-72fb-41e9-b15b-1bcb2996f191
     status: 200 OK
     code: 200
     duration: ""
@@ -644,12 +611,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "729"
@@ -658,7 +625,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:52:25 GMT
+      - Thu, 02 Nov 2023 18:52:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -668,7 +635,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a418ea0-6101-4bb6-845e-21d7a4d99d59
+      - c42c15b6-1335-4122-b382-7c2c3de22e33
     status: 200 OK
     code: 200
     duration: ""
@@ -677,12 +644,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "729"
@@ -691,7 +658,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:52:59 GMT
+      - Thu, 02 Nov 2023 18:52:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -701,7 +668,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ef1a1db-3338-4c69-9231-9827f9d26c32
+      - bb455c10-91a5-48df-a385-769d4ab68906
     status: 200 OK
     code: 200
     duration: ""
@@ -710,21 +677,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1204"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:53:29 GMT
+      - Thu, 02 Nov 2023 18:53:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -734,7 +701,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01fc9262-a2f1-4793-8d97-fbba9df70647
+      - b68306f6-9818-4f8c-b261-776e7b173284
     status: 200 OK
     code: 200
     duration: ""
@@ -745,21 +712,21 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1204"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:53:29 GMT
+      - Thu, 02 Nov 2023 18:53:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -769,7 +736,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 617262dc-e349-4c8d-baa4-bb24ffc63c9c
+      - dac930cb-3b7e-41dd-b2fa-84f8b1342a98
     status: 200 OK
     code: 200
     duration: ""
@@ -778,21 +745,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1204"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:53:29 GMT
+      - Thu, 02 Nov 2023 18:53:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -802,7 +769,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3dd9adc-4714-4169-bdd7-616a11400627
+      - bfc41364-6e06-4cbc-97d7-15245875d456
     status: 200 OK
     code: 200
     duration: ""
@@ -811,21 +778,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVQkFsVmFEMkd0WTA2NWdSdVNheW9peW9KcDd3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UazJNQjRYCkRUSXpNVEF6TVRFME5URXdNbG9YRFRNek1UQXlPREUwTlRFd01sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRrMk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZTaFV5bnRiVnRvVVdOR2d2SDV4SVhrK21DbllLR0hqK0ZoS0czK1MxR0pQVmxOeVBURHkKRFVCVVM4MVE2SkZHMUpjd3BMMll5dGtiUEVyRURZOFBEaS9MTy9zdVZpN0d1MVlzNVFhNlVQNWFvREk2SkYzVgpKV01jczBhRWw3RG1EN011dmd4WEhKVEFoOUtFVUdyL3hWRXJTS05aMVJIZWFpcmU2Q2hyR0VLZ3ZOVXc2eDBpCnhmUjQ5V2hnNUlxWmtpWmRnWXpUR2RyZ0NyK2UzR0NoQldWanVQSFMrSm9OYVlDcnc0cngwenRqQ1VHamtma08KWFd0cnZzMkNtVXI1WnBxbVU3cGRWUW1ickUxVnRBQkZqTEgrTDVVVUN4Y3RSZFF1L05LZ3ZFWXBWYkZKY2VWZAoxMEN1UytUQ0FTS1ZlUnVKakU3dzFvaC9VZmRvazMxbkJRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBM0xqRTVOb0k4Y25jdE1tWm1Nalk0T0dFdE5UZGpOUzAwWWpJMExXRTVNamd0WVdWbVpXSmkKTm1Nek1tVmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrYXRod1F6bjgvRU1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUF3aHlqdHJVN2NUZGlLMjdQMnBIb3dyWVhYcnhGNkh4OUp0VERJcjErd1pMSm5kKzVXCm1nSmtSK2hQRWJmTWd6L1ZQVEI5d3hmYnBEa29PVHN1UXhuZDR1d1l3alNwTlBlRFFKdVRSbUdTMEIxbXJSMFAKamRTL202SUQyd2pVS3pTcTNlbWc2OHpYRmZwMlBOUzd4ckprM0g0RXMzYk9TSDFUTm1VemFMaFJRUXZ1VmcweQpFM1F3ZTRsV0hXSFZNc21QWUdvUGZtaGVTRWlEbHBic2FSWk1Gclh1WjBnWU43eFBNa3MzdEZLWll4SFZwcnJHCnA3dUlRbHdZSGxwVU9teWFXTmRkcjUydG5ZdTRBK0laeDdYdzNucDBINndxQ2FrSjdBUEFXM1JTWnB3TkVsMkMKTUl2MjBZTjArc3lLdzkvamNhdHV3eVkzWVhwTW1NaXZSTVZECi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTThENFNmN2ttY1BEb3duK3IvUTdvOEl3Ukt3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnMU1USXpXaGNOTXpNeE1ETXdNVGcxTVRJeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpldCtiRWRWUWMrWDhoOUNXTTVmSDdDRFhKVlpHMDdlK3FsazF3RGlObmpBWHNZV3lpd3V1TG4KeEY0QzlNekFMT3Q4emh6aGZGbHFwUlhYckVMOFlMVktDengyTUt4U2ZVbWE1b2RDbTA4M2Y2M2F1U210VWlvSAp2bkRha240OVM0VU5yWWYraDZLNWNPM2w1c211OG1CUVhmbXhjeU9jQTlOUWx2ZTRZYWhmVnJDcElaZ2tPSTBaCmN0cjQ3M2tEMmNaN3hKMDUzVWZMVTMrbVdUWTc4NlJJcFJvdnRON1lNVnNDSWM2Y3dDS1kvb1RnQ3J1VWExZ1cKdllmRjdHclVQMlVDa1h6OWplSno3Nm92Ujh6MEw4YnBiTDIwWU54cmhZYlhMQUFLd3hnbEtPYlF1VEtkcmE4SwowdWUxWnpXK0FiR2NvKzRUem4yOTkzMTFqN3VFMG44Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0Tm1Vell6QXlNekl0WkRZeFpDMDBNbVJrTFRrNFpqWXRaR0kzTVdGbU1qUmkKTVdKa0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm5jeWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXRYY2JhVkxzNVE3TytmK25XVkIyaTdkU1lPb1NBUXpHS0l0cFZWenpwMTdyem04c1ltQThDCmcwZ2hHZm5SS2pTTVZ2YnlEWVcweGMrNTdPNEp1Rm9SMGI0Y1FYZkNLUFFPT0cwOWFBTXg0U25WRlpIbjZpZU8KRE9xeUwybElpS3hXbWJnWCtRRkVKZlRMTXcvRnVnYXlwclZ4a3dMTm9YNjVURTdlRVRieHBsSHVLckl5dHd3Tgo5bFRkekRNdExwUDFkYnZaOHNlK2NFdHN1elFNbGtjMytnTjdNcU1zaUhEanNLRDlnOE1SQUdwRkdwSDIycVJoCnhMVyttdkVkdWdPMHhrSU9GVjg2VEgwakFkNGJFOGdVcmNlRE10NUs3bzBRcUlsd05BWE80c2piUm1DVS9rWWUKb2tYV28ySjdLYnNiM05NbXQzRVplcUlseU91T2ZnVisKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1847"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:53:31 GMT
+      - Thu, 02 Nov 2023 18:53:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -835,7 +802,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 664f64e9-2587-4876-84ec-64e3f3c14588
+      - 368a741a-7fa3-4578-84ef-5c5ead9d56a6
     status: 200 OK
     code: 200
     duration: ""
@@ -844,21 +811,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1204"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:53:31 GMT
+      - Thu, 02 Nov 2023 18:53:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -868,24 +835,24 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fcdc6d02-a4d4-49a7-9043-5cc3ff60c334
+      - 36ac40ae-5195-4c9f-8f07-37c35861d183
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"rules":[{"ip":"51.15.208.177/32","description":""},{"ip":"51.158.70.246/32","description":""}]}'
+    body: '{"rules":[{"ip":"51.15.211.1/32","description":""},{"ip":"163.172.144.233/32","description":""}]}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
     method: PUT
   response:
-    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.15.208.177/32","port":10010,"protocol":"tcp"},{"action":"allow","description":"IP
-      allowed","direction":"inbound","ip":"51.158.70.246/32","port":10010,"protocol":"tcp"}]}'
+    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.15.211.1/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"IP
+      allowed","direction":"inbound","ip":"163.172.144.233/32","port":12508,"protocol":"tcp"}]}'
     headers:
       Content-Length:
       - "255"
@@ -894,7 +861,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:53:31 GMT
+      - Thu, 02 Nov 2023 18:53:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -904,7 +871,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61e07912-cfa2-419d-bf99-d9812fc7fd3a
+      - b06ca8fd-dacd-4e63-b89d-f3a923a43e38
     status: 200 OK
     code: 200
     duration: ""
@@ -913,21 +880,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1210"
+      - "1208"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:53:31 GMT
+      - Thu, 02 Nov 2023 18:53:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -937,7 +904,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b82ca939-242f-40f4-98ba-e1654d81944d
+      - f24e09b4-aa9f-4db4-9bde-82ea222c2c16
     status: 200 OK
     code: 200
     duration: ""
@@ -946,21 +913,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1204"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:02 GMT
+      - Thu, 02 Nov 2023 18:53:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -970,7 +937,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e642b1c0-9ed9-425a-a460-186e69b1fcf5
+      - 72ec5352-fc98-4e8a-9209-5522263a36b9
     status: 200 OK
     code: 200
     duration: ""
@@ -979,212 +946,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.15.208.177/32","port":10010,"protocol":"tcp"},{"action":"allow","description":"IP
-      allowed","direction":"inbound","ip":"51.158.70.246/32","port":10010,"protocol":"tcp"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "271"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:54:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 07314412-3996-4ef7-9778-2720b04847ec
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/6fbb59fb-11a0-4a50-abc4-bd81c4547c07
-    method: GET
-  response:
-    body: '{"ip":{"address":"51.15.208.177","id":"6fbb59fb-11a0-4a50-abc4-bd81c4547c07","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "306"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:54:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d8a79fe3-762c-4aa1-b2db-af3accdecdc7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
-    method: GET
-  response:
-    body: '{"ip":{"address":"51.158.70.246","id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "306"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:54:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b6d59987-b72c-420f-b342-f49381f64319
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1204"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:54:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d88cf41c-20cc-4d86-b1d8-25248b290af7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVQkFsVmFEMkd0WTA2NWdSdVNheW9peW9KcDd3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UazJNQjRYCkRUSXpNVEF6TVRFME5URXdNbG9YRFRNek1UQXlPREUwTlRFd01sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRrMk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZTaFV5bnRiVnRvVVdOR2d2SDV4SVhrK21DbllLR0hqK0ZoS0czK1MxR0pQVmxOeVBURHkKRFVCVVM4MVE2SkZHMUpjd3BMMll5dGtiUEVyRURZOFBEaS9MTy9zdVZpN0d1MVlzNVFhNlVQNWFvREk2SkYzVgpKV01jczBhRWw3RG1EN011dmd4WEhKVEFoOUtFVUdyL3hWRXJTS05aMVJIZWFpcmU2Q2hyR0VLZ3ZOVXc2eDBpCnhmUjQ5V2hnNUlxWmtpWmRnWXpUR2RyZ0NyK2UzR0NoQldWanVQSFMrSm9OYVlDcnc0cngwenRqQ1VHamtma08KWFd0cnZzMkNtVXI1WnBxbVU3cGRWUW1ickUxVnRBQkZqTEgrTDVVVUN4Y3RSZFF1L05LZ3ZFWXBWYkZKY2VWZAoxMEN1UytUQ0FTS1ZlUnVKakU3dzFvaC9VZmRvazMxbkJRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBM0xqRTVOb0k4Y25jdE1tWm1Nalk0T0dFdE5UZGpOUzAwWWpJMExXRTVNamd0WVdWbVpXSmkKTm1Nek1tVmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrYXRod1F6bjgvRU1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUF3aHlqdHJVN2NUZGlLMjdQMnBIb3dyWVhYcnhGNkh4OUp0VERJcjErd1pMSm5kKzVXCm1nSmtSK2hQRWJmTWd6L1ZQVEI5d3hmYnBEa29PVHN1UXhuZDR1d1l3alNwTlBlRFFKdVRSbUdTMEIxbXJSMFAKamRTL202SUQyd2pVS3pTcTNlbWc2OHpYRmZwMlBOUzd4ckprM0g0RXMzYk9TSDFUTm1VemFMaFJRUXZ1VmcweQpFM1F3ZTRsV0hXSFZNc21QWUdvUGZtaGVTRWlEbHBic2FSWk1Gclh1WjBnWU43eFBNa3MzdEZLWll4SFZwcnJHCnA3dUlRbHdZSGxwVU9teWFXTmRkcjUydG5ZdTRBK0laeDdYdzNucDBINndxQ2FrSjdBUEFXM1JTWnB3TkVsMkMKTUl2MjBZTjArc3lLdzkvamNhdHV3eVkzWVhwTW1NaXZSTVZECi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1847"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:54:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5973ef7e-a689-43ec-ac11-119523190dd8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1204"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:54:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 574ba291-fe03-46b6-b79a-f10200b5abc0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee/acls
-    method: GET
-  response:
-    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.15.208.177/32","port":10010,"protocol":"tcp"},{"action":"allow","description":"IP
-      allowed","direction":"inbound","ip":"51.158.70.246/32","port":10010,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.15.211.1/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"IP
+      allowed","direction":"inbound","ip":"163.172.144.233/32","port":12508,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
       - "271"
@@ -1193,7 +961,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:03 GMT
+      - Thu, 02 Nov 2023 18:53:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1203,7 +971,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20bc4ebc-0aaf-4b5b-9870-353b21e00a37
+      - ee22d843-1be3-4920-9967-a79495d0cd76
     status: 200 OK
     code: 200
     duration: ""
@@ -1212,21 +980,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/6fbb59fb-11a0-4a50-abc4-bd81c4547c07
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/d3970f1f-ac85-4434-904d-760f78fef8f8
     method: GET
   response:
-    body: '{"ip":{"address":"51.15.208.177","id":"6fbb59fb-11a0-4a50-abc4-bd81c4547c07","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.15.211.1","id":"d3970f1f-ac85-4434-904d-760f78fef8f8","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "306"
+      - "304"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:04 GMT
+      - Thu, 02 Nov 2023 18:53:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1236,7 +1004,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac1d66c9-d157-4fe8-b265-8fb4202a092a
+      - 64e1f654-f6b0-4ccf-8019-8d88db39b83e
     status: 200 OK
     code: 200
     duration: ""
@@ -1245,21 +1013,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fc60dd87-2665-43fb-82f7-37416e799532
     method: GET
   response:
-    body: '{"ip":{"address":"51.158.70.246","id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"163.172.144.233","id":"fc60dd87-2665-43fb-82f7-37416e799532","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "306"
+      - "308"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:04 GMT
+      - Thu, 02 Nov 2023 18:53:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1269,7 +1037,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d3bbcaa-f22c-477c-a156-5ad8409ec3c3
+      - cff1c464-a645-41b5-84f2-88aba31aab81
     status: 200 OK
     code: 200
     duration: ""
@@ -1278,21 +1046,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1204"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:04 GMT
+      - Thu, 02 Nov 2023 18:53:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1302,7 +1070,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02e3826b-3e8a-49b1-8bf8-3452e836ea58
+      - b6c564e4-a5d4-4c7d-9e53-28211073dadb
     status: 200 OK
     code: 200
     duration: ""
@@ -1311,21 +1079,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVQkFsVmFEMkd0WTA2NWdSdVNheW9peW9KcDd3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UazJNQjRYCkRUSXpNVEF6TVRFME5URXdNbG9YRFRNek1UQXlPREUwTlRFd01sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRrMk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZTaFV5bnRiVnRvVVdOR2d2SDV4SVhrK21DbllLR0hqK0ZoS0czK1MxR0pQVmxOeVBURHkKRFVCVVM4MVE2SkZHMUpjd3BMMll5dGtiUEVyRURZOFBEaS9MTy9zdVZpN0d1MVlzNVFhNlVQNWFvREk2SkYzVgpKV01jczBhRWw3RG1EN011dmd4WEhKVEFoOUtFVUdyL3hWRXJTS05aMVJIZWFpcmU2Q2hyR0VLZ3ZOVXc2eDBpCnhmUjQ5V2hnNUlxWmtpWmRnWXpUR2RyZ0NyK2UzR0NoQldWanVQSFMrSm9OYVlDcnc0cngwenRqQ1VHamtma08KWFd0cnZzMkNtVXI1WnBxbVU3cGRWUW1ickUxVnRBQkZqTEgrTDVVVUN4Y3RSZFF1L05LZ3ZFWXBWYkZKY2VWZAoxMEN1UytUQ0FTS1ZlUnVKakU3dzFvaC9VZmRvazMxbkJRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBM0xqRTVOb0k4Y25jdE1tWm1Nalk0T0dFdE5UZGpOUzAwWWpJMExXRTVNamd0WVdWbVpXSmkKTm1Nek1tVmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrYXRod1F6bjgvRU1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUF3aHlqdHJVN2NUZGlLMjdQMnBIb3dyWVhYcnhGNkh4OUp0VERJcjErd1pMSm5kKzVXCm1nSmtSK2hQRWJmTWd6L1ZQVEI5d3hmYnBEa29PVHN1UXhuZDR1d1l3alNwTlBlRFFKdVRSbUdTMEIxbXJSMFAKamRTL202SUQyd2pVS3pTcTNlbWc2OHpYRmZwMlBOUzd4ckprM0g0RXMzYk9TSDFUTm1VemFMaFJRUXZ1VmcweQpFM1F3ZTRsV0hXSFZNc21QWUdvUGZtaGVTRWlEbHBic2FSWk1Gclh1WjBnWU43eFBNa3MzdEZLWll4SFZwcnJHCnA3dUlRbHdZSGxwVU9teWFXTmRkcjUydG5ZdTRBK0laeDdYdzNucDBINndxQ2FrSjdBUEFXM1JTWnB3TkVsMkMKTUl2MjBZTjArc3lLdzkvamNhdHV3eVkzWVhwTW1NaXZSTVZECi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTThENFNmN2ttY1BEb3duK3IvUTdvOEl3Ukt3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnMU1USXpXaGNOTXpNeE1ETXdNVGcxTVRJeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpldCtiRWRWUWMrWDhoOUNXTTVmSDdDRFhKVlpHMDdlK3FsazF3RGlObmpBWHNZV3lpd3V1TG4KeEY0QzlNekFMT3Q4emh6aGZGbHFwUlhYckVMOFlMVktDengyTUt4U2ZVbWE1b2RDbTA4M2Y2M2F1U210VWlvSAp2bkRha240OVM0VU5yWWYraDZLNWNPM2w1c211OG1CUVhmbXhjeU9jQTlOUWx2ZTRZYWhmVnJDcElaZ2tPSTBaCmN0cjQ3M2tEMmNaN3hKMDUzVWZMVTMrbVdUWTc4NlJJcFJvdnRON1lNVnNDSWM2Y3dDS1kvb1RnQ3J1VWExZ1cKdllmRjdHclVQMlVDa1h6OWplSno3Nm92Ujh6MEw4YnBiTDIwWU54cmhZYlhMQUFLd3hnbEtPYlF1VEtkcmE4SwowdWUxWnpXK0FiR2NvKzRUem4yOTkzMTFqN3VFMG44Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0Tm1Vell6QXlNekl0WkRZeFpDMDBNbVJrTFRrNFpqWXRaR0kzTVdGbU1qUmkKTVdKa0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm5jeWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXRYY2JhVkxzNVE3TytmK25XVkIyaTdkU1lPb1NBUXpHS0l0cFZWenpwMTdyem04c1ltQThDCmcwZ2hHZm5SS2pTTVZ2YnlEWVcweGMrNTdPNEp1Rm9SMGI0Y1FYZkNLUFFPT0cwOWFBTXg0U25WRlpIbjZpZU8KRE9xeUwybElpS3hXbWJnWCtRRkVKZlRMTXcvRnVnYXlwclZ4a3dMTm9YNjVURTdlRVRieHBsSHVLckl5dHd3Tgo5bFRkekRNdExwUDFkYnZaOHNlK2NFdHN1elFNbGtjMytnTjdNcU1zaUhEanNLRDlnOE1SQUdwRkdwSDIycVJoCnhMVyttdkVkdWdPMHhrSU9GVjg2VEgwakFkNGJFOGdVcmNlRE10NUs3bzBRcUlsd05BWE80c2piUm1DVS9rWWUKb2tYV28ySjdLYnNiM05NbXQzRVplcUlseU91T2ZnVisKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1847"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:04 GMT
+      - Thu, 02 Nov 2023 18:53:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1335,7 +1103,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee2c99ed-ff90-49f2-9342-7df9858e9c74
+      - fadf38a5-7698-4dc2-b0cf-6a40d620f946
     status: 200 OK
     code: 200
     duration: ""
@@ -1344,21 +1112,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1204"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:04 GMT
+      - Thu, 02 Nov 2023 18:53:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1368,7 +1136,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47bd4ab5-b6e6-4691-8ad7-8febc15fd7a7
+      - 0f1dde11-9d57-49cc-86a0-fb3626d23ba2
     status: 200 OK
     code: 200
     duration: ""
@@ -1377,13 +1145,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.15.208.177/32","port":10010,"protocol":"tcp"},{"action":"allow","description":"IP
-      allowed","direction":"inbound","ip":"51.158.70.246/32","port":10010,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.15.211.1/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"IP
+      allowed","direction":"inbound","ip":"163.172.144.233/32","port":12508,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
       - "271"
@@ -1392,7 +1160,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:04 GMT
+      - Thu, 02 Nov 2023 18:53:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1402,7 +1170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d840f81f-2f70-4862-b5c3-959dcc5039ed
+      - 4ddc9a4c-c2fb-49f0-a57c-d78303b79ce9
     status: 200 OK
     code: 200
     duration: ""
@@ -1411,9 +1179,208 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fc60dd87-2665-43fb-82f7-37416e799532
+    method: GET
+  response:
+    body: '{"ip":{"address":"163.172.144.233","id":"fc60dd87-2665-43fb-82f7-37416e799532","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "308"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 038b0472-aabd-4dce-8e93-35a71867096d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/d3970f1f-ac85-4434-904d-760f78fef8f8
+    method: GET
+  response:
+    body: '{"ip":{"address":"51.15.211.1","id":"d3970f1f-ac85-4434-904d-760f78fef8f8","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "304"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 728dc8bb-2068-42bc-9885-0e122bd284b5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1202"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c972eea8-5d5e-4606-b8f3-68c80a3b92df
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTThENFNmN2ttY1BEb3duK3IvUTdvOEl3Ukt3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnMU1USXpXaGNOTXpNeE1ETXdNVGcxTVRJeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpldCtiRWRWUWMrWDhoOUNXTTVmSDdDRFhKVlpHMDdlK3FsazF3RGlObmpBWHNZV3lpd3V1TG4KeEY0QzlNekFMT3Q4emh6aGZGbHFwUlhYckVMOFlMVktDengyTUt4U2ZVbWE1b2RDbTA4M2Y2M2F1U210VWlvSAp2bkRha240OVM0VU5yWWYraDZLNWNPM2w1c211OG1CUVhmbXhjeU9jQTlOUWx2ZTRZYWhmVnJDcElaZ2tPSTBaCmN0cjQ3M2tEMmNaN3hKMDUzVWZMVTMrbVdUWTc4NlJJcFJvdnRON1lNVnNDSWM2Y3dDS1kvb1RnQ3J1VWExZ1cKdllmRjdHclVQMlVDa1h6OWplSno3Nm92Ujh6MEw4YnBiTDIwWU54cmhZYlhMQUFLd3hnbEtPYlF1VEtkcmE4SwowdWUxWnpXK0FiR2NvKzRUem4yOTkzMTFqN3VFMG44Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0Tm1Vell6QXlNekl0WkRZeFpDMDBNbVJrTFRrNFpqWXRaR0kzTVdGbU1qUmkKTVdKa0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm5jeWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXRYY2JhVkxzNVE3TytmK25XVkIyaTdkU1lPb1NBUXpHS0l0cFZWenpwMTdyem04c1ltQThDCmcwZ2hHZm5SS2pTTVZ2YnlEWVcweGMrNTdPNEp1Rm9SMGI0Y1FYZkNLUFFPT0cwOWFBTXg0U25WRlpIbjZpZU8KRE9xeUwybElpS3hXbWJnWCtRRkVKZlRMTXcvRnVnYXlwclZ4a3dMTm9YNjVURTdlRVRieHBsSHVLckl5dHd3Tgo5bFRkekRNdExwUDFkYnZaOHNlK2NFdHN1elFNbGtjMytnTjdNcU1zaUhEanNLRDlnOE1SQUdwRkdwSDIycVJoCnhMVyttdkVkdWdPMHhrSU9GVjg2VEgwakFkNGJFOGdVcmNlRE10NUs3bzBRcUlsd05BWE80c2piUm1DVS9rWWUKb2tYV28ySjdLYnNiM05NbXQzRVplcUlseU91T2ZnVisKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1843"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9b685e5b-5827-48a8-a240-92254e780cc8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1202"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f2f4df26-d4d9-497d-85a7-68337821db7d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
+    method: GET
+  response:
+    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.15.211.1/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"IP
+      allowed","direction":"inbound","ip":"163.172.144.233/32","port":12508,"protocol":"tcp"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "271"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 942ec956-ba86-4aeb-b239-c39ea5880807
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fc60dd87-2665-43fb-82f7-37416e799532
     method: DELETE
   response:
     body: ""
@@ -1421,7 +1388,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 31 Oct 2023 14:54:05 GMT
+      - Thu, 02 Nov 2023 18:53:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1431,7 +1398,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c007867-ec7e-487e-9ad5-a8a89cd4a7f9
+      - f0a22a20-4ea1-442f-b373-fc6f9e3a510c
     status: 204 No Content
     code: 204
     duration: ""
@@ -1440,9 +1407,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/6fbb59fb-11a0-4a50-abc4-bd81c4547c07
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/d3970f1f-ac85-4434-904d-760f78fef8f8
     method: DELETE
   response:
     body: ""
@@ -1450,7 +1417,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 31 Oct 2023 14:54:05 GMT
+      - Thu, 02 Nov 2023 18:53:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1460,7 +1427,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad5b298f-28b8-439b-a28c-46cf4c42fb44
+      - c88cc12d-7691-4177-9fdb-6ea21ea2f964
     status: 204 No Content
     code: 204
     duration: ""
@@ -1469,21 +1436,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1204"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:05 GMT
+      - Thu, 02 Nov 2023 18:53:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1493,7 +1460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9943e00a-d320-4d53-8ed2-b87e73584703
+      - bd00fd25-a629-4ac3-86c2-348d97189d4d
     status: 200 OK
     code: 200
     duration: ""
@@ -1502,21 +1469,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1204"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:05 GMT
+      - Thu, 02 Nov 2023 18:53:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1526,7 +1493,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6f533c9-6262-405d-a190-c84489d454e4
+      - 8106e1fe-40cc-4189-99cd-915ffaa06b22
     status: 200 OK
     code: 200
     duration: ""
@@ -1537,12 +1504,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
     method: PUT
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":10010,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":10010,"protocol":"tcp"}]}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":12508,"protocol":"tcp"}]}'
     headers:
       Content-Length:
       - "229"
@@ -1551,7 +1518,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:06 GMT
+      - Thu, 02 Nov 2023 18:53:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1561,7 +1528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 938c9220-d30d-4850-b3ec-b9a4fb603144
+      - df7cec48-47fc-475c-b090-f7cd89eb19f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1570,21 +1537,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1210"
+      - "1208"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:06 GMT
+      - Thu, 02 Nov 2023 18:53:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1594,7 +1561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3ea656b-2bf9-4725-874a-745460855096
+      - 040a9029-c6af-4e50-9ec2-adc3bcc958d3
     status: 200 OK
     code: 200
     duration: ""
@@ -1603,21 +1570,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1204"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:36 GMT
+      - Thu, 02 Nov 2023 18:54:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1627,7 +1594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8f451af-a7c0-4ca3-a926-5d17bcff62e5
+      - d018268a-3436-426c-8ef9-58006b21f21c
     status: 200 OK
     code: 200
     duration: ""
@@ -1636,144 +1603,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":10010,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":10010,"protocol":"tcp"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "245"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:54:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1fe026e7-ae91-485b-af25-f7ff0739a653
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1204"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:54:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 13486b0d-c420-4c2c-9d35-ff670e398a89
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVQkFsVmFEMkd0WTA2NWdSdVNheW9peW9KcDd3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UazJNQjRYCkRUSXpNVEF6TVRFME5URXdNbG9YRFRNek1UQXlPREUwTlRFd01sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRrMk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZTaFV5bnRiVnRvVVdOR2d2SDV4SVhrK21DbllLR0hqK0ZoS0czK1MxR0pQVmxOeVBURHkKRFVCVVM4MVE2SkZHMUpjd3BMMll5dGtiUEVyRURZOFBEaS9MTy9zdVZpN0d1MVlzNVFhNlVQNWFvREk2SkYzVgpKV01jczBhRWw3RG1EN011dmd4WEhKVEFoOUtFVUdyL3hWRXJTS05aMVJIZWFpcmU2Q2hyR0VLZ3ZOVXc2eDBpCnhmUjQ5V2hnNUlxWmtpWmRnWXpUR2RyZ0NyK2UzR0NoQldWanVQSFMrSm9OYVlDcnc0cngwenRqQ1VHamtma08KWFd0cnZzMkNtVXI1WnBxbVU3cGRWUW1ickUxVnRBQkZqTEgrTDVVVUN4Y3RSZFF1L05LZ3ZFWXBWYkZKY2VWZAoxMEN1UytUQ0FTS1ZlUnVKakU3dzFvaC9VZmRvazMxbkJRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBM0xqRTVOb0k4Y25jdE1tWm1Nalk0T0dFdE5UZGpOUzAwWWpJMExXRTVNamd0WVdWbVpXSmkKTm1Nek1tVmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrYXRod1F6bjgvRU1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUF3aHlqdHJVN2NUZGlLMjdQMnBIb3dyWVhYcnhGNkh4OUp0VERJcjErd1pMSm5kKzVXCm1nSmtSK2hQRWJmTWd6L1ZQVEI5d3hmYnBEa29PVHN1UXhuZDR1d1l3alNwTlBlRFFKdVRSbUdTMEIxbXJSMFAKamRTL202SUQyd2pVS3pTcTNlbWc2OHpYRmZwMlBOUzd4ckprM0g0RXMzYk9TSDFUTm1VemFMaFJRUXZ1VmcweQpFM1F3ZTRsV0hXSFZNc21QWUdvUGZtaGVTRWlEbHBic2FSWk1Gclh1WjBnWU43eFBNa3MzdEZLWll4SFZwcnJHCnA3dUlRbHdZSGxwVU9teWFXTmRkcjUydG5ZdTRBK0laeDdYdzNucDBINndxQ2FrSjdBUEFXM1JTWnB3TkVsMkMKTUl2MjBZTjArc3lLdzkvamNhdHV3eVkzWVhwTW1NaXZSTVZECi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1847"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:54:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 892a9a3c-98cc-4fd9-964e-3c73f67c7aba
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1204"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:54:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3110f411-209f-4072-bc18-c6d57d165f07
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee/acls
-    method: GET
-  response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":10010,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":10010,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":12508,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
       - "245"
@@ -1782,7 +1617,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:38 GMT
+      - Thu, 02 Nov 2023 18:54:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1792,7 +1627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b48ae573-77ed-42ad-afd9-53f0de0da0cd
+      - 33692369-36b6-46d0-b3d1-cf461a142b20
     status: 200 OK
     code: 200
     duration: ""
@@ -1801,21 +1636,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1204"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:38 GMT
+      - Thu, 02 Nov 2023 18:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1825,7 +1660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1396af0-974f-49bb-a8d2-e4e214ecc007
+      - 6858c37f-5abd-4c2d-92b7-f10f28317acf
     status: 200 OK
     code: 200
     duration: ""
@@ -1834,21 +1669,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVQkFsVmFEMkd0WTA2NWdSdVNheW9peW9KcDd3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UazJNQjRYCkRUSXpNVEF6TVRFME5URXdNbG9YRFRNek1UQXlPREUwTlRFd01sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRrMk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZTaFV5bnRiVnRvVVdOR2d2SDV4SVhrK21DbllLR0hqK0ZoS0czK1MxR0pQVmxOeVBURHkKRFVCVVM4MVE2SkZHMUpjd3BMMll5dGtiUEVyRURZOFBEaS9MTy9zdVZpN0d1MVlzNVFhNlVQNWFvREk2SkYzVgpKV01jczBhRWw3RG1EN011dmd4WEhKVEFoOUtFVUdyL3hWRXJTS05aMVJIZWFpcmU2Q2hyR0VLZ3ZOVXc2eDBpCnhmUjQ5V2hnNUlxWmtpWmRnWXpUR2RyZ0NyK2UzR0NoQldWanVQSFMrSm9OYVlDcnc0cngwenRqQ1VHamtma08KWFd0cnZzMkNtVXI1WnBxbVU3cGRWUW1ickUxVnRBQkZqTEgrTDVVVUN4Y3RSZFF1L05LZ3ZFWXBWYkZKY2VWZAoxMEN1UytUQ0FTS1ZlUnVKakU3dzFvaC9VZmRvazMxbkJRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBM0xqRTVOb0k4Y25jdE1tWm1Nalk0T0dFdE5UZGpOUzAwWWpJMExXRTVNamd0WVdWbVpXSmkKTm1Nek1tVmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrYXRod1F6bjgvRU1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUF3aHlqdHJVN2NUZGlLMjdQMnBIb3dyWVhYcnhGNkh4OUp0VERJcjErd1pMSm5kKzVXCm1nSmtSK2hQRWJmTWd6L1ZQVEI5d3hmYnBEa29PVHN1UXhuZDR1d1l3alNwTlBlRFFKdVRSbUdTMEIxbXJSMFAKamRTL202SUQyd2pVS3pTcTNlbWc2OHpYRmZwMlBOUzd4ckprM0g0RXMzYk9TSDFUTm1VemFMaFJRUXZ1VmcweQpFM1F3ZTRsV0hXSFZNc21QWUdvUGZtaGVTRWlEbHBic2FSWk1Gclh1WjBnWU43eFBNa3MzdEZLWll4SFZwcnJHCnA3dUlRbHdZSGxwVU9teWFXTmRkcjUydG5ZdTRBK0laeDdYdzNucDBINndxQ2FrSjdBUEFXM1JTWnB3TkVsMkMKTUl2MjBZTjArc3lLdzkvamNhdHV3eVkzWVhwTW1NaXZSTVZECi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTThENFNmN2ttY1BEb3duK3IvUTdvOEl3Ukt3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnMU1USXpXaGNOTXpNeE1ETXdNVGcxTVRJeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpldCtiRWRWUWMrWDhoOUNXTTVmSDdDRFhKVlpHMDdlK3FsazF3RGlObmpBWHNZV3lpd3V1TG4KeEY0QzlNekFMT3Q4emh6aGZGbHFwUlhYckVMOFlMVktDengyTUt4U2ZVbWE1b2RDbTA4M2Y2M2F1U210VWlvSAp2bkRha240OVM0VU5yWWYraDZLNWNPM2w1c211OG1CUVhmbXhjeU9jQTlOUWx2ZTRZYWhmVnJDcElaZ2tPSTBaCmN0cjQ3M2tEMmNaN3hKMDUzVWZMVTMrbVdUWTc4NlJJcFJvdnRON1lNVnNDSWM2Y3dDS1kvb1RnQ3J1VWExZ1cKdllmRjdHclVQMlVDa1h6OWplSno3Nm92Ujh6MEw4YnBiTDIwWU54cmhZYlhMQUFLd3hnbEtPYlF1VEtkcmE4SwowdWUxWnpXK0FiR2NvKzRUem4yOTkzMTFqN3VFMG44Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0Tm1Vell6QXlNekl0WkRZeFpDMDBNbVJrTFRrNFpqWXRaR0kzTVdGbU1qUmkKTVdKa0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm5jeWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXRYY2JhVkxzNVE3TytmK25XVkIyaTdkU1lPb1NBUXpHS0l0cFZWenpwMTdyem04c1ltQThDCmcwZ2hHZm5SS2pTTVZ2YnlEWVcweGMrNTdPNEp1Rm9SMGI0Y1FYZkNLUFFPT0cwOWFBTXg0U25WRlpIbjZpZU8KRE9xeUwybElpS3hXbWJnWCtRRkVKZlRMTXcvRnVnYXlwclZ4a3dMTm9YNjVURTdlRVRieHBsSHVLckl5dHd3Tgo5bFRkekRNdExwUDFkYnZaOHNlK2NFdHN1elFNbGtjMytnTjdNcU1zaUhEanNLRDlnOE1SQUdwRkdwSDIycVJoCnhMVyttdkVkdWdPMHhrSU9GVjg2VEgwakFkNGJFOGdVcmNlRE10NUs3bzBRcUlsd05BWE80c2piUm1DVS9rWWUKb2tYV28ySjdLYnNiM05NbXQzRVplcUlseU91T2ZnVisKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1847"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:38 GMT
+      - Thu, 02 Nov 2023 18:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1858,7 +1693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 127d13cf-4894-4928-b220-28bf531b4428
+      - 817695ef-a5aa-489a-a83a-222deca14906
     status: 200 OK
     code: 200
     duration: ""
@@ -1867,21 +1702,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1204"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:39 GMT
+      - Thu, 02 Nov 2023 18:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1891,7 +1726,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 999ac45d-f1d7-46a8-9531-bde9b4f05434
+      - 9ac28beb-37d9-4c17-a167-95a00a8d5269
     status: 200 OK
     code: 200
     duration: ""
@@ -1900,12 +1735,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":10010,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":10010,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":12508,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
       - "245"
@@ -1914,7 +1749,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:39 GMT
+      - Thu, 02 Nov 2023 18:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1924,7 +1759,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5aa38293-b8ef-4025-ba87-15c831b63725
+      - 2e954cfe-3ae6-4d43-bdb5-ecd8c03f8e12
     status: 200 OK
     code: 200
     duration: ""
@@ -1933,21 +1768,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1204"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:39 GMT
+      - Thu, 02 Nov 2023 18:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1957,7 +1792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7faf6086-6233-4c6a-a882-cc6ea481dbb9
+      - ffdad242-5310-486c-9969-b02cce5ff87a
     status: 200 OK
     code: 200
     duration: ""
@@ -1966,21 +1801,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTThENFNmN2ttY1BEb3duK3IvUTdvOEl3Ukt3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnMU1USXpXaGNOTXpNeE1ETXdNVGcxTVRJeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpldCtiRWRWUWMrWDhoOUNXTTVmSDdDRFhKVlpHMDdlK3FsazF3RGlObmpBWHNZV3lpd3V1TG4KeEY0QzlNekFMT3Q4emh6aGZGbHFwUlhYckVMOFlMVktDengyTUt4U2ZVbWE1b2RDbTA4M2Y2M2F1U210VWlvSAp2bkRha240OVM0VU5yWWYraDZLNWNPM2w1c211OG1CUVhmbXhjeU9jQTlOUWx2ZTRZYWhmVnJDcElaZ2tPSTBaCmN0cjQ3M2tEMmNaN3hKMDUzVWZMVTMrbVdUWTc4NlJJcFJvdnRON1lNVnNDSWM2Y3dDS1kvb1RnQ3J1VWExZ1cKdllmRjdHclVQMlVDa1h6OWplSno3Nm92Ujh6MEw4YnBiTDIwWU54cmhZYlhMQUFLd3hnbEtPYlF1VEtkcmE4SwowdWUxWnpXK0FiR2NvKzRUem4yOTkzMTFqN3VFMG44Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0Tm1Vell6QXlNekl0WkRZeFpDMDBNbVJrTFRrNFpqWXRaR0kzTVdGbU1qUmkKTVdKa0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm5jeWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXRYY2JhVkxzNVE3TytmK25XVkIyaTdkU1lPb1NBUXpHS0l0cFZWenpwMTdyem04c1ltQThDCmcwZ2hHZm5SS2pTTVZ2YnlEWVcweGMrNTdPNEp1Rm9SMGI0Y1FYZkNLUFFPT0cwOWFBTXg0U25WRlpIbjZpZU8KRE9xeUwybElpS3hXbWJnWCtRRkVKZlRMTXcvRnVnYXlwclZ4a3dMTm9YNjVURTdlRVRieHBsSHVLckl5dHd3Tgo5bFRkekRNdExwUDFkYnZaOHNlK2NFdHN1elFNbGtjMytnTjdNcU1zaUhEanNLRDlnOE1SQUdwRkdwSDIycVJoCnhMVyttdkVkdWdPMHhrSU9GVjg2VEgwakFkNGJFOGdVcmNlRE10NUs3bzBRcUlsd05BWE80c2piUm1DVS9rWWUKb2tYV28ySjdLYnNiM05NbXQzRVplcUlseU91T2ZnVisKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1204"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:40 GMT
+      - Thu, 02 Nov 2023 18:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1990,7 +1825,139 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a07df36-b368-4918-8dbe-89f9210f12c1
+      - bfbba1af-591f-41fa-8783-b7b852c8e03b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1202"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:54:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bb574219-578d-4df1-9f05-8943cf2cc590
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
+    method: GET
+  response:
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":12508,"protocol":"tcp"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "245"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:54:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b797c581-edc9-4728-ab24-b164aa4de2fc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1202"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:54:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 37cc853b-f393-4593-bb88-b0bb4753c5c0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1202"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:54:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 16c020d7-630f-4fae-9f88-e286c6c83dcb
     status: 200 OK
     code: 200
     duration: ""
@@ -2001,12 +1968,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
     method: PUT
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":10010,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":10010,"protocol":"tcp"}]}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":12508,"protocol":"tcp"}]}'
     headers:
       Content-Length:
       - "229"
@@ -2015,7 +1982,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:40 GMT
+      - Thu, 02 Nov 2023 18:54:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2025,7 +1992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eee7e5e2-316a-4698-8d95-f1640aeea5f1
+      - d2109977-ce44-406e-aa4b-a582c82236a9
     status: 200 OK
     code: 200
     duration: ""
@@ -2034,21 +2001,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1210"
+      - "1208"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:54:40 GMT
+      - Thu, 02 Nov 2023 18:54:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2058,7 +2025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db149c4f-1c91-487a-9225-8a442489fd88
+      - 0c490da5-0794-458e-9b2d-5ae646830584
     status: 200 OK
     code: 200
     duration: ""
@@ -2067,21 +2034,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1204"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:55:10 GMT
+      - Thu, 02 Nov 2023 18:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2091,7 +2058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c2f079f-53c8-4713-8e67-1ef4895735d5
+      - 04209fa0-36c3-431e-bbb8-aa80f6d7e2cf
     status: 200 OK
     code: 200
     duration: ""
@@ -2100,144 +2067,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":10010,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":10010,"protocol":"tcp"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "245"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:55:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 77967bea-bd9f-44f3-98a1-6aaa6df565cb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1204"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:55:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3f6161e8-3922-4817-bef0-ebcf69af7e5c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVQkFsVmFEMkd0WTA2NWdSdVNheW9peW9KcDd3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UazJNQjRYCkRUSXpNVEF6TVRFME5URXdNbG9YRFRNek1UQXlPREUwTlRFd01sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRrMk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZTaFV5bnRiVnRvVVdOR2d2SDV4SVhrK21DbllLR0hqK0ZoS0czK1MxR0pQVmxOeVBURHkKRFVCVVM4MVE2SkZHMUpjd3BMMll5dGtiUEVyRURZOFBEaS9MTy9zdVZpN0d1MVlzNVFhNlVQNWFvREk2SkYzVgpKV01jczBhRWw3RG1EN011dmd4WEhKVEFoOUtFVUdyL3hWRXJTS05aMVJIZWFpcmU2Q2hyR0VLZ3ZOVXc2eDBpCnhmUjQ5V2hnNUlxWmtpWmRnWXpUR2RyZ0NyK2UzR0NoQldWanVQSFMrSm9OYVlDcnc0cngwenRqQ1VHamtma08KWFd0cnZzMkNtVXI1WnBxbVU3cGRWUW1ickUxVnRBQkZqTEgrTDVVVUN4Y3RSZFF1L05LZ3ZFWXBWYkZKY2VWZAoxMEN1UytUQ0FTS1ZlUnVKakU3dzFvaC9VZmRvazMxbkJRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBM0xqRTVOb0k4Y25jdE1tWm1Nalk0T0dFdE5UZGpOUzAwWWpJMExXRTVNamd0WVdWbVpXSmkKTm1Nek1tVmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrYXRod1F6bjgvRU1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUF3aHlqdHJVN2NUZGlLMjdQMnBIb3dyWVhYcnhGNkh4OUp0VERJcjErd1pMSm5kKzVXCm1nSmtSK2hQRWJmTWd6L1ZQVEI5d3hmYnBEa29PVHN1UXhuZDR1d1l3alNwTlBlRFFKdVRSbUdTMEIxbXJSMFAKamRTL202SUQyd2pVS3pTcTNlbWc2OHpYRmZwMlBOUzd4ckprM0g0RXMzYk9TSDFUTm1VemFMaFJRUXZ1VmcweQpFM1F3ZTRsV0hXSFZNc21QWUdvUGZtaGVTRWlEbHBic2FSWk1Gclh1WjBnWU43eFBNa3MzdEZLWll4SFZwcnJHCnA3dUlRbHdZSGxwVU9teWFXTmRkcjUydG5ZdTRBK0laeDdYdzNucDBINndxQ2FrSjdBUEFXM1JTWnB3TkVsMkMKTUl2MjBZTjArc3lLdzkvamNhdHV3eVkzWVhwTW1NaXZSTVZECi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1847"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:55:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 447f9071-8e74-4f8c-a7fb-3d3907c7ea9f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1204"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:55:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f3d1f654-1e8b-43f8-9093-238a2b0de6f2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee/acls
-    method: GET
-  response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":10010,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":10010,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":12508,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
       - "245"
@@ -2246,7 +2081,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:55:12 GMT
+      - Thu, 02 Nov 2023 18:54:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2256,7 +2091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f0596dc-9b9e-408b-99e8-42fb18fe24aa
+      - 71dffb83-dff1-44bf-8522-23e1414b4bc1
     status: 200 OK
     code: 200
     duration: ""
@@ -2265,21 +2100,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1204"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:55:12 GMT
+      - Thu, 02 Nov 2023 18:55:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2289,7 +2124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82069b4e-5539-48e4-9cb0-3c3ef198c874
+      - ad9be827-b97f-4339-b7f3-56c6b64f8198
     status: 200 OK
     code: 200
     duration: ""
@@ -2298,21 +2133,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTThENFNmN2ttY1BEb3duK3IvUTdvOEl3Ukt3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnMU1USXpXaGNOTXpNeE1ETXdNVGcxTVRJeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpldCtiRWRWUWMrWDhoOUNXTTVmSDdDRFhKVlpHMDdlK3FsazF3RGlObmpBWHNZV3lpd3V1TG4KeEY0QzlNekFMT3Q4emh6aGZGbHFwUlhYckVMOFlMVktDengyTUt4U2ZVbWE1b2RDbTA4M2Y2M2F1U210VWlvSAp2bkRha240OVM0VU5yWWYraDZLNWNPM2w1c211OG1CUVhmbXhjeU9jQTlOUWx2ZTRZYWhmVnJDcElaZ2tPSTBaCmN0cjQ3M2tEMmNaN3hKMDUzVWZMVTMrbVdUWTc4NlJJcFJvdnRON1lNVnNDSWM2Y3dDS1kvb1RnQ3J1VWExZ1cKdllmRjdHclVQMlVDa1h6OWplSno3Nm92Ujh6MEw4YnBiTDIwWU54cmhZYlhMQUFLd3hnbEtPYlF1VEtkcmE4SwowdWUxWnpXK0FiR2NvKzRUem4yOTkzMTFqN3VFMG44Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0Tm1Vell6QXlNekl0WkRZeFpDMDBNbVJrTFRrNFpqWXRaR0kzTVdGbU1qUmkKTVdKa0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm5jeWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXRYY2JhVkxzNVE3TytmK25XVkIyaTdkU1lPb1NBUXpHS0l0cFZWenpwMTdyem04c1ltQThDCmcwZ2hHZm5SS2pTTVZ2YnlEWVcweGMrNTdPNEp1Rm9SMGI0Y1FYZkNLUFFPT0cwOWFBTXg0U25WRlpIbjZpZU8KRE9xeUwybElpS3hXbWJnWCtRRkVKZlRMTXcvRnVnYXlwclZ4a3dMTm9YNjVURTdlRVRieHBsSHVLckl5dHd3Tgo5bFRkekRNdExwUDFkYnZaOHNlK2NFdHN1elFNbGtjMytnTjdNcU1zaUhEanNLRDlnOE1SQUdwRkdwSDIycVJoCnhMVyttdkVkdWdPMHhrSU9GVjg2VEgwakFkNGJFOGdVcmNlRE10NUs3bzBRcUlsd05BWE80c2piUm1DVS9rWWUKb2tYV28ySjdLYnNiM05NbXQzRVplcUlseU91T2ZnVisKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1204"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:55:12 GMT
+      - Thu, 02 Nov 2023 18:55:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2322,7 +2157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b7ae189-1921-427b-b247-f8a4803a395e
+      - 3d873090-4a91-4ff3-9f71-3735acc0825e
     status: 200 OK
     code: 200
     duration: ""
@@ -2331,21 +2166,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVQkFsVmFEMkd0WTA2NWdSdVNheW9peW9KcDd3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UazJNQjRYCkRUSXpNVEF6TVRFME5URXdNbG9YRFRNek1UQXlPREUwTlRFd01sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRrMk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZTaFV5bnRiVnRvVVdOR2d2SDV4SVhrK21DbllLR0hqK0ZoS0czK1MxR0pQVmxOeVBURHkKRFVCVVM4MVE2SkZHMUpjd3BMMll5dGtiUEVyRURZOFBEaS9MTy9zdVZpN0d1MVlzNVFhNlVQNWFvREk2SkYzVgpKV01jczBhRWw3RG1EN011dmd4WEhKVEFoOUtFVUdyL3hWRXJTS05aMVJIZWFpcmU2Q2hyR0VLZ3ZOVXc2eDBpCnhmUjQ5V2hnNUlxWmtpWmRnWXpUR2RyZ0NyK2UzR0NoQldWanVQSFMrSm9OYVlDcnc0cngwenRqQ1VHamtma08KWFd0cnZzMkNtVXI1WnBxbVU3cGRWUW1ickUxVnRBQkZqTEgrTDVVVUN4Y3RSZFF1L05LZ3ZFWXBWYkZKY2VWZAoxMEN1UytUQ0FTS1ZlUnVKakU3dzFvaC9VZmRvazMxbkJRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBM0xqRTVOb0k4Y25jdE1tWm1Nalk0T0dFdE5UZGpOUzAwWWpJMExXRTVNamd0WVdWbVpXSmkKTm1Nek1tVmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrYXRod1F6bjgvRU1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUF3aHlqdHJVN2NUZGlLMjdQMnBIb3dyWVhYcnhGNkh4OUp0VERJcjErd1pMSm5kKzVXCm1nSmtSK2hQRWJmTWd6L1ZQVEI5d3hmYnBEa29PVHN1UXhuZDR1d1l3alNwTlBlRFFKdVRSbUdTMEIxbXJSMFAKamRTL202SUQyd2pVS3pTcTNlbWc2OHpYRmZwMlBOUzd4ckprM0g0RXMzYk9TSDFUTm1VemFMaFJRUXZ1VmcweQpFM1F3ZTRsV0hXSFZNc21QWUdvUGZtaGVTRWlEbHBic2FSWk1Gclh1WjBnWU43eFBNa3MzdEZLWll4SFZwcnJHCnA3dUlRbHdZSGxwVU9teWFXTmRkcjUydG5ZdTRBK0laeDdYdzNucDBINndxQ2FrSjdBUEFXM1JTWnB3TkVsMkMKTUl2MjBZTjArc3lLdzkvamNhdHV3eVkzWVhwTW1NaXZSTVZECi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1847"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:55:13 GMT
+      - Thu, 02 Nov 2023 18:55:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2355,7 +2190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af26b969-8342-4740-9969-62e29250d3d3
+      - 17de0ad6-044d-4749-9ecd-2c66c902e60c
     status: 200 OK
     code: 200
     duration: ""
@@ -2364,12 +2199,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":10010,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":10010,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":12508,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
       - "245"
@@ -2378,7 +2213,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:55:13 GMT
+      - Thu, 02 Nov 2023 18:55:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2388,7 +2223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00f27e5a-444c-427b-a8e1-9157e1224936
+      - ad69da7c-2122-483e-ba0c-c99e52fdd668
     status: 200 OK
     code: 200
     duration: ""
@@ -2397,21 +2232,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1204"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:55:13 GMT
+      - Thu, 02 Nov 2023 18:55:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2421,7 +2256,139 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e583609-5fd3-4468-9d7e-2b22693e1fbc
+      - df17901c-c569-43f9-a946-5d27c1bd199d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1202"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:55:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5a17fd04-903e-46d8-b2da-64871f9b9e1c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTThENFNmN2ttY1BEb3duK3IvUTdvOEl3Ukt3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnMU1USXpXaGNOTXpNeE1ETXdNVGcxTVRJeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpldCtiRWRWUWMrWDhoOUNXTTVmSDdDRFhKVlpHMDdlK3FsazF3RGlObmpBWHNZV3lpd3V1TG4KeEY0QzlNekFMT3Q4emh6aGZGbHFwUlhYckVMOFlMVktDengyTUt4U2ZVbWE1b2RDbTA4M2Y2M2F1U210VWlvSAp2bkRha240OVM0VU5yWWYraDZLNWNPM2w1c211OG1CUVhmbXhjeU9jQTlOUWx2ZTRZYWhmVnJDcElaZ2tPSTBaCmN0cjQ3M2tEMmNaN3hKMDUzVWZMVTMrbVdUWTc4NlJJcFJvdnRON1lNVnNDSWM2Y3dDS1kvb1RnQ3J1VWExZ1cKdllmRjdHclVQMlVDa1h6OWplSno3Nm92Ujh6MEw4YnBiTDIwWU54cmhZYlhMQUFLd3hnbEtPYlF1VEtkcmE4SwowdWUxWnpXK0FiR2NvKzRUem4yOTkzMTFqN3VFMG44Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0Tm1Vell6QXlNekl0WkRZeFpDMDBNbVJrTFRrNFpqWXRaR0kzTVdGbU1qUmkKTVdKa0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm5jeWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXRYY2JhVkxzNVE3TytmK25XVkIyaTdkU1lPb1NBUXpHS0l0cFZWenpwMTdyem04c1ltQThDCmcwZ2hHZm5SS2pTTVZ2YnlEWVcweGMrNTdPNEp1Rm9SMGI0Y1FYZkNLUFFPT0cwOWFBTXg0U25WRlpIbjZpZU8KRE9xeUwybElpS3hXbWJnWCtRRkVKZlRMTXcvRnVnYXlwclZ4a3dMTm9YNjVURTdlRVRieHBsSHVLckl5dHd3Tgo5bFRkekRNdExwUDFkYnZaOHNlK2NFdHN1elFNbGtjMytnTjdNcU1zaUhEanNLRDlnOE1SQUdwRkdwSDIycVJoCnhMVyttdkVkdWdPMHhrSU9GVjg2VEgwakFkNGJFOGdVcmNlRE10NUs3bzBRcUlsd05BWE80c2piUm1DVS9rWWUKb2tYV28ySjdLYnNiM05NbXQzRVplcUlseU91T2ZnVisKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1843"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:55:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b7c53e0f-6c41-48dd-af47-0ba5ae5e203c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
+    method: GET
+  response:
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":12508,"protocol":"tcp"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "245"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:55:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 042e679d-d610-4865-bfa6-f00785f3dbd5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1202"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:55:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 609462ae-402f-4716-9776-614d54ba33ba
     status: 200 OK
     code: 200
     duration: ""
@@ -2432,12 +2399,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
     method: DELETE
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":10010,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":10010,"protocol":"tcp"}]}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":12508,"protocol":"tcp"}]}'
     headers:
       Content-Length:
       - "229"
@@ -2446,7 +2413,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:55:13 GMT
+      - Thu, 02 Nov 2023 18:55:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2456,7 +2423,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 603175d2-d684-419b-b8c2-b7e18bfc1ab3
+      - e5f25734-e6e8-4bdd-a3d6-c32bdaf81635
     status: 200 OK
     code: 200
     duration: ""
@@ -2465,21 +2432,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1210"
+      - "1208"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:55:14 GMT
+      - Thu, 02 Nov 2023 18:55:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2489,7 +2456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aece91af-453e-4d3a-b5a4-8a0441bbc0e3
+      - 81fa4ef3-7de9-49e2-8820-d0ec33441801
     status: 200 OK
     code: 200
     duration: ""
@@ -2498,21 +2465,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1204"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:55:44 GMT
+      - Thu, 02 Nov 2023 18:55:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2522,7 +2489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 320842e4-3f90-4d34-835f-218f73e82409
+      - 9a106911-bd95-48e5-97cf-a24bee019f6c
     status: 200 OK
     code: 200
     duration: ""
@@ -2531,21 +2498,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1204"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:55:45 GMT
+      - Thu, 02 Nov 2023 18:55:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2555,7 +2522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9caf5416-d614-4e14-bdf7-b9a927abed7d
+      - 725f1001-5113-406c-ba0c-ad1136cde138
     status: 200 OK
     code: 200
     duration: ""
@@ -2564,21 +2531,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVQkFsVmFEMkd0WTA2NWdSdVNheW9peW9KcDd3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UazJNQjRYCkRUSXpNVEF6TVRFME5URXdNbG9YRFRNek1UQXlPREUwTlRFd01sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRrMk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZTaFV5bnRiVnRvVVdOR2d2SDV4SVhrK21DbllLR0hqK0ZoS0czK1MxR0pQVmxOeVBURHkKRFVCVVM4MVE2SkZHMUpjd3BMMll5dGtiUEVyRURZOFBEaS9MTy9zdVZpN0d1MVlzNVFhNlVQNWFvREk2SkYzVgpKV01jczBhRWw3RG1EN011dmd4WEhKVEFoOUtFVUdyL3hWRXJTS05aMVJIZWFpcmU2Q2hyR0VLZ3ZOVXc2eDBpCnhmUjQ5V2hnNUlxWmtpWmRnWXpUR2RyZ0NyK2UzR0NoQldWanVQSFMrSm9OYVlDcnc0cngwenRqQ1VHamtma08KWFd0cnZzMkNtVXI1WnBxbVU3cGRWUW1ickUxVnRBQkZqTEgrTDVVVUN4Y3RSZFF1L05LZ3ZFWXBWYkZKY2VWZAoxMEN1UytUQ0FTS1ZlUnVKakU3dzFvaC9VZmRvazMxbkJRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBM0xqRTVOb0k4Y25jdE1tWm1Nalk0T0dFdE5UZGpOUzAwWWpJMExXRTVNamd0WVdWbVpXSmkKTm1Nek1tVmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrYXRod1F6bjgvRU1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUF3aHlqdHJVN2NUZGlLMjdQMnBIb3dyWVhYcnhGNkh4OUp0VERJcjErd1pMSm5kKzVXCm1nSmtSK2hQRWJmTWd6L1ZQVEI5d3hmYnBEa29PVHN1UXhuZDR1d1l3alNwTlBlRFFKdVRSbUdTMEIxbXJSMFAKamRTL202SUQyd2pVS3pTcTNlbWc2OHpYRmZwMlBOUzd4ckprM0g0RXMzYk9TSDFUTm1VemFMaFJRUXZ1VmcweQpFM1F3ZTRsV0hXSFZNc21QWUdvUGZtaGVTRWlEbHBic2FSWk1Gclh1WjBnWU43eFBNa3MzdEZLWll4SFZwcnJHCnA3dUlRbHdZSGxwVU9teWFXTmRkcjUydG5ZdTRBK0laeDdYdzNucDBINndxQ2FrSjdBUEFXM1JTWnB3TkVsMkMKTUl2MjBZTjArc3lLdzkvamNhdHV3eVkzWVhwTW1NaXZSTVZECi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTThENFNmN2ttY1BEb3duK3IvUTdvOEl3Ukt3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnMU1USXpXaGNOTXpNeE1ETXdNVGcxTVRJeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpldCtiRWRWUWMrWDhoOUNXTTVmSDdDRFhKVlpHMDdlK3FsazF3RGlObmpBWHNZV3lpd3V1TG4KeEY0QzlNekFMT3Q4emh6aGZGbHFwUlhYckVMOFlMVktDengyTUt4U2ZVbWE1b2RDbTA4M2Y2M2F1U210VWlvSAp2bkRha240OVM0VU5yWWYraDZLNWNPM2w1c211OG1CUVhmbXhjeU9jQTlOUWx2ZTRZYWhmVnJDcElaZ2tPSTBaCmN0cjQ3M2tEMmNaN3hKMDUzVWZMVTMrbVdUWTc4NlJJcFJvdnRON1lNVnNDSWM2Y3dDS1kvb1RnQ3J1VWExZ1cKdllmRjdHclVQMlVDa1h6OWplSno3Nm92Ujh6MEw4YnBiTDIwWU54cmhZYlhMQUFLd3hnbEtPYlF1VEtkcmE4SwowdWUxWnpXK0FiR2NvKzRUem4yOTkzMTFqN3VFMG44Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0Tm1Vell6QXlNekl0WkRZeFpDMDBNbVJrTFRrNFpqWXRaR0kzTVdGbU1qUmkKTVdKa0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm5jeWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXRYY2JhVkxzNVE3TytmK25XVkIyaTdkU1lPb1NBUXpHS0l0cFZWenpwMTdyem04c1ltQThDCmcwZ2hHZm5SS2pTTVZ2YnlEWVcweGMrNTdPNEp1Rm9SMGI0Y1FYZkNLUFFPT0cwOWFBTXg0U25WRlpIbjZpZU8KRE9xeUwybElpS3hXbWJnWCtRRkVKZlRMTXcvRnVnYXlwclZ4a3dMTm9YNjVURTdlRVRieHBsSHVLckl5dHd3Tgo5bFRkekRNdExwUDFkYnZaOHNlK2NFdHN1elFNbGtjMytnTjdNcU1zaUhEanNLRDlnOE1SQUdwRkdwSDIycVJoCnhMVyttdkVkdWdPMHhrSU9GVjg2VEgwakFkNGJFOGdVcmNlRE10NUs3bzBRcUlsd05BWE80c2piUm1DVS9rWWUKb2tYV28ySjdLYnNiM05NbXQzRVplcUlseU91T2ZnVisKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1847"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:55:45 GMT
+      - Thu, 02 Nov 2023 18:55:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2588,7 +2555,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4cc1436d-f3b2-41dd-8564-910f7e5bb7aa
+      - 2d1ab7db-2e38-43c1-ab14-8892cdc4336c
     status: 200 OK
     code: 200
     duration: ""
@@ -2597,21 +2564,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1204"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:55:48 GMT
+      - Thu, 02 Nov 2023 18:55:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2621,7 +2588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6481dab0-c509-4a90-bb4c-d60cd9b55d29
+      - 8ba66f74-49dc-4580-82cb-f983861ad752
     status: 200 OK
     code: 200
     duration: ""
@@ -2630,21 +2597,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1207"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:55:49 GMT
+      - Thu, 02 Nov 2023 18:55:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2654,7 +2621,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59e5285f-1355-400a-82c9-5f24c9f04be5
+      - 704b73f2-b308-41df-be02-c3153166d801
     status: 200 OK
     code: 200
     duration: ""
@@ -2663,21 +2630,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-01T14:50:23.690240Z","retention":7},"created_at":"2023-10-31T14:50:23.690240Z","endpoint":{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010},"endpoints":[{"id":"d56e65a0-db67-4823-a625-ab99eccac8a9","ip":"51.159.207.196","load_balancer":{},"name":null,"port":10010}],"engine":"PostgreSQL-15","id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1207"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:55:50 GMT
+      - Thu, 02 Nov 2023 18:55:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2687,7 +2654,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76a40a0c-8abc-4438-989b-4b314d611964
+      - 27c53568-94ce-4073-bd57-5d67dcc95780
     status: 200 OK
     code: 200
     duration: ""
@@ -2696,12 +2663,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2710,7 +2677,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:56:20 GMT
+      - Thu, 02 Nov 2023 18:56:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2720,7 +2687,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a49bd04-eb1c-4d4e-90a6-a8fdb18a2d38
+      - 4c44be64-dcfe-45c7-a566-b4b2edaf4c9c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2729,12 +2696,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2ff2688a-57c5-4b24-a928-aefebb6c32ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"2ff2688a-57c5-4b24-a928-aefebb6c32ee","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2743,7 +2710,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:56:20 GMT
+      - Thu, 02 Nov 2023 18:56:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2753,7 +2720,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58d69c8f-d9e9-4b1b-93a5-29bda5ecd773
+      - ce2d2e90-3d80-4320-a5d6-a08d5b52e6a5
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-database-backup-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-database-backup-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:04 GMT
+      - Thu, 02 Nov 2023 18:46:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f373811b-8e7b-45e0-b4d0-9376cfe0701a
+      - a87f3d98-da0c-455d-9404-f78489c92383
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayRdbDatabaseBackup_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayRdbDatabaseBackup_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:54:51.238886Z","retention":7},"created_at":"2023-10-20T15:54:51.238886Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "781"
+      - "754"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:51 GMT
+      - Thu, 02 Nov 2023 18:46:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5653308-967c-4a98-a0ca-7200659b2313
+      - 9cc70ab5-4fc1-4664-80af-df41967492f1
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:54:51.238886Z","retention":7},"created_at":"2023-10-20T15:54:51.238886Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "781"
+      - "754"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:53 GMT
+      - Thu, 02 Nov 2023 18:46:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eae84313-5f82-4737-b3ed-8459660dcf3e
+      - 49fdc126-8f31-499d-b622-bfc943c3545d
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:54:51.238886Z","retention":7},"created_at":"2023-10-20T15:54:51.238886Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "781"
+      - "754"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:23 GMT
+      - Thu, 02 Nov 2023 18:47:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ab3582b-12d2-4f59-814a-f114a887258a
+      - 00f35f06-c2c8-4128-b523-3d8d5bc1e76c
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:54:51.238886Z","retention":7},"created_at":"2023-10-20T15:54:51.238886Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "781"
+      - "754"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:53 GMT
+      - Thu, 02 Nov 2023 18:47:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de9a040d-3c84-474d-a2c4-9a6d20129a97
+      - 398e3321-1f01-4517-afb2-070c69f6449f
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:54:51.238886Z","retention":7},"created_at":"2023-10-20T15:54:51.238886Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "781"
+      - "754"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:56:23 GMT
+      - Thu, 02 Nov 2023 18:48:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06339365-7847-42c4-8e32-63c1d50e9a7a
+      - f816d2a3-96e6-4ac5-8753-2c8c1eb8c30a
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:54:51.238886Z","retention":7},"created_at":"2023-10-20T15:54:51.238886Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "781"
+      - "754"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:56:53 GMT
+      - Thu, 02 Nov 2023 18:48:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9729b2e2-1e48-4f2f-ad02-0e2e498ebb44
+      - b8b44685-5a8d-454b-a408-33494075f141
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:54:51.238886Z","retention":7},"created_at":"2023-10-20T15:54:51.238886Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "781"
+      - "754"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:24 GMT
+      - Thu, 02 Nov 2023 18:49:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62a68b4d-2e10-47ac-aa8e-0e1fb18593cd
+      - b84442be-83ac-484b-8719-e0d1b7c20f00
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:54:51.238886Z","retention":7},"created_at":"2023-10-20T15:54:51.238886Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "781"
+      - "1227"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:54 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,45 +594,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f672fd8e-6bc1-4bcc-9422-a3078519364a
+      - 15b305c7-24dd-4b7f-b9d2-e99a8f1d7aab
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:54:51.238886Z","retention":7},"created_at":"2023-10-20T15:54:51.238886Z","endpoint":{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188},"endpoints":[{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188}],"engine":"PostgreSQL-15","id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1267"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3e2ff53a-18d6-497a-8a3a-34bc958c0982
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"backup_schedule_frequency":null,"backup_schedule_retention":null,"is_backup_schedule_disabled":false,"name":null,"tags":null,"logs_policy":null,"backup_same_region":false,"backup_schedule_start_hour":null}'
+    body: '{"is_backup_schedule_disabled":false,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -640,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:54:51.238886Z","retention":7},"created_at":"2023-10-20T15:54:51.238886Z","endpoint":{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188},"endpoints":[{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188}],"engine":"PostgreSQL-15","id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1267"
+      - "1227"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:24 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52e66eb4-df80-45e0-b45d-dbc91ef0aca5
+      - 8690db69-af50-4b82-9990-bb717f2066b6
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:54:51.238886Z","retention":7},"created_at":"2023-10-20T15:54:51.238886Z","endpoint":{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188},"endpoints":[{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188}],"engine":"PostgreSQL-15","id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1267"
+      - "1227"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:24 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eeaf5e03-baaa-47d0-aa7b-4365e7a65810
+      - d689901f-069a-46c0-be8f-8e9d1b5ca341
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVV3labXFGeHVKV09UU0Zjdm1oTng2b3hGNWVRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRVek5sb1hEVE16TVRBeE56RTFOVFV6Tmxvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFzbEZzeXRLaXZqTXVYR0tWZHRxUlM0OFpGemUwTDRzMzN2ajVUcFUyRUJFVUZXbXdHbWliL1lwc1EvdEQKYXp1d3U2OVVqcHpWOFhzbUt0RlBHYko5UVgzbFRPbHAxVmNPRGVucmxIbzVZS2ZiY2UrY0lvdmF0N1ZDK2FRSwpSSkxUUkx1alBnTGhVUi9WMTJ4NmRocmFmeXVMV21zL0dRaTZzU05RSktyVkUzV3pXNzI4YzM1UGtXVHZpdWhxCktEaG9JYnlDOTVvWHF0YmVDakp3VmtzckZDMlZoUGY4eVloaHZBTGZFS3EweFFyNEE5dnRMUXl6QnE1aVJTcEUKSjU4NVA5QjZENHFUYVBoTkxtdlhyOG42aDgvam43YlBwT0VjUlNYRHlWbm4yOFRuNVIwZVoyalRYd1NyQlFlaApoWmM1RkFYK3lKU2xrcDNOUGlIdy9nT245d0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdE4yRmpZamczWWpZdE16RXhNUzAwWVRWbUxXRTVOVE10TmpFMll6TmxOVFUwWTJabExuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJKOHZod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUFmQXE2bFNta1BGWEJ2dVcvSVNQUkIvNkRvSklRWmtvWjFxM0R1cm81Z0JocDN2Y2NIaGUwd0xqenpuaCs3CjM5aWVxWURld2RQTEpFdkNIMUpBNi9ZU2E3WUFqSDZ6d1JiZ1lZcmRUeG12RnFjU09WeWlzQW90NU42V3hNME4KdzNzc3pWMnhjNktDeGQ1MHNLallrdEtvNjhDYkFoZGhwMUx3YUhsbDJtOFNKeUVUSzlPZldyb0lIVjFuVThocwpRZFBDTmdtay9OUU16OUU0OWp6WnlhcEpJWXIyQmlEendQejI4SkVMMzRabjFWSkZKd0xwQVl3N0ExK281K3hYCko3cThoalZjV1FuVTNmVWt6S1N3WGtPYUtEVHUyNmJpektFOFBRRG5qVS9xT2xudVNZaitSUlBEdlRjNittWE8KWU9Jc1RiSWhYRWlOY1YvM2ZiTkJhVFBuCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUXo1eXBPU3ZyNUwyU0ZKWkxLaFlaV2U2QWxRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56TXdXaGNOTXpNeE1ETXdNVGcwTnpNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxTbDAwWTVrVGlyQTBsdGIzU3pUQ2NNZEgvMWJFd29VdmM4cmRxdXU5UUhERlQxQXNEOEZmU1UKQmprSzdnRXBjU0RMcXcvT00ySGtKVUVrYUhWQ3EvRi9DeXNPY2doQjhYMkRkNGZ6V3VwWmUxclBORHVIdDI1WQpkL0FHMmRLSFdTRW8xd2RwY3NaTnY2T2NZMUhwNHRUM0x0UklleStXeDBCUzRjWlBIZWFML3IzRnZ4WUdlUHZJClUzNTc4L1NSdWRaZ1NBM2ZqUjJLS3B1LzlrcitzRERrdkJ4MG5ReGdSVEdWUS9yaVVPQmZxSld4dms5MnlPYUMKZlFNVWFFV0Z6c2FiTmFzbzZGY2ZWbEUrNTZJQ0tHZ1lzUDdJYldWcFFJQy9lUWFaY1N5WUxoVkVCRnV1bnlyLwpkWHJqM3NQbGhlTnFpNWtMMTZlb2ZPeGY1YngvUHVVQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WldaaFpEUm1PRFF0WmpReFlTMDBNelV5TFRrd05tSXROR1UyTldVeVptUXgKTmpNeUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQVFEbGM2eEhFNzdsbmU0SEpkSVY1TmsreXVLZG9ldVRvbXozZVVwMnA0eWlBNDJ0dGcyN0JxCkN0QldEMnJqN1BCVEQ3bnJueWdubDVuYXBuU0hhNjFjT3MxSGI5MWRzYnM0aU1rTHAzZ1A0SDZiendQaWZGNVAKeWRjT0xoVCtSbzd6aUpuTEx5ckVNNUw2cFV3ZlI2TGRVMTYyRmUvK1RVREJ1b3QrRHZmS0w4dVgwZXJQTkhmWApibms2dlFLcHNDdGlqT0lwTGhNekxENEk2aERiRDNOZXhFVHBJMHVBVmV3dm9IdUN0M3lXZE5OaHZleFJoTDdiCk1xWTBmVHQwcXorVHRBUnFqYnlHbUVqemFVRHFwb1NoMnl6ajdvVC80bUJrb0dSQ0ZIMjE4ZXhVYmNCUkhBZ2EKbEdadGcwYW1EdjhONEpSUVhJQVMvNlBobExNbWdEQmIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:24 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16bd95fe-4bad-4d06-b544-03b3a9b2e0c0
+      - eacef93f-c99e-45f5-8e73-7262924541f9
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:54:51.238886Z","retention":7},"created_at":"2023-10-20T15:54:51.238886Z","endpoint":{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188},"endpoints":[{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188}],"engine":"PostgreSQL-15","id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1267"
+      - "1227"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:25 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88223f2c-8dfd-425d-b1f6-83bb8a1fdce3
+      - 9bd9d04a-fee4-42b5-8592-16f0b533fdcc
     status: 200 OK
     code: 200
     duration: ""
@@ -774,19 +741,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/databases
     method: POST
   response:
     body: '{"managed":true,"name":"foo","owner":"","size":0}'
     headers:
       Content-Length:
-      - "52"
+      - "49"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:25 GMT
+      - Thu, 02 Nov 2023 18:49:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +763,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1de6b86-782d-4ed7-9b51-578c66f799ab
+      - 9a76399e-3329-4295-850c-4258ce536c79
     status: 200 OK
     code: 200
     duration: ""
@@ -807,19 +774,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:54:51.238886Z","retention":7},"created_at":"2023-10-20T15:54:51.238886Z","endpoint":{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188},"endpoints":[{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188}],"engine":"PostgreSQL-15","id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1267"
+      - "1227"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:25 GMT
+      - Thu, 02 Nov 2023 18:49:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e302a27-121b-4818-985a-da1f5531d1e8
+      - d988888b-1cc7-4e9d-87f9-85a6ccb441fd
     status: 200 OK
     code: 200
     duration: ""
@@ -840,52 +807,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe/databases?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "106"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 01e9661d-40f6-4011-b5ba-66076d74c27a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:25 GMT
+      - Thu, 02 Nov 2023 18:49:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 114836af-aaa5-4fa1-84a6-08ec52c7d52d
+      - 2000c061-44d7-4438-962f-aebce5674c84
     status: 200 OK
     code: 200
     duration: ""
@@ -906,85 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:54:51.238886Z","retention":7},"created_at":"2023-10-20T15:54:51.238886Z","endpoint":{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188},"endpoints":[{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188}],"engine":"PostgreSQL-15","id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1267"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - adb85b0d-d380-48cd-b84d-1ad171a5b0bf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVV3labXFGeHVKV09UU0Zjdm1oTng2b3hGNWVRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRVek5sb1hEVE16TVRBeE56RTFOVFV6Tmxvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFzbEZzeXRLaXZqTXVYR0tWZHRxUlM0OFpGemUwTDRzMzN2ajVUcFUyRUJFVUZXbXdHbWliL1lwc1EvdEQKYXp1d3U2OVVqcHpWOFhzbUt0RlBHYko5UVgzbFRPbHAxVmNPRGVucmxIbzVZS2ZiY2UrY0lvdmF0N1ZDK2FRSwpSSkxUUkx1alBnTGhVUi9WMTJ4NmRocmFmeXVMV21zL0dRaTZzU05RSktyVkUzV3pXNzI4YzM1UGtXVHZpdWhxCktEaG9JYnlDOTVvWHF0YmVDakp3VmtzckZDMlZoUGY4eVloaHZBTGZFS3EweFFyNEE5dnRMUXl6QnE1aVJTcEUKSjU4NVA5QjZENHFUYVBoTkxtdlhyOG42aDgvam43YlBwT0VjUlNYRHlWbm4yOFRuNVIwZVoyalRYd1NyQlFlaApoWmM1RkFYK3lKU2xrcDNOUGlIdy9nT245d0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdE4yRmpZamczWWpZdE16RXhNUzAwWVRWbUxXRTVOVE10TmpFMll6TmxOVFUwWTJabExuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJKOHZod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUFmQXE2bFNta1BGWEJ2dVcvSVNQUkIvNkRvSklRWmtvWjFxM0R1cm81Z0JocDN2Y2NIaGUwd0xqenpuaCs3CjM5aWVxWURld2RQTEpFdkNIMUpBNi9ZU2E3WUFqSDZ6d1JiZ1lZcmRUeG12RnFjU09WeWlzQW90NU42V3hNME4KdzNzc3pWMnhjNktDeGQ1MHNLallrdEtvNjhDYkFoZGhwMUx3YUhsbDJtOFNKeUVUSzlPZldyb0lIVjFuVThocwpRZFBDTmdtay9OUU16OUU0OWp6WnlhcEpJWXIyQmlEendQejI4SkVMMzRabjFWSkZKd0xwQVl3N0ExK281K3hYCko3cThoalZjV1FuVTNmVWt6S1N3WGtPYUtEVHUyNmJpektFOFBRRG5qVS9xT2xudVNZaitSUlBEdlRjNittWE8KWU9Jc1RiSWhYRWlOY1YvM2ZiTkJhVFBuCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1833"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 709d732f-3b5f-406a-a322-680acfdb0733
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:26 GMT
+      - Thu, 02 Nov 2023 18:49:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 263aaef6-d54b-4a86-b5e6-c4951002207b
+      - 907ce36a-a07e-4425-b490-ffe7796a98ed
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:54:51.238886Z","retention":7},"created_at":"2023-10-20T15:54:51.238886Z","endpoint":{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188},"endpoints":[{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188}],"engine":"PostgreSQL-15","id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1267"
+      - "1227"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:27 GMT
+      - Thu, 02 Nov 2023 18:49:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0995283d-21ed-45a4-bd1e-e19061a8bd08
+      - b1f2203b-81d3-4c6d-85e8-c47bf62b393e
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVV3labXFGeHVKV09UU0Zjdm1oTng2b3hGNWVRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRVek5sb1hEVE16TVRBeE56RTFOVFV6Tmxvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFzbEZzeXRLaXZqTXVYR0tWZHRxUlM0OFpGemUwTDRzMzN2ajVUcFUyRUJFVUZXbXdHbWliL1lwc1EvdEQKYXp1d3U2OVVqcHpWOFhzbUt0RlBHYko5UVgzbFRPbHAxVmNPRGVucmxIbzVZS2ZiY2UrY0lvdmF0N1ZDK2FRSwpSSkxUUkx1alBnTGhVUi9WMTJ4NmRocmFmeXVMV21zL0dRaTZzU05RSktyVkUzV3pXNzI4YzM1UGtXVHZpdWhxCktEaG9JYnlDOTVvWHF0YmVDakp3VmtzckZDMlZoUGY4eVloaHZBTGZFS3EweFFyNEE5dnRMUXl6QnE1aVJTcEUKSjU4NVA5QjZENHFUYVBoTkxtdlhyOG42aDgvam43YlBwT0VjUlNYRHlWbm4yOFRuNVIwZVoyalRYd1NyQlFlaApoWmM1RkFYK3lKU2xrcDNOUGlIdy9nT245d0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdE4yRmpZamczWWpZdE16RXhNUzAwWVRWbUxXRTVOVE10TmpFMll6TmxOVFUwWTJabExuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJKOHZod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUFmQXE2bFNta1BGWEJ2dVcvSVNQUkIvNkRvSklRWmtvWjFxM0R1cm81Z0JocDN2Y2NIaGUwd0xqenpuaCs3CjM5aWVxWURld2RQTEpFdkNIMUpBNi9ZU2E3WUFqSDZ6d1JiZ1lZcmRUeG12RnFjU09WeWlzQW90NU42V3hNME4KdzNzc3pWMnhjNktDeGQ1MHNLallrdEtvNjhDYkFoZGhwMUx3YUhsbDJtOFNKeUVUSzlPZldyb0lIVjFuVThocwpRZFBDTmdtay9OUU16OUU0OWp6WnlhcEpJWXIyQmlEendQejI4SkVMMzRabjFWSkZKd0xwQVl3N0ExK281K3hYCko3cThoalZjV1FuVTNmVWt6S1N3WGtPYUtEVHUyNmJpektFOFBRRG5qVS9xT2xudVNZaitSUlBEdlRjNittWE8KWU9Jc1RiSWhYRWlOY1YvM2ZiTkJhVFBuCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUXo1eXBPU3ZyNUwyU0ZKWkxLaFlaV2U2QWxRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56TXdXaGNOTXpNeE1ETXdNVGcwTnpNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxTbDAwWTVrVGlyQTBsdGIzU3pUQ2NNZEgvMWJFd29VdmM4cmRxdXU5UUhERlQxQXNEOEZmU1UKQmprSzdnRXBjU0RMcXcvT00ySGtKVUVrYUhWQ3EvRi9DeXNPY2doQjhYMkRkNGZ6V3VwWmUxclBORHVIdDI1WQpkL0FHMmRLSFdTRW8xd2RwY3NaTnY2T2NZMUhwNHRUM0x0UklleStXeDBCUzRjWlBIZWFML3IzRnZ4WUdlUHZJClUzNTc4L1NSdWRaZ1NBM2ZqUjJLS3B1LzlrcitzRERrdkJ4MG5ReGdSVEdWUS9yaVVPQmZxSld4dms5MnlPYUMKZlFNVWFFV0Z6c2FiTmFzbzZGY2ZWbEUrNTZJQ0tHZ1lzUDdJYldWcFFJQy9lUWFaY1N5WUxoVkVCRnV1bnlyLwpkWHJqM3NQbGhlTnFpNWtMMTZlb2ZPeGY1YngvUHVVQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WldaaFpEUm1PRFF0WmpReFlTMDBNelV5TFRrd05tSXROR1UyTldVeVptUXgKTmpNeUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQVFEbGM2eEhFNzdsbmU0SEpkSVY1TmsreXVLZG9ldVRvbXozZVVwMnA0eWlBNDJ0dGcyN0JxCkN0QldEMnJqN1BCVEQ3bnJueWdubDVuYXBuU0hhNjFjT3MxSGI5MWRzYnM0aU1rTHAzZ1A0SDZiendQaWZGNVAKeWRjT0xoVCtSbzd6aUpuTEx5ckVNNUw2cFV3ZlI2TGRVMTYyRmUvK1RVREJ1b3QrRHZmS0w4dVgwZXJQTkhmWApibms2dlFLcHNDdGlqT0lwTGhNekxENEk2aERiRDNOZXhFVHBJMHVBVmV3dm9IdUN0M3lXZE5OaHZleFJoTDdiCk1xWTBmVHQwcXorVHRBUnFqYnlHbUVqemFVRHFwb1NoMnl6ajdvVC80bUJrb0dSQ0ZIMjE4ZXhVYmNCUkhBZ2EKbEdadGcwYW1EdjhONEpSUVhJQVMvNlBobExNbWdEQmIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:27 GMT
+      - Thu, 02 Nov 2023 18:49:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2aa39e51-fc05-4034-b674-958f1dde3c34
+      - ad70bf99-a761-459e-aa5e-01d26f4f9f46
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:27 GMT
+      - Thu, 02 Nov 2023 18:49:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,12 +961,111 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 570fced7-cdd4-4898-9394-b435c50505aa
+      - 1ebaa686-9f1c-4d51-ba18-f614b6cc927f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","database_name":"foo","name":"test_backup","expires_at":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1227"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:49:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - aa6860ca-4959-4b9a-aac4-81f14b41b409
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUXo1eXBPU3ZyNUwyU0ZKWkxLaFlaV2U2QWxRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56TXdXaGNOTXpNeE1ETXdNVGcwTnpNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxTbDAwWTVrVGlyQTBsdGIzU3pUQ2NNZEgvMWJFd29VdmM4cmRxdXU5UUhERlQxQXNEOEZmU1UKQmprSzdnRXBjU0RMcXcvT00ySGtKVUVrYUhWQ3EvRi9DeXNPY2doQjhYMkRkNGZ6V3VwWmUxclBORHVIdDI1WQpkL0FHMmRLSFdTRW8xd2RwY3NaTnY2T2NZMUhwNHRUM0x0UklleStXeDBCUzRjWlBIZWFML3IzRnZ4WUdlUHZJClUzNTc4L1NSdWRaZ1NBM2ZqUjJLS3B1LzlrcitzRERrdkJ4MG5ReGdSVEdWUS9yaVVPQmZxSld4dms5MnlPYUMKZlFNVWFFV0Z6c2FiTmFzbzZGY2ZWbEUrNTZJQ0tHZ1lzUDdJYldWcFFJQy9lUWFaY1N5WUxoVkVCRnV1bnlyLwpkWHJqM3NQbGhlTnFpNWtMMTZlb2ZPeGY1YngvUHVVQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WldaaFpEUm1PRFF0WmpReFlTMDBNelV5TFRrd05tSXROR1UyTldVeVptUXgKTmpNeUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQVFEbGM2eEhFNzdsbmU0SEpkSVY1TmsreXVLZG9ldVRvbXozZVVwMnA0eWlBNDJ0dGcyN0JxCkN0QldEMnJqN1BCVEQ3bnJueWdubDVuYXBuU0hhNjFjT3MxSGI5MWRzYnM0aU1rTHAzZ1A0SDZiendQaWZGNVAKeWRjT0xoVCtSbzd6aUpuTEx5ckVNNUw2cFV3ZlI2TGRVMTYyRmUvK1RVREJ1b3QrRHZmS0w4dVgwZXJQTkhmWApibms2dlFLcHNDdGlqT0lwTGhNekxENEk2aERiRDNOZXhFVHBJMHVBVmV3dm9IdUN0M3lXZE5OaHZleFJoTDdiCk1xWTBmVHQwcXorVHRBUnFqYnlHbUVqemFVRHFwb1NoMnl6ajdvVC80bUJrb0dSQ0ZIMjE4ZXhVYmNCUkhBZ2EKbEdadGcwYW1EdjhONEpSUVhJQVMvNlBobExNbWdEQmIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1843"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:49:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 69075c70-f842-48fc-9892-b530b458eb68
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/databases?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "102"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:49:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - df520579-37e4-4584-9e32-02fc9605b551
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"instance_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","database_name":"foo","name":"test_backup"}'
     form: {}
     headers:
       Content-Type:
@@ -1109,16 +1076,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups
     method: POST
   response:
-    body: '{"created_at":"2023-10-20T15:58:28.402547Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"694467fb-5feb-408d-8207-9c912fd5aeee","instance_id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
+    body: '{"created_at":"2023-11-02T18:49:44.206371Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4","instance_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
     headers:
       Content-Length:
-      - "411"
+      - "398"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:28 GMT
+      - Thu, 02 Nov 2023 18:49:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1128,7 +1095,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41d162bd-2e87-4e01-8393-85f8a35574f9
+      - e4508e43-9b33-4f97-8af2-6ffcf807a251
     status: 200 OK
     code: 200
     duration: ""
@@ -1139,19 +1106,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/694467fb-5feb-408d-8207-9c912fd5aeee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T15:58:28.402547Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"694467fb-5feb-408d-8207-9c912fd5aeee","instance_id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
+    body: '{"created_at":"2023-11-02T18:49:44.206371Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4","instance_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
     headers:
       Content-Length:
-      - "411"
+      - "398"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:28 GMT
+      - Thu, 02 Nov 2023 18:49:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1161,7 +1128,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc045305-7207-4de5-b0dd-af5b5f4e3117
+      - 6bd4866d-0182-43f1-9c97-0bfb5d8f8fb5
     status: 200 OK
     code: 200
     duration: ""
@@ -1172,19 +1139,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/694467fb-5feb-408d-8207-9c912fd5aeee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T15:58:28.402547Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"694467fb-5feb-408d-8207-9c912fd5aeee","instance_id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-10-20T15:58:30.323592Z"}'
+    body: '{"created_at":"2023-11-02T18:49:44.206371Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4","instance_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-11-02T18:49:46.021270Z"}'
     headers:
       Content-Length:
-      - "433"
+      - "420"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:59 GMT
+      - Thu, 02 Nov 2023 18:50:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1194,7 +1161,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aad93c8e-51fe-465b-8adb-56ba1d29791c
+      - 3b7e2ec4-c032-4d13-acaa-cb3f9b8ea8c5
     status: 200 OK
     code: 200
     duration: ""
@@ -1205,19 +1172,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/694467fb-5feb-408d-8207-9c912fd5aeee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T15:58:28.402547Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"694467fb-5feb-408d-8207-9c912fd5aeee","instance_id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-10-20T15:58:30.323592Z"}'
+    body: '{"created_at":"2023-11-02T18:49:44.206371Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4","instance_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-11-02T18:49:46.021270Z"}'
     headers:
       Content-Length:
-      - "433"
+      - "420"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:01 GMT
+      - Thu, 02 Nov 2023 18:50:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1227,7 +1194,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4f540b2-f349-457c-800e-1c19b9877f4d
+      - fc55b9a4-2224-4e6d-bb78-106da8ee476f
     status: 200 OK
     code: 200
     duration: ""
@@ -1238,19 +1205,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/694467fb-5feb-408d-8207-9c912fd5aeee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T15:58:28.402547Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"694467fb-5feb-408d-8207-9c912fd5aeee","instance_id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-10-20T15:58:30.323592Z"}'
+    body: '{"created_at":"2023-11-02T18:49:44.206371Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4","instance_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-11-02T18:49:46.021270Z"}'
     headers:
       Content-Length:
-      - "433"
+      - "420"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:01 GMT
+      - Thu, 02 Nov 2023 18:50:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1260,7 +1227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 392e389c-fa0a-46b9-8eb4-6e4fe5efd811
+      - 4edaaa61-fd42-4f6a-ae39-03f838cd779a
     status: 200 OK
     code: 200
     duration: ""
@@ -1271,19 +1238,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:54:51.238886Z","retention":7},"created_at":"2023-10-20T15:54:51.238886Z","endpoint":{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188},"endpoints":[{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188}],"engine":"PostgreSQL-15","id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1267"
+      - "1227"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:01 GMT
+      - Thu, 02 Nov 2023 18:50:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1293,7 +1260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 000f87d3-18a5-4250-8324-ee9f560457e7
+      - c7a49a99-1ad9-4b2f-b26f-022ac67e5898
     status: 200 OK
     code: 200
     duration: ""
@@ -1304,19 +1271,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVV3labXFGeHVKV09UU0Zjdm1oTng2b3hGNWVRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRVek5sb1hEVE16TVRBeE56RTFOVFV6Tmxvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFzbEZzeXRLaXZqTXVYR0tWZHRxUlM0OFpGemUwTDRzMzN2ajVUcFUyRUJFVUZXbXdHbWliL1lwc1EvdEQKYXp1d3U2OVVqcHpWOFhzbUt0RlBHYko5UVgzbFRPbHAxVmNPRGVucmxIbzVZS2ZiY2UrY0lvdmF0N1ZDK2FRSwpSSkxUUkx1alBnTGhVUi9WMTJ4NmRocmFmeXVMV21zL0dRaTZzU05RSktyVkUzV3pXNzI4YzM1UGtXVHZpdWhxCktEaG9JYnlDOTVvWHF0YmVDakp3VmtzckZDMlZoUGY4eVloaHZBTGZFS3EweFFyNEE5dnRMUXl6QnE1aVJTcEUKSjU4NVA5QjZENHFUYVBoTkxtdlhyOG42aDgvam43YlBwT0VjUlNYRHlWbm4yOFRuNVIwZVoyalRYd1NyQlFlaApoWmM1RkFYK3lKU2xrcDNOUGlIdy9nT245d0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdE4yRmpZamczWWpZdE16RXhNUzAwWVRWbUxXRTVOVE10TmpFMll6TmxOVFUwWTJabExuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJKOHZod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUFmQXE2bFNta1BGWEJ2dVcvSVNQUkIvNkRvSklRWmtvWjFxM0R1cm81Z0JocDN2Y2NIaGUwd0xqenpuaCs3CjM5aWVxWURld2RQTEpFdkNIMUpBNi9ZU2E3WUFqSDZ6d1JiZ1lZcmRUeG12RnFjU09WeWlzQW90NU42V3hNME4KdzNzc3pWMnhjNktDeGQ1MHNLallrdEtvNjhDYkFoZGhwMUx3YUhsbDJtOFNKeUVUSzlPZldyb0lIVjFuVThocwpRZFBDTmdtay9OUU16OUU0OWp6WnlhcEpJWXIyQmlEendQejI4SkVMMzRabjFWSkZKd0xwQVl3N0ExK281K3hYCko3cThoalZjV1FuVTNmVWt6S1N3WGtPYUtEVHUyNmJpektFOFBRRG5qVS9xT2xudVNZaitSUlBEdlRjNittWE8KWU9Jc1RiSWhYRWlOY1YvM2ZiTkJhVFBuCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUXo1eXBPU3ZyNUwyU0ZKWkxLaFlaV2U2QWxRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56TXdXaGNOTXpNeE1ETXdNVGcwTnpNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxTbDAwWTVrVGlyQTBsdGIzU3pUQ2NNZEgvMWJFd29VdmM4cmRxdXU5UUhERlQxQXNEOEZmU1UKQmprSzdnRXBjU0RMcXcvT00ySGtKVUVrYUhWQ3EvRi9DeXNPY2doQjhYMkRkNGZ6V3VwWmUxclBORHVIdDI1WQpkL0FHMmRLSFdTRW8xd2RwY3NaTnY2T2NZMUhwNHRUM0x0UklleStXeDBCUzRjWlBIZWFML3IzRnZ4WUdlUHZJClUzNTc4L1NSdWRaZ1NBM2ZqUjJLS3B1LzlrcitzRERrdkJ4MG5ReGdSVEdWUS9yaVVPQmZxSld4dms5MnlPYUMKZlFNVWFFV0Z6c2FiTmFzbzZGY2ZWbEUrNTZJQ0tHZ1lzUDdJYldWcFFJQy9lUWFaY1N5WUxoVkVCRnV1bnlyLwpkWHJqM3NQbGhlTnFpNWtMMTZlb2ZPeGY1YngvUHVVQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WldaaFpEUm1PRFF0WmpReFlTMDBNelV5TFRrd05tSXROR1UyTldVeVptUXgKTmpNeUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQVFEbGM2eEhFNzdsbmU0SEpkSVY1TmsreXVLZG9ldVRvbXozZVVwMnA0eWlBNDJ0dGcyN0JxCkN0QldEMnJqN1BCVEQ3bnJueWdubDVuYXBuU0hhNjFjT3MxSGI5MWRzYnM0aU1rTHAzZ1A0SDZiendQaWZGNVAKeWRjT0xoVCtSbzd6aUpuTEx5ckVNNUw2cFV3ZlI2TGRVMTYyRmUvK1RVREJ1b3QrRHZmS0w4dVgwZXJQTkhmWApibms2dlFLcHNDdGlqT0lwTGhNekxENEk2aERiRDNOZXhFVHBJMHVBVmV3dm9IdUN0M3lXZE5OaHZleFJoTDdiCk1xWTBmVHQwcXorVHRBUnFqYnlHbUVqemFVRHFwb1NoMnl6ajdvVC80bUJrb0dSQ0ZIMjE4ZXhVYmNCUkhBZ2EKbEdadGcwYW1EdjhONEpSUVhJQVMvNlBobExNbWdEQmIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:01 GMT
+      - Thu, 02 Nov 2023 18:50:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1326,7 +1293,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce8ce059-b27c-4766-b18a-3b1cbfae5b42
+      - 4b31f51b-130f-4f62-9cf1-eab5d996b4a4
     status: 200 OK
     code: 200
     duration: ""
@@ -1337,19 +1304,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:02 GMT
+      - Thu, 02 Nov 2023 18:50:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1359,7 +1326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 297aa41f-1ea5-475a-9e34-7596a3f2fd59
+      - 28fdfa22-c676-473e-9c1f-c50222c1a46d
     status: 200 OK
     code: 200
     duration: ""
@@ -1370,19 +1337,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/694467fb-5feb-408d-8207-9c912fd5aeee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T15:58:28.402547Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"694467fb-5feb-408d-8207-9c912fd5aeee","instance_id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-10-20T15:58:30.323592Z"}'
+    body: '{"created_at":"2023-11-02T18:49:44.206371Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4","instance_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-11-02T18:49:46.021270Z"}'
     headers:
       Content-Length:
-      - "433"
+      - "420"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:02 GMT
+      - Thu, 02 Nov 2023 18:50:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1392,7 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84755069-73f4-434a-ab07-955cac41ea07
+      - 24b30ae6-a9fe-4561-9a74-447d425255b7
     status: 200 OK
     code: 200
     duration: ""
@@ -1403,19 +1370,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/694467fb-5feb-408d-8207-9c912fd5aeee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T15:58:28.402547Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"694467fb-5feb-408d-8207-9c912fd5aeee","instance_id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-10-20T15:58:30.323592Z"}'
+    body: '{"created_at":"2023-11-02T18:49:44.206371Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4","instance_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-11-02T18:49:46.021270Z"}'
     headers:
       Content-Length:
-      - "433"
+      - "420"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:03 GMT
+      - Thu, 02 Nov 2023 18:50:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1425,7 +1392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2759bf45-cd45-4a36-a9da-05bf92757293
+      - aed2e13a-592c-4cac-947b-3371495d2885
     status: 200 OK
     code: 200
     duration: ""
@@ -1436,19 +1403,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/694467fb-5feb-408d-8207-9c912fd5aeee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4
     method: DELETE
   response:
-    body: '{"created_at":"2023-10-20T15:58:28.402547Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"694467fb-5feb-408d-8207-9c912fd5aeee","instance_id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"deleting","updated_at":"2023-10-20T15:58:30.323592Z"}'
+    body: '{"created_at":"2023-11-02T18:49:44.206371Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4","instance_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"deleting","updated_at":"2023-11-02T18:49:46.021270Z"}'
     headers:
       Content-Length:
-      - "436"
+      - "423"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:03 GMT
+      - Thu, 02 Nov 2023 18:50:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1458,7 +1425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91a4e782-c3de-4621-9313-28964ba68efe
+      - e83df395-0f46-4af4-b90d-12cf23af89f3
     status: 200 OK
     code: 200
     duration: ""
@@ -1469,10 +1436,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/694467fb-5feb-408d-8207-9c912fd5aeee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"694467fb-5feb-408d-8207-9c912fd5aeee","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -1481,7 +1448,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:03 GMT
+      - Thu, 02 Nov 2023 18:50:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1491,7 +1458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c500fd32-75bd-462e-9413-a8fd5d71ee02
+      - 2d2d308a-14ef-4f4a-add3-673113b7e996
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1502,19 +1469,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:54:51.238886Z","retention":7},"created_at":"2023-10-20T15:54:51.238886Z","endpoint":{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188},"endpoints":[{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188}],"engine":"PostgreSQL-15","id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1267"
+      - "1227"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:03 GMT
+      - Thu, 02 Nov 2023 18:50:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1524,7 +1491,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8abd26d1-e3fb-4e20-bec0-3520b3ea7a1e
+      - a37a091f-bf6a-4a82-a286-fd9dbd8db683
     status: 200 OK
     code: 200
     duration: ""
@@ -1535,7 +1502,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe/databases/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/databases/foo
     method: DELETE
   response:
     body: ""
@@ -1545,7 +1512,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:03 GMT
+      - Thu, 02 Nov 2023 18:50:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5100dba8-5e4f-4875-8dce-f9bb8dd220a0
+      - 1e53bbd8-a5da-4774-968f-7f179f2ca2d8
     status: 204 No Content
     code: 204
     duration: ""
@@ -1566,19 +1533,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:54:51.238886Z","retention":7},"created_at":"2023-10-20T15:54:51.238886Z","endpoint":{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188},"endpoints":[{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188}],"engine":"PostgreSQL-15","id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1267"
+      - "1227"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:04 GMT
+      - Thu, 02 Nov 2023 18:50:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1555,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c73ebd9-e62f-41e5-9132-821c993d9554
+      - efe54419-cbfd-4bc4-b2e7-4990fda4a8dd
     status: 200 OK
     code: 200
     duration: ""
@@ -1599,19 +1566,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:54:51.238886Z","retention":7},"created_at":"2023-10-20T15:54:51.238886Z","endpoint":{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188},"endpoints":[{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188}],"engine":"PostgreSQL-15","id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1267"
+      - "1227"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:04 GMT
+      - Thu, 02 Nov 2023 18:50:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1621,7 +1588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5849618b-3b6e-4591-8581-a7540167690e
+      - 21655f83-65aa-47b8-a91a-57eac53469db
     status: 200 OK
     code: 200
     duration: ""
@@ -1632,19 +1599,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:54:51.238886Z","retention":7},"created_at":"2023-10-20T15:54:51.238886Z","endpoint":{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188},"endpoints":[{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188}],"engine":"PostgreSQL-15","id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1230"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:04 GMT
+      - Thu, 02 Nov 2023 18:50:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1654,7 +1621,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db27b068-f872-44d1-998b-fbedea26c3c2
+      - 968b049a-33a5-4bb9-9b0c-981aa6206392
     status: 200 OK
     code: 200
     duration: ""
@@ -1665,19 +1632,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:54:51.238886Z","retention":7},"created_at":"2023-10-20T15:54:51.238886Z","endpoint":{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188},"endpoints":[{"id":"b296d20d-bd67-4ce9-9cb8-312a8aefa0c1","ip":"51.159.9.88","load_balancer":{},"name":null,"port":1188}],"engine":"PostgreSQL-15","id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1230"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:04 GMT
+      - Thu, 02 Nov 2023 18:50:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1687,7 +1654,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b101b34c-7dfe-4773-81a0-5f62b47e4070
+      - b305880f-8123-44ef-9aa8-5ce5edd35cde
     status: 200 OK
     code: 200
     duration: ""
@@ -1698,10 +1665,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1710,7 +1677,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:34 GMT
+      - Thu, 02 Nov 2023 18:50:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1720,7 +1687,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1089835-313f-4b16-b7d8-e4ca7d96de2a
+      - 8946ab78-92f6-4a67-a123-71f8ae4fbaa9
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1731,10 +1698,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7acb87b6-3111-4a5f-a953-616c3e554cfe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"7acb87b6-3111-4a5f-a953-616c3e554cfe","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1743,7 +1710,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:34 GMT
+      - Thu, 02 Nov 2023 18:50:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1753,7 +1720,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1fe625cb-a29c-46d8-afd4-4914bb62bbde
+      - 651a6419-cd0f-434a-9a21-ed98d406f674
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1764,10 +1731,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/694467fb-5feb-408d-8207-9c912fd5aeee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"694467fb-5feb-408d-8207-9c912fd5aeee","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -1776,7 +1743,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:35 GMT
+      - Thu, 02 Nov 2023 18:50:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1786,7 +1753,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c43fd59-5a79-4283-8af9-15bc675104ce
+      - 1b053ea2-147f-47f2-b094-f95ab210fa71
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-database-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-database-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:04 GMT
+      - Thu, 02 Nov 2023 18:46:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c4f8c34-a8b3-4302-b336-7185acae399a
+      - fc2ce1a6-5023-4785-9f45-0bd82d3cca7e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayRdbDatabase_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayRdbDatabase_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.450543Z","retention":7},"created_at":"2023-10-20T15:51:10.450543Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"55629c49-c695-463f-9934-1aad74e72acc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "823"
+      - "794"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:10 GMT
+      - Thu, 02 Nov 2023 18:46:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9b59ea3-9ba6-4b4b-9723-ecb2b8829ddd
+      - 59f5cd76-a25e-4b27-9a13-58058eb0f4bc
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.450543Z","retention":7},"created_at":"2023-10-20T15:51:10.450543Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"55629c49-c695-463f-9934-1aad74e72acc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "823"
+      - "794"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:10 GMT
+      - Thu, 02 Nov 2023 18:46:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7962f242-d6f9-41ad-b587-0806ee7a33f3
+      - 7e0f2ea7-2146-43c4-8ba3-91739505f286
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.450543Z","retention":7},"created_at":"2023-10-20T15:51:10.450543Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"55629c49-c695-463f-9934-1aad74e72acc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "823"
+      - "794"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:40 GMT
+      - Thu, 02 Nov 2023 18:47:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a80d56e7-5c5c-486a-bab1-becd332cef5c
+      - ac91c512-e15d-468d-9ad8-41ea02887365
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.450543Z","retention":7},"created_at":"2023-10-20T15:51:10.450543Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"55629c49-c695-463f-9934-1aad74e72acc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "823"
+      - "794"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:52:11 GMT
+      - Thu, 02 Nov 2023 18:47:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3edcd41-1c45-4c83-b0ca-0ff324f0ae95
+      - a71a97a5-861e-49d5-a071-0f2adbf01b2e
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.450543Z","retention":7},"created_at":"2023-10-20T15:51:10.450543Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"55629c49-c695-463f-9934-1aad74e72acc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "823"
+      - "794"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:52:41 GMT
+      - Thu, 02 Nov 2023 18:48:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6cb6821-a3a8-41d1-a613-1b4a25d224a7
+      - 37a23ec4-5f5e-4838-84b0-c6619d072e9e
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.450543Z","retention":7},"created_at":"2023-10-20T15:51:10.450543Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"55629c49-c695-463f-9934-1aad74e72acc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "823"
+      - "794"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:53:11 GMT
+      - Thu, 02 Nov 2023 18:48:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa166827-75cf-46a7-aa2d-f54494883b18
+      - 57504f45-4b45-4e74-841b-8181d3f14b9d
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.450543Z","retention":7},"created_at":"2023-10-20T15:51:10.450543Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"55629c49-c695-463f-9934-1aad74e72acc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "823"
+      - "794"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:53:41 GMT
+      - Thu, 02 Nov 2023 18:49:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb9f34eb-83a0-4ba3-a265-4bb0e940e958
+      - 1485592d-19ea-42de-a831-32e6d4b49ded
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.450543Z","retention":7},"created_at":"2023-10-20T15:51:10.450543Z","endpoint":{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055},"endpoints":[{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055}],"engine":"PostgreSQL-15","id":"55629c49-c695-463f-9934-1aad74e72acc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1319"
+      - "1265"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,12 +594,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d77715e-d94e-4d5c-a559-247d888befa0
+      - 5ea43ef9-97da-4063-98a5-6562c25105eb
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"backup_schedule_frequency":null,"backup_schedule_retention":null,"is_backup_schedule_disabled":false,"name":null,"tags":null,"logs_policy":null,"backup_same_region":false,"backup_schedule_start_hour":null}'
+    body: '{"is_backup_schedule_disabled":false,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -607,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.450543Z","retention":7},"created_at":"2023-10-20T15:51:10.450543Z","endpoint":{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055},"endpoints":[{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055}],"engine":"PostgreSQL-15","id":"55629c49-c695-463f-9934-1aad74e72acc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1319"
+      - "1265"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5c2c18d-fa7e-402e-bd90-9e1120e4312b
+      - b9522eee-885f-4858-b547-dcd7b6f4b12b
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.450543Z","retention":7},"created_at":"2023-10-20T15:51:10.450543Z","endpoint":{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055},"endpoints":[{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055}],"engine":"PostgreSQL-15","id":"55629c49-c695-463f-9934-1aad74e72acc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1319"
+      - "1265"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e64de38-eb63-43a8-a8af-e053bf6f97d4
+      - f21c08d5-a814-44ed-8869-28eb92d73236
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURxakNDQXBLZ0F3SUJBZ0lVQ3ZwVlpBV1M2clVJT2p4RXRtQTlIY2pCdXhvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTBPREFlCkZ3MHlNekV3TWpBeE5UVXhOVEJhRncwek16RXdNVGN4TlRVeE5UQmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5EZ3dnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRRGRyeExZR3I4NEhXalNJd2NkZGZadmUySXliellGdE9OOGdMWDhmWVFWNkVDV0RONzEKbGRrNlNmd0hDb0VMSGhZaFJPQ0tCZE01L25JQmFoV1EvSmxDanZmdTQzeEpiZEF6eVIyTzc0bXBxREpCSjBCcApRYVM2KzVJeXY4MlJpUEh2TWFQcXRPYm9BVTY0RllKSVNTeGUvNEpkTEJHVGVSS0MyL05iT244YlFCSjBxc05vCksvU2pZam4rZnI3Q1VEZ3FQQ2pPZGN2WStTUC9RM29WODVUOHhSUGpSdlBXZWd1SkN6Ympjc2Z3WXpTN0R5azAKdFFHOElXZ0N3Z2h4bjlGZWsyaGNFaHQ3OEpsSVlxZDcxY2lpd1k4Q1VWeWM4c2syMW5NQ3lHQ3VMdWdkYnM4dwpNaHl3aEttbFNzK0NvazJ1aW8yWldHcHlVbFRuUnNnTm9ENlZBZ01CQUFHamFEQm1NR1FHQTFVZEVRUmRNRnVDCkR6RTVOUzR4TlRRdU1UazNMakkwT0lJOGNuY3ROVFUyTWpsak5Ea3RZelk1TlMwME5qTm1MVGs1TXpRdE1XRmgKWkRjMFpUY3lZV05qTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOTBsaHdURG1zWDRNQTBHQ1NxRwpTSWIzRFFFQkN3VUFBNElCQVFDdmpWQkxndVRsVllUT2k0TFRKaE13UlZPaGhSOHk5dlZvbkNSdlZETWhrRFpZCnlUTlFRTDlFTGlXc3l6dkJxNUdWejlIL0tnVzVKMjNzODhEVUhJMW0yeEh6ZnprN0lsdmhydkl6S01rRkZDUVMKZ1p5VUdxUVlNNG01bGxDK0J4ME5FRXZNQXNHalcyNCtoUWxkUVZ6L04xMTIwZHRzeGo2VFhZZms4VFZEaXNnSQo0RG9QOFlnNUtuWHRDZVd5c2J6V09HTk95SW1sNVVrbGQza0dFangxQ24vRSt6MXFScENGbk93SFhPMFVxRHhuCnNicU5PL0NzeElBMHpEVXlVOG41ZjY1MXpZcnpidWtvQVZIT24zandOVTBjTFVweGd0V3VvMDcyZ1hsVWp0RlkKYUg1VU9HZkRpK0Y0TjBMR3BSWEJnSUFqRjlZZHd0TTJuRE00VFlzUAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSHFnT01CUzl1QmFUWFJZdGR5ZVc0QlFNOWs0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56STVXaGNOTXpNeE1ETXdNVGcwTnpJNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5CNCtid1RVaStkVXhFd0RSYklXdkRNelpXdHNOMC8yNlJBZG93b2RqY1REOXdMbzNCek5oeTkKZVdGQndkaEZnbk5janoxLzkyVjc5L1QxZHUrSk8xTHNMd0VqUzd1WXlvWFlSS252WFVELytneDhLY2hiZ0w1dwpNby9Ib25Ba1hkc29JOFJaMjJEVlBORCs2ako4SnNKV09wK1hyRmZxYWExbHQrWDVaQjRyL1hGS3dmUng0cVVPCkh5Mkc3QndzaE9aeFgzQ1gvT0xHRElGZTNMd3cxa1VaaUkvOXpZWjN6WkpyenlUUVZnQy9xWVBiQVZ5NlBMS2oKVlVPWWZvU1N1bEdkMVl0WXZkenlzd3pTM0FocG95cHZNVVRxVzFkM0s0V082NmxDOWhrTTNOdDYzTVlUVTF5bApBOWtOS09PeThtME5ub2ZETERweHdzQld5dmdRVFRzQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0TWpZNFpqazJZV0l0T1RJeE1TMDBaamxqTFdKak56UXRORGRrT1RNd1l6azIKWm1GakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpGcmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQnUwVW1LdXorOE1YNVorVHZlbnluemVvekk3K2hNVFowYVRjSzd4ZWN5SXFjdWtHdU9kaFR6ClJGbkowT1lHdDU1cUZRRjNtZXVkclZFSk5yaHN5NHV3UjV2bW9WVjRFaVBnMU1IcGgzRGh5MWNjUEp1TFVTMnQKRk52T0xwYXNUVjBUZlRBeWVDWVBuOUErUjQ3NjRnZ0ZlMmxWbW5BYWs1ZWtLVEUveGRKcDU2WW5zeGFFa21mUQp5R2RKNHkrQnJxUEpZUytva0dJbVovdVhoMHNjTTNnUEJRUnR6V1dHY2NKalUrWG9wYTVCcDlBZkRDcXhCY0VPClJ0S05NNk5RRzNMNy9vczJjVEFRUVNqTG1zNlVPaWF3SURUU3JPc1d5d2VGN01YZ3RzREVSNzBkaTRTWVUyZ24KejVtcEx5RTBwajEzNnBaUk1HT1M4ZmtSSFpOUXYrdUwKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1857"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:12 GMT
+      - Thu, 02 Nov 2023 18:49:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c743849-4b90-4276-aee4-edfb9871a679
+      - c1378b32-c286-4a2b-a111-54d3f0ff74a8
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.450543Z","retention":7},"created_at":"2023-10-20T15:51:10.450543Z","endpoint":{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055},"endpoints":[{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055}],"engine":"PostgreSQL-15","id":"55629c49-c695-463f-9934-1aad74e72acc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1319"
+      - "1265"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:12 GMT
+      - Thu, 02 Nov 2023 18:49:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 261f284e-b57d-4dde-9d6e-9f2b410e2b02
+      - 52d9c927-a5e2-43c6-aef5-93856f6eda0e
     status: 200 OK
     code: 200
     duration: ""
@@ -741,19 +741,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac/databases
     method: POST
   response:
     body: '{"managed":true,"name":"foo","owner":"","size":0}'
     headers:
       Content-Length:
-      - "52"
+      - "49"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:12 GMT
+      - Thu, 02 Nov 2023 18:49:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +763,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df2094cb-82d0-47a7-9796-20e78d2c630f
+      - 155793f5-33bc-4019-9cd6-b2f256e04b5d
     status: 200 OK
     code: 200
     duration: ""
@@ -774,19 +774,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.450543Z","retention":7},"created_at":"2023-10-20T15:51:10.450543Z","endpoint":{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055},"endpoints":[{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055}],"engine":"PostgreSQL-15","id":"55629c49-c695-463f-9934-1aad74e72acc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1319"
+      - "1265"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:12 GMT
+      - Thu, 02 Nov 2023 18:49:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b77380e-0fa0-4a5b-a7fb-6ae32e6678d3
+      - a5908593-46c4-411b-a1e1-17f73e52a00f
     status: 200 OK
     code: 200
     duration: ""
@@ -807,52 +807,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc/databases?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "106"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 127cd66f-d73c-4bcd-800d-8c9a7b712994
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:12 GMT
+      - Thu, 02 Nov 2023 18:49:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19b3d5f7-549e-427b-af24-cda636679f92
+      - 87859bce-bf7e-4fbb-9a5d-7f0dc89ca2bd
     status: 200 OK
     code: 200
     duration: ""
@@ -873,85 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.450543Z","retention":7},"created_at":"2023-10-20T15:51:10.450543Z","endpoint":{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055},"endpoints":[{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055}],"engine":"PostgreSQL-15","id":"55629c49-c695-463f-9934-1aad74e72acc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1319"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bdaa01ad-6286-4317-b74e-5207c4ea7f48
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURxakNDQXBLZ0F3SUJBZ0lVQ3ZwVlpBV1M2clVJT2p4RXRtQTlIY2pCdXhvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTBPREFlCkZ3MHlNekV3TWpBeE5UVXhOVEJhRncwek16RXdNVGN4TlRVeE5UQmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5EZ3dnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRRGRyeExZR3I4NEhXalNJd2NkZGZadmUySXliellGdE9OOGdMWDhmWVFWNkVDV0RONzEKbGRrNlNmd0hDb0VMSGhZaFJPQ0tCZE01L25JQmFoV1EvSmxDanZmdTQzeEpiZEF6eVIyTzc0bXBxREpCSjBCcApRYVM2KzVJeXY4MlJpUEh2TWFQcXRPYm9BVTY0RllKSVNTeGUvNEpkTEJHVGVSS0MyL05iT244YlFCSjBxc05vCksvU2pZam4rZnI3Q1VEZ3FQQ2pPZGN2WStTUC9RM29WODVUOHhSUGpSdlBXZWd1SkN6Ympjc2Z3WXpTN0R5azAKdFFHOElXZ0N3Z2h4bjlGZWsyaGNFaHQ3OEpsSVlxZDcxY2lpd1k4Q1VWeWM4c2syMW5NQ3lHQ3VMdWdkYnM4dwpNaHl3aEttbFNzK0NvazJ1aW8yWldHcHlVbFRuUnNnTm9ENlZBZ01CQUFHamFEQm1NR1FHQTFVZEVRUmRNRnVDCkR6RTVOUzR4TlRRdU1UazNMakkwT0lJOGNuY3ROVFUyTWpsak5Ea3RZelk1TlMwME5qTm1MVGs1TXpRdE1XRmgKWkRjMFpUY3lZV05qTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOTBsaHdURG1zWDRNQTBHQ1NxRwpTSWIzRFFFQkN3VUFBNElCQVFDdmpWQkxndVRsVllUT2k0TFRKaE13UlZPaGhSOHk5dlZvbkNSdlZETWhrRFpZCnlUTlFRTDlFTGlXc3l6dkJxNUdWejlIL0tnVzVKMjNzODhEVUhJMW0yeEh6ZnprN0lsdmhydkl6S01rRkZDUVMKZ1p5VUdxUVlNNG01bGxDK0J4ME5FRXZNQXNHalcyNCtoUWxkUVZ6L04xMTIwZHRzeGo2VFhZZms4VFZEaXNnSQo0RG9QOFlnNUtuWHRDZVd5c2J6V09HTk95SW1sNVVrbGQza0dFangxQ24vRSt6MXFScENGbk93SFhPMFVxRHhuCnNicU5PL0NzeElBMHpEVXlVOG41ZjY1MXpZcnpidWtvQVZIT24zandOVTBjTFVweGd0V3VvMDcyZ1hsVWp0RlkKYUg1VU9HZkRpK0Y0TjBMR3BSWEJnSUFqRjlZZHd0TTJuRE00VFlzUAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1857"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ee9d0aca-93e4-4e5b-b665-a438e0216537
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:13 GMT
+      - Thu, 02 Nov 2023 18:49:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0dbdc9eb-d067-46a5-9c89-e292b8ff155a
+      - 42f2096e-aa11-48b5-a01c-094df9a41b2c
     status: 200 OK
     code: 200
     duration: ""
@@ -972,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.450543Z","retention":7},"created_at":"2023-10-20T15:51:10.450543Z","endpoint":{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055},"endpoints":[{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055}],"engine":"PostgreSQL-15","id":"55629c49-c695-463f-9934-1aad74e72acc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1319"
+      - "1265"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 18:49:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d5dba71-67ee-4904-810b-598639881af9
+      - 1211278d-2c44-4e2c-92c7-d112d7393355
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,7 +906,106 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc/databases/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSHFnT01CUzl1QmFUWFJZdGR5ZVc0QlFNOWs0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56STVXaGNOTXpNeE1ETXdNVGcwTnpJNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5CNCtid1RVaStkVXhFd0RSYklXdkRNelpXdHNOMC8yNlJBZG93b2RqY1REOXdMbzNCek5oeTkKZVdGQndkaEZnbk5janoxLzkyVjc5L1QxZHUrSk8xTHNMd0VqUzd1WXlvWFlSS252WFVELytneDhLY2hiZ0w1dwpNby9Ib25Ba1hkc29JOFJaMjJEVlBORCs2ako4SnNKV09wK1hyRmZxYWExbHQrWDVaQjRyL1hGS3dmUng0cVVPCkh5Mkc3QndzaE9aeFgzQ1gvT0xHRElGZTNMd3cxa1VaaUkvOXpZWjN6WkpyenlUUVZnQy9xWVBiQVZ5NlBMS2oKVlVPWWZvU1N1bEdkMVl0WXZkenlzd3pTM0FocG95cHZNVVRxVzFkM0s0V082NmxDOWhrTTNOdDYzTVlUVTF5bApBOWtOS09PeThtME5ub2ZETERweHdzQld5dmdRVFRzQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0TWpZNFpqazJZV0l0T1RJeE1TMDBaamxqTFdKak56UXRORGRrT1RNd1l6azIKWm1GakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpGcmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQnUwVW1LdXorOE1YNVorVHZlbnluemVvekk3K2hNVFowYVRjSzd4ZWN5SXFjdWtHdU9kaFR6ClJGbkowT1lHdDU1cUZRRjNtZXVkclZFSk5yaHN5NHV3UjV2bW9WVjRFaVBnMU1IcGgzRGh5MWNjUEp1TFVTMnQKRk52T0xwYXNUVjBUZlRBeWVDWVBuOUErUjQ3NjRnZ0ZlMmxWbW5BYWs1ZWtLVEUveGRKcDU2WW5zeGFFa21mUQp5R2RKNHkrQnJxUEpZUytva0dJbVovdVhoMHNjTTNnUEJRUnR6V1dHY2NKalUrWG9wYTVCcDlBZkRDcXhCY0VPClJ0S05NNk5RRzNMNy9vczJjVEFRUVNqTG1zNlVPaWF3SURUU3JPc1d5d2VGN01YZ3RzREVSNzBkaTRTWVUyZ24KejVtcEx5RTBwajEzNnBaUk1HT1M4ZmtSSFpOUXYrdUwKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1843"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:49:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1749a588-31eb-4b22-80eb-8068a7eb1dca
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac/databases?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "102"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:49:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 58adb256-edf3-4e68-8c46-28ee4ec71cd1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1265"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:49:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 16d550df-fb2a-4af5-b80b-1c665a3d9620
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac/databases/foo
     method: DELETE
   response:
     body: ""
@@ -1015,7 +1015,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 18:49:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab6a8864-61dc-4c2c-86d6-20f08cc8118e
+      - 9493f65a-bc0d-4a07-a128-64dba2d6a308
     status: 204 No Content
     code: 204
     duration: ""
@@ -1036,19 +1036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.450543Z","retention":7},"created_at":"2023-10-20T15:51:10.450543Z","endpoint":{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055},"endpoints":[{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055}],"engine":"PostgreSQL-15","id":"55629c49-c695-463f-9934-1aad74e72acc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1319"
+      - "1265"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 18:49:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1058,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5ff5c28-cdeb-4a3f-bd99-7bc6eb97913c
+      - 7774febb-b244-4546-80b9-d904f58046f4
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,19 +1069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.450543Z","retention":7},"created_at":"2023-10-20T15:51:10.450543Z","endpoint":{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055},"endpoints":[{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055}],"engine":"PostgreSQL-15","id":"55629c49-c695-463f-9934-1aad74e72acc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1319"
+      - "1265"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 18:49:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1091,7 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d4240ef-4cfd-48ce-bad7-d5e6356cdb9c
+      - ca20c142-e21a-41c0-8223-5b7a3852de34
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,19 +1102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.450543Z","retention":7},"created_at":"2023-10-20T15:51:10.450543Z","endpoint":{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055},"endpoints":[{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055}],"engine":"PostgreSQL-15","id":"55629c49-c695-463f-9934-1aad74e72acc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1322"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:15 GMT
+      - Thu, 02 Nov 2023 18:49:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1124,7 +1124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14d88782-e950-42b9-857b-ac1ce38885c0
+      - b19aeb42-a62f-443f-8d82-0bb42d3b3eb7
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,19 +1135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.450543Z","retention":7},"created_at":"2023-10-20T15:51:10.450543Z","endpoint":{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055},"endpoints":[{"id":"64468a1c-8200-489f-a556-c83d38f77870","ip":"195.154.197.248","load_balancer":{},"name":null,"port":15055}],"engine":"PostgreSQL-15","id":"55629c49-c695-463f-9934-1aad74e72acc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1322"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:15 GMT
+      - Thu, 02 Nov 2023 18:49:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1157,7 +1157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e04b822b-6b5f-45b5-ba92-84c600e29525
+      - a7807052-e846-42de-b638-554a96940c42
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,10 +1168,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"55629c49-c695-463f-9934-1aad74e72acc","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"268f96ab-9211-4f9c-bc74-47d930c96fac","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1180,7 +1180,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:45 GMT
+      - Thu, 02 Nov 2023 18:50:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +1190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca634218-9d03-49b9-a322-af4f5c3a11a7
+      - 9e5beefa-1f8d-4f56-b908-797e70964d62
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1201,10 +1201,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/55629c49-c695-463f-9934-1aad74e72acc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"55629c49-c695-463f-9934-1aad74e72acc","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"268f96ab-9211-4f9c-bc74-47d930c96fac","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1213,7 +1213,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:50 GMT
+      - Thu, 02 Nov 2023 18:50:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a081e8c5-b6bb-4179-abe4-19d3dff22420
+      - 49e50d47-a0ab-40cf-870a-0ba621da8038
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-database-manual-delete.cassette.yaml
+++ b/scaleway/testdata/rdb-database-manual-delete.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:05 GMT
+      - Thu, 02 Nov 2023 18:46:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99d420b4-2276-45c0-b3f2-61f8d70fccb1
+      - 306071b1-007f-49c5-8afb-fdb5154274f0
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"bug","engine":"PostgreSQL-15","user_name":"admin","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-m","is_ha_cluster":false,"disable_backup":true,"tags":["bug"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"bug","engine":"PostgreSQL-15","user_name":"admin","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-m","is_ha_cluster":false,"disable_backup":true,"tags":["bug"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "726"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:36 GMT
+      - Thu, 02 Nov 2023 18:50:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce5912a6-2243-48fc-a7b8-420b2270340d
+      - 6fc866c3-7a48-4535-8799-c94b57037c26
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "726"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:36 GMT
+      - Thu, 02 Nov 2023 18:50:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ff0a657-6081-4b55-86a0-b62e3e46e774
+      - b5258796-201f-4a5c-9f43-c7cb2b7c8eb7
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "726"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:06 GMT
+      - Thu, 02 Nov 2023 18:50:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c6102e7-eaf9-4785-9a21-a3caecabf271
+      - 64d0a6ca-c5eb-441e-8d72-3741988b6a8c
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "726"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:36 GMT
+      - Thu, 02 Nov 2023 18:51:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83b07d34-4fc3-4645-bc72-880256c15468
+      - 8e2481d4-2085-4121-8605-601b4437727c
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "726"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:06 GMT
+      - Thu, 02 Nov 2023 18:51:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03400109-ee16-4cb5-be5d-9b1f05f68e3c
+      - 25515151-8aff-41b0-ade3-48872cca3d03
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "726"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:37 GMT
+      - Thu, 02 Nov 2023 18:52:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc84c830-2c2d-40c0-af83-ac542480384a
+      - 709e750e-00d4-4ae7-b13c-cbe842720bee
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "726"
+      - "1170"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:07 GMT
+      - Thu, 02 Nov 2023 18:52:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa6fb709-5899-404b-879a-9563eae4e1ad
+      - 2001603d-56a3-49eb-aa52-b5d272ae9561
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571},"endpoints":[{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571}],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVSSs4c0ltWnM1eG9aWk9DanFCNGZ1NzNpNnl3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR5TlM0Mk5UQWVGdzB5Ck16RXhNREl4T0RVd05ESmFGdzB6TXpFd016QXhPRFV3TkRKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1qVXVOalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNxdEczcUJVYmZHV2V0Y09nV2JPSFpCclBQOTEzcC9SM1VBTGhZQ2Urc0M3OVBNUTRPUUJxN044TWoKY1ZYTzUwT3FNN2dxRkhxRUtSUGc2UG1Lc0Y4SEk4VFhlbmMzNVZ0U0U1MTJoZldZUW91emVCU3IrWGx3enBKRwpyTWNUNjhLNEJITXBhSWgxN3pvbzliN2RnKzhBRFF1ZS9YR0U3VkpwMjFiMDVjS3FaSU80aVFldG13YVR2dkRxCk5oMVRkOStaTmw0UDJ1YjQxODFtL0F6L3NsMUlkL2p4bTFQSEMvWDZTQkVNb0JHZG1ZcU03WjZmWDg5SlphRDYKRXpGSE5JRkZXc051SndPQXg5K0ViNWZIaDJDWnJJOFZKVWYzRDh1aStoOHk4RU52SDROL1play9yeXA0ZDlGSQpyL0pUL0ZWMnAyVzNhQWQxc0QzUjVPeG1uNFgvQWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHlOUzQyTllJOGNuY3RPVFF6TmpRNFlURXRNRFk0WXkwME16bG1MV0ZpWkRFdFpqUmpPRGRqT1dZMlptSTUKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpubkhLaHdRem54bEJNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFDTTh0TkR3VktoakpFVk9rN3l3VnF0clExRlNLUnIrT0R3Q1VhU2NIUHV1VW8yODVwZy9iRjVBaEowCkt3L2d4VmdYQTdxblB5cE5YdlBieEkvZktIakh3aE1DeXZnR2hld3RHWEpKbFRlbDNOT1poblFTaWt1dHY4MVMKVmZjMDNvTEZUMmpLc1VoUnJ3bHF5Nno0VjZJeVlaUnZoZEYvMll6K2Q0MGM4Sy9tTlJsak9HWHpoaEJQbEp4dQoyUGpwZzBxT05RNnlLeFJONENLdDdnZ3FCR1lJNDg4YTZ1ejB2OC90dmJYcENTZWowVmpINzlYOU9WMlBwTlJOCllva3dYZ1h4cHlra1h6eDV4dUh0eG9paGFQcnlqd0pvc2VGVnVkSjQ3eDlWMURydlpBS3FjZi8yTHZEZTl4YnEKcE1EU0xCdFZUVDlKdzFacUN1MWdUQm9obk1lSgotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1222"
+      - "1839"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:37 GMT
+      - Thu, 02 Nov 2023 18:52:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 921031d6-a5d9-4483-b055-1c29297059f3
+      - 0a73a26f-8a54-49c6-a30c-9928f1021e7c
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURxakNDQXBLZ0F3SUJBZ0lVUEdMekErRko3TzdDS3ZUK3F4WlBJZHlUNkcwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTBPREFlCkZ3MHlNekV3TWpBeE5qQXdNVFZhRncwek16RXdNVGN4TmpBd01UVmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5EZ3dnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRREJDMFlsQjJHenpGendDV0JuTFFDVWY1Z2NaVitPazdxN3MwWjZNS2l6OWdMWUxnWGgKdjZMYVlBOUlQMEMxczhTUndqV0ptMDVTbytwbHkyRldib0ZBdWNlWGxBNENOcHg2UmNmZjBHb3dSYnZtNEpxUQo4cDZpNTQvNVdYdktNSkpxVGZxSGUvWG1lQWFuWWl1YTdjVHpUNmNadHhtbXVyRDgwc0tSK1VwWmtQdE94eHRBCjEyZlVicWhWazA1VDhYRkhIbFJEZmJId1hBS3piTS8vUnZ0MWZoc251em41TGxpVndVMGhwWThRM1N5WC9ScVkKcWdNVU5Oc01NZ3d0QVErMGNuZUgzNG1ZZHo4ZEVVNk1iRGdnUHNnS0pDbE0xSHRNSFBtUjdacm1pSThNMlFQVQpzRldEL05iaC9zUGlWV2xBYWFCcW0yQzhaSTFvZmJsMG1oMnhBZ01CQUFHamFEQm1NR1FHQTFVZEVRUmRNRnVDCkR6RTVOUzR4TlRRdU1UazNMakkwT0lJOGNuY3RNbVpqTmpjNU5tRXRaVGd6WkMwME9UQTJMV0UzT1RBdE0yUTEKTW1Kak5HSXlPR1ZpTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOTBsaHdURG1zWDRNQTBHQ1NxRwpTSWIzRFFFQkN3VUFBNElCQVFDSmVrRVMvRFJvdmM1VndHMi81R09DeHdHZEVnVXFnRlBuQ3FBTU8zSUdWbU91CmhxUGpaTWx0OGxhcWZEbk05ektaMjhPWERsVHFTNTYzc3BDcm96eEdoRENPcFRpc3FSczdEUXh2amgwa0MvWDIKSWhDVjBGc21NVkt2Rms0aHpBRjRPQjBBdk5oeWRQRzJXY2ZsMFhPNTNobXo3Yy9jazRUV0s3N3NMck51UUdyZgpHbEp0WDl6SlE0djFvcjNob0JYMVgrZE43SEgzVGZ4MVdpVVdqMEZxVGJZeCt0MGZyY0JuZGpoR1p6QkpPd3FCCm9rL1RMYVdwOWJaemNTc0VlY1dkSjVieFRmSnBPK0hRc3hXNTFkd3VKMEVMRmxGdEhRMFVrbS91L1BJMUpGbmsKYWF5aFpPWTUvK1FrcjFucHE5ajIrbzRUTDNoS0QrY1Vka2JhbTYwMQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1857"
+      - "1170"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:37 GMT
+      - Thu, 02 Nov 2023 18:52:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf7df04e-06eb-4ca3-ae31-55d21b905f30
+      - 260f1f3e-730f-4f35-a07d-5e7deacb95f0
     status: 200 OK
     code: 200
     duration: ""
@@ -638,19 +638,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571},"endpoints":[{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571}],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1222"
+      - "1170"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:37 GMT
+      - Thu, 02 Nov 2023 18:52:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -660,40 +660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0de4581b-1fa7-4c1d-a580-b10156edc806
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571},"endpoints":[{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571}],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1222"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:02:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 863460f2-ed61-490c-bb03-9e595ed3f211
+      - 653354a7-9013-44a6-9356-bbfb691e4659
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/users
     method: POST
   response:
     body: '{"is_admin":false,"name":"bug"}'
     headers:
       Content-Length:
-      - "32"
+      - "31"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:37 GMT
+      - Thu, 02 Nov 2023 18:52:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35c11930-0fba-4355-ae8a-3dbc655b12a5
+      - 6fb1df89-58f1-4f69-b450-d3c0af0947ba
     status: 200 OK
     code: 200
     duration: ""
@@ -741,19 +708,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/databases
     method: POST
   response:
     body: '{"managed":true,"name":"bug","owner":"","size":0}'
     headers:
       Content-Length:
-      - "52"
+      - "49"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:37 GMT
+      - Thu, 02 Nov 2023 18:52:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +730,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42a36adf-94ca-46a3-bdcf-036e32d0f34a
+      - b50db6fe-d9bf-49bd-b86e-789d4e84151c
     status: 200 OK
     code: 200
     duration: ""
@@ -774,19 +741,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571},"endpoints":[{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571}],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1222"
+      - "1170"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:37 GMT
+      - Thu, 02 Nov 2023 18:52:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +763,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d984763e-0932-41cd-a3b3-af85829d9285
+      - 421e3643-0964-4117-81ef-1bae2c5c901b
     status: 200 OK
     code: 200
     duration: ""
@@ -807,19 +774,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571},"endpoints":[{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571}],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1222"
+      - "1170"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:37 GMT
+      - Thu, 02 Nov 2023 18:52:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a71ea564-6912-455a-aea6-bbb901f356de
+      - 20c46eb4-365c-44ca-a799-5e54b4464be4
     status: 200 OK
     code: 200
     duration: ""
@@ -840,19 +807,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb/users?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/users?name=bug&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bug"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:38 GMT
+      - Thu, 02 Nov 2023 18:52:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6afe564b-8c3a-4ca3-bd78-34f2c8496a97
+      - d6f0cbe0-737a-48d5-b40f-16bc4ca862c0
     status: 200 OK
     code: 200
     duration: ""
@@ -873,19 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb/databases?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/databases?name=bug&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"bug","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:38 GMT
+      - Thu, 02 Nov 2023 18:52:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7719adda-9929-45af-8fa7-20ceb4ac3e7c
+      - b85da48f-c32b-4ce9-afb7-a54604d0fbbd
     status: 200 OK
     code: 200
     duration: ""
@@ -906,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571},"endpoints":[{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571}],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1222"
+      - "1170"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:38 GMT
+      - Thu, 02 Nov 2023 18:52:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67f68570-e55f-4978-8fb4-26f5e4e44521
+      - d0e90bb8-65dd-4f22-8b47-8d5fab990ebe
     status: 200 OK
     code: 200
     duration: ""
@@ -941,19 +908,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/privileges
     method: PUT
   response:
     body: '{"database_name":"bug","permission":"all","user_name":"bug"}'
     headers:
       Content-Length:
-      - "62"
+      - "60"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:38 GMT
+      - Thu, 02 Nov 2023 18:52:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -963,7 +930,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c6ed4d6-587d-4504-8b34-557da3a8895a
+      - ad002d95-2fbf-4430-b8a7-835ec81623ec
     status: 200 OK
     code: 200
     duration: ""
@@ -974,19 +941,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571},"endpoints":[{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571}],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1222"
+      - "1170"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:38 GMT
+      - Thu, 02 Nov 2023 18:52:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -996,7 +963,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7435e2e5-afe3-459d-b4b9-dcfdb7a48c71
+      - e540150e-4aef-4bad-b6e1-d8bc02b241ab
     status: 200 OK
     code: 200
     duration: ""
@@ -1007,19 +974,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571},"endpoints":[{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571}],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1222"
+      - "1170"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:38 GMT
+      - Thu, 02 Nov 2023 18:52:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1029,7 +996,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de60cb73-effd-4a2c-aab4-4d16ccebd983
+      - 417b1454-5457-4f9b-b7a6-eb866e46b109
     status: 200 OK
     code: 200
     duration: ""
@@ -1040,19 +1007,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb/users?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/users?name=bug&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bug"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:38 GMT
+      - Thu, 02 Nov 2023 18:52:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1062,7 +1029,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9b75b3f-1e64-44ef-9cf6-6a7f4ef2aed1
+      - da60b52b-51bc-4591-b0da-725f286f01d5
     status: 200 OK
     code: 200
     duration: ""
@@ -1073,19 +1040,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb/privileges?database_name=bug&order_by=user_name_asc&user_name=bug
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/privileges?database_name=bug&order_by=user_name_asc&user_name=bug
     method: GET
   response:
     body: '{"privileges":[{"database_name":"bug","permission":"all","user_name":"bug"}],"total_count":1}'
     headers:
       Content-Length:
-      - "96"
+      - "93"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:39 GMT
+      - Thu, 02 Nov 2023 18:52:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1095,7 +1062,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6942566b-ec37-4680-a7cb-44b9c5a20eab
+      - 72dd32af-1747-4675-97eb-3187ec596e25
     status: 200 OK
     code: 200
     duration: ""
@@ -1106,19 +1073,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb/databases?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/databases?name=bug&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"bug","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:39 GMT
+      - Thu, 02 Nov 2023 18:52:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1128,7 +1095,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5a89ee9-6fe8-4e66-9b1e-2b817a3c2337
+      - 9a3dbc87-c1d9-4612-9ca9-1d4c0bc1ecf8
     status: 200 OK
     code: 200
     duration: ""
@@ -1139,19 +1106,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571},"endpoints":[{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571}],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1222"
+      - "1170"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:39 GMT
+      - Thu, 02 Nov 2023 18:52:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1161,7 +1128,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd95d802-72b3-418b-b068-9399d8000c59
+      - 7ece9296-3678-445d-9a0a-239da2eb6928
     status: 200 OK
     code: 200
     duration: ""
@@ -1172,19 +1139,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURxakNDQXBLZ0F3SUJBZ0lVUEdMekErRko3TzdDS3ZUK3F4WlBJZHlUNkcwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTBPREFlCkZ3MHlNekV3TWpBeE5qQXdNVFZhRncwek16RXdNVGN4TmpBd01UVmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5EZ3dnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRREJDMFlsQjJHenpGendDV0JuTFFDVWY1Z2NaVitPazdxN3MwWjZNS2l6OWdMWUxnWGgKdjZMYVlBOUlQMEMxczhTUndqV0ptMDVTbytwbHkyRldib0ZBdWNlWGxBNENOcHg2UmNmZjBHb3dSYnZtNEpxUQo4cDZpNTQvNVdYdktNSkpxVGZxSGUvWG1lQWFuWWl1YTdjVHpUNmNadHhtbXVyRDgwc0tSK1VwWmtQdE94eHRBCjEyZlVicWhWazA1VDhYRkhIbFJEZmJId1hBS3piTS8vUnZ0MWZoc251em41TGxpVndVMGhwWThRM1N5WC9ScVkKcWdNVU5Oc01NZ3d0QVErMGNuZUgzNG1ZZHo4ZEVVNk1iRGdnUHNnS0pDbE0xSHRNSFBtUjdacm1pSThNMlFQVQpzRldEL05iaC9zUGlWV2xBYWFCcW0yQzhaSTFvZmJsMG1oMnhBZ01CQUFHamFEQm1NR1FHQTFVZEVRUmRNRnVDCkR6RTVOUzR4TlRRdU1UazNMakkwT0lJOGNuY3RNbVpqTmpjNU5tRXRaVGd6WkMwME9UQTJMV0UzT1RBdE0yUTEKTW1Kak5HSXlPR1ZpTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOTBsaHdURG1zWDRNQTBHQ1NxRwpTSWIzRFFFQkN3VUFBNElCQVFDSmVrRVMvRFJvdmM1VndHMi81R09DeHdHZEVnVXFnRlBuQ3FBTU8zSUdWbU91CmhxUGpaTWx0OGxhcWZEbk05ektaMjhPWERsVHFTNTYzc3BDcm96eEdoRENPcFRpc3FSczdEUXh2amgwa0MvWDIKSWhDVjBGc21NVkt2Rms0aHpBRjRPQjBBdk5oeWRQRzJXY2ZsMFhPNTNobXo3Yy9jazRUV0s3N3NMck51UUdyZgpHbEp0WDl6SlE0djFvcjNob0JYMVgrZE43SEgzVGZ4MVdpVVdqMEZxVGJZeCt0MGZyY0JuZGpoR1p6QkpPd3FCCm9rL1RMYVdwOWJaemNTc0VlY1dkSjVieFRmSnBPK0hRc3hXNTFkd3VKMEVMRmxGdEhRMFVrbS91L1BJMUpGbmsKYWF5aFpPWTUvK1FrcjFucHE5ajIrbzRUTDNoS0QrY1Vka2JhbTYwMQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVSSs4c0ltWnM1eG9aWk9DanFCNGZ1NzNpNnl3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR5TlM0Mk5UQWVGdzB5Ck16RXhNREl4T0RVd05ESmFGdzB6TXpFd016QXhPRFV3TkRKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1qVXVOalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNxdEczcUJVYmZHV2V0Y09nV2JPSFpCclBQOTEzcC9SM1VBTGhZQ2Urc0M3OVBNUTRPUUJxN044TWoKY1ZYTzUwT3FNN2dxRkhxRUtSUGc2UG1Lc0Y4SEk4VFhlbmMzNVZ0U0U1MTJoZldZUW91emVCU3IrWGx3enBKRwpyTWNUNjhLNEJITXBhSWgxN3pvbzliN2RnKzhBRFF1ZS9YR0U3VkpwMjFiMDVjS3FaSU80aVFldG13YVR2dkRxCk5oMVRkOStaTmw0UDJ1YjQxODFtL0F6L3NsMUlkL2p4bTFQSEMvWDZTQkVNb0JHZG1ZcU03WjZmWDg5SlphRDYKRXpGSE5JRkZXc051SndPQXg5K0ViNWZIaDJDWnJJOFZKVWYzRDh1aStoOHk4RU52SDROL1play9yeXA0ZDlGSQpyL0pUL0ZWMnAyVzNhQWQxc0QzUjVPeG1uNFgvQWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHlOUzQyTllJOGNuY3RPVFF6TmpRNFlURXRNRFk0WXkwME16bG1MV0ZpWkRFdFpqUmpPRGRqT1dZMlptSTUKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpubkhLaHdRem54bEJNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFDTTh0TkR3VktoakpFVk9rN3l3VnF0clExRlNLUnIrT0R3Q1VhU2NIUHV1VW8yODVwZy9iRjVBaEowCkt3L2d4VmdYQTdxblB5cE5YdlBieEkvZktIakh3aE1DeXZnR2hld3RHWEpKbFRlbDNOT1poblFTaWt1dHY4MVMKVmZjMDNvTEZUMmpLc1VoUnJ3bHF5Nno0VjZJeVlaUnZoZEYvMll6K2Q0MGM4Sy9tTlJsak9HWHpoaEJQbEp4dQoyUGpwZzBxT05RNnlLeFJONENLdDdnZ3FCR1lJNDg4YTZ1ejB2OC90dmJYcENTZWowVmpINzlYOU9WMlBwTlJOCllva3dYZ1h4cHlra1h6eDV4dUh0eG9paGFQcnlqd0pvc2VGVnVkSjQ3eDlWMURydlpBS3FjZi8yTHZEZTl4YnEKcE1EU0xCdFZUVDlKdzFacUN1MWdUQm9obk1lSgotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1857"
+      - "1839"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:40 GMT
+      - Thu, 02 Nov 2023 18:52:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1194,7 +1161,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bbef844-ac0a-4904-82d3-461e85be8d28
+      - f7ae2d34-2734-47d8-91d0-b38298f4f7c2
     status: 200 OK
     code: 200
     duration: ""
@@ -1205,19 +1172,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb/databases?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1170"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:52:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 010532da-4653-4acf-bee2-f38e064ee7ed
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/databases?name=bug&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"bug","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:40 GMT
+      - Thu, 02 Nov 2023 18:52:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1227,7 +1227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b26d404-e03f-4c5d-9291-13b395405011
+      - dafa363e-280b-4aed-83c8-731d3cdd4a26
     status: 200 OK
     code: 200
     duration: ""
@@ -1238,52 +1238,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571},"endpoints":[{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571}],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1222"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:02:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7a656b81-571f-42bd-8c73-16634597e52c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb/users?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/users?name=bug&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bug"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:40 GMT
+      - Thu, 02 Nov 2023 18:52:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1293,7 +1260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d474204-b8f2-4cbe-9770-41fc2e80ec2b
+      - 92711829-21af-4aca-b3da-b16477ec38cd
     status: 200 OK
     code: 200
     duration: ""
@@ -1304,19 +1271,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571},"endpoints":[{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571}],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1222"
+      - "1170"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:40 GMT
+      - Thu, 02 Nov 2023 18:52:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1326,7 +1293,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1660d7df-1201-4724-b972-c8ffbe472168
+      - 6cd780e3-36c5-48f8-a99d-4f080da60a5d
     status: 200 OK
     code: 200
     duration: ""
@@ -1337,19 +1304,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb/users?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/users?name=bug&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bug"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:40 GMT
+      - Thu, 02 Nov 2023 18:52:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1359,7 +1326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9abd606-92f0-4aa5-acfd-492a9b50da9d
+      - c65671a1-1eeb-4b69-9129-04d056493fa8
     status: 200 OK
     code: 200
     duration: ""
@@ -1370,19 +1337,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb/privileges?database_name=bug&order_by=user_name_asc&user_name=bug
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/privileges?database_name=bug&order_by=user_name_asc&user_name=bug
     method: GET
   response:
     body: '{"privileges":[{"database_name":"bug","permission":"all","user_name":"bug"}],"total_count":1}'
     headers:
       Content-Length:
-      - "96"
+      - "93"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:41 GMT
+      - Thu, 02 Nov 2023 18:52:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1392,7 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 590df63f-0d65-4ad9-a4b8-3bc76109607e
+      - 982009e1-a159-47f9-9157-5b4cbf4348fb
     status: 200 OK
     code: 200
     duration: ""
@@ -1403,19 +1370,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571},"endpoints":[{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571}],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1222"
+      - "1170"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:42 GMT
+      - Thu, 02 Nov 2023 18:52:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1425,7 +1392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 340dca75-fd1a-4daa-a25c-3a4269428801
+      - 65873be7-de7f-4601-b3d1-6219df258743
     status: 200 OK
     code: 200
     duration: ""
@@ -1436,52 +1403,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb/users?name=bug&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"bug"}]}'
-    headers:
-      Content-Length:
-      - "61"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:02:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 412f6c29-b6bd-4f66-aa3d-c45c1b873e76
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb/users?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/users?name=bug&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bug"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:42 GMT
+      - Thu, 02 Nov 2023 18:52:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1491,7 +1425,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d46faebc-597d-4490-925a-1c5cb74e6eb1
+      - 0dfe9f97-0f59-49d4-b771-0a4be411db0f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/users?name=bug&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"bug"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:52:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 25591045-bb5b-4423-8fd8-ef2863f3dc83
     status: 200 OK
     code: 200
     duration: ""
@@ -1504,19 +1471,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/privileges
     method: PUT
   response:
     body: '{"database_name":"bug","permission":"none","user_name":"bug"}'
     headers:
       Content-Length:
-      - "63"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:42 GMT
+      - Thu, 02 Nov 2023 18:52:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1526,7 +1493,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a77af84-6c2f-4df1-b222-74a4221e0cf0
+      - ce2fbe21-f292-43c7-9c4a-a25928534cd6
     status: 200 OK
     code: 200
     duration: ""
@@ -1537,19 +1504,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571},"endpoints":[{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571}],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1222"
+      - "1170"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:42 GMT
+      - Thu, 02 Nov 2023 18:52:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1559,7 +1526,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77476aa9-5376-4d93-9235-5c314a83fff0
+      - 35e2adf2-b9f8-45c3-9391-d73b7323b48b
     status: 200 OK
     code: 200
     duration: ""
@@ -1570,19 +1537,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571},"endpoints":[{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571}],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1222"
+      - "1170"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:43 GMT
+      - Thu, 02 Nov 2023 18:52:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1592,7 +1559,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27f566f5-2af6-4ecd-adf1-c36a1806fa00
+      - 01df8188-15cf-4b86-85a4-dfa02ae1f5a7
     status: 200 OK
     code: 200
     duration: ""
@@ -1603,19 +1570,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571},"endpoints":[{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571}],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1222"
+      - "1170"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:43 GMT
+      - Thu, 02 Nov 2023 18:52:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1625,7 +1592,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 015b0a05-fb1f-4f11-b3aa-e2beb4ffa981
+      - 1b0727e1-5820-49aa-9f9e-9537bcfc7eaf
     status: 200 OK
     code: 200
     duration: ""
@@ -1636,7 +1603,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb/users/bug
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/users/bug
     method: DELETE
   response:
     body: ""
@@ -1646,7 +1613,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:43 GMT
+      - Thu, 02 Nov 2023 18:52:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1656,7 +1623,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c22822a-a07b-49b7-810b-9163cf4c0bbd
+      - 4c4b5eda-49d2-41d2-9f70-c79c52905834
     status: 204 No Content
     code: 204
     duration: ""
@@ -1667,7 +1634,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb/databases/bug
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/databases/bug
     method: DELETE
   response:
     body: ""
@@ -1677,7 +1644,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:43 GMT
+      - Thu, 02 Nov 2023 18:53:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1687,7 +1654,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edcf24c8-d3d8-426d-9317-f5c9b49c9a2a
+      - a3b69253-056a-4d5c-9fbe-071cdf076220
     status: 204 No Content
     code: 204
     duration: ""
@@ -1698,19 +1665,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571},"endpoints":[{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571}],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1222"
+      - "1170"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:43 GMT
+      - Thu, 02 Nov 2023 18:53:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1720,7 +1687,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c7d087d-c393-489a-b630-476256e4b260
+      - a95030d1-d17a-4cb2-b360-ae63e393ed3e
     status: 200 OK
     code: 200
     duration: ""
@@ -1731,19 +1698,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571},"endpoints":[{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571}],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1222"
+      - "1170"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:44 GMT
+      - Thu, 02 Nov 2023 18:53:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1753,7 +1720,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5019f3f4-dc76-4bab-99da-e1395b66ba40
+      - 643fb9cf-f5c1-4903-a0da-ccf00f748e39
     status: 200 OK
     code: 200
     duration: ""
@@ -1764,19 +1731,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571},"endpoints":[{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571}],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1225"
+      - "1173"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:44 GMT
+      - Thu, 02 Nov 2023 18:53:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1786,7 +1753,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 814efd7a-5f8d-46f8-a001-5682a8fa498e
+      - 308cf78f-1590-4d71-b16c-fcb5c36cf331
     status: 200 OK
     code: 200
     duration: ""
@@ -1797,19 +1764,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:59:36.256052Z","endpoint":{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571},"endpoints":[{"id":"2d9337c2-2de3-485c-b512-a456500fedf7","ip":"195.154.197.248","load_balancer":{},"name":null,"port":21571}],"engine":"PostgreSQL-15","id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1225"
+      - "1173"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:44 GMT
+      - Thu, 02 Nov 2023 18:53:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1819,7 +1786,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96d8256e-0aff-43af-8ed1-12e2e4ef8e22
+      - 0fdb35bf-174b-4b5e-b2e8-12e69058c154
     status: 200 OK
     code: 200
     duration: ""
@@ -1830,10 +1797,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1842,7 +1809,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:14 GMT
+      - Thu, 02 Nov 2023 18:53:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1852,7 +1819,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c440cb02-4011-40d8-92d8-7a66615f3b5b
+      - b7c16a61-152c-46e9-b112-b2bcf47e48ae
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1863,10 +1830,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2fc6796a-e83d-4906-a790-3d52bc4b28eb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"2fc6796a-e83d-4906-a790-3d52bc4b28eb","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1875,7 +1842,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:14 GMT
+      - Thu, 02 Nov 2023 18:53:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1885,7 +1852,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 591ac65f-03ae-47c8-9bd7-603674aa0668
+      - 6d45bcb4-e93a-4650-8889-2fd624d88eab
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-backup-schedule.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-backup-schedule.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:07 GMT
+      - Thu, 02 Nov 2023 18:46:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 550e3d78-2460-4e58-b547-584f501b2c2a
+      - c5538dfa-c3dc-4a76-8a9f-05b865b5f97a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_instance","volume"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_instance","volume"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T16:02:23.377944Z","retention":7},"created_at":"2023-10-20T16:02:23.377944Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4ed20cfa-80bd-4eb1-934c-ff2d54efda01","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:57:36.054032Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "802"
+      - "773"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:23 GMT
+      - Thu, 02 Nov 2023 18:57:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5152ac74-2eec-4564-a109-3fb8c8ce662a
+      - 3e9a7a99-7c0a-4578-bc3c-6f6bf531f152
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4ed20cfa-80bd-4eb1-934c-ff2d54efda01
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T16:02:23.377944Z","retention":7},"created_at":"2023-10-20T16:02:23.377944Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4ed20cfa-80bd-4eb1-934c-ff2d54efda01","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:57:36.054032Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "802"
+      - "773"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:23 GMT
+      - Thu, 02 Nov 2023 18:57:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3d7c52b-d854-4659-ac22-6606742b7916
+      - cef47a51-3483-404d-afb6-8254484b4332
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4ed20cfa-80bd-4eb1-934c-ff2d54efda01
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T16:02:23.377944Z","retention":7},"created_at":"2023-10-20T16:02:23.377944Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4ed20cfa-80bd-4eb1-934c-ff2d54efda01","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:57:36.054032Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "802"
+      - "773"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:53 GMT
+      - Thu, 02 Nov 2023 18:58:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - faf5bfc4-9ba2-4ea1-88f6-f0b4190c3592
+      - b98fc3e4-0722-4a5f-aaf6-b1a283f821f6
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4ed20cfa-80bd-4eb1-934c-ff2d54efda01
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T16:02:23.377944Z","retention":7},"created_at":"2023-10-20T16:02:23.377944Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4ed20cfa-80bd-4eb1-934c-ff2d54efda01","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:57:36.054032Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "802"
+      - "773"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:24 GMT
+      - Thu, 02 Nov 2023 18:58:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d0b32e0-d335-4dac-a44e-62dfee9cfba5
+      - c7c521a9-b46e-49e4-828f-44ad2110c6ef
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4ed20cfa-80bd-4eb1-934c-ff2d54efda01
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T16:02:23.377944Z","retention":7},"created_at":"2023-10-20T16:02:23.377944Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4ed20cfa-80bd-4eb1-934c-ff2d54efda01","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:57:36.054032Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "802"
+      - "773"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:54 GMT
+      - Thu, 02 Nov 2023 18:59:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42960e7c-1935-43d5-8a3b-f42309b4e552
+      - cdf93da3-02e3-4d23-98d7-3e35ab3b6be1
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4ed20cfa-80bd-4eb1-934c-ff2d54efda01
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T16:02:23.377944Z","retention":7},"created_at":"2023-10-20T16:02:23.377944Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4ed20cfa-80bd-4eb1-934c-ff2d54efda01","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:57:36.054032Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "802"
+      - "773"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:04:24 GMT
+      - Thu, 02 Nov 2023 18:59:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f074e989-d3de-4a74-a006-454e5cfa5718
+      - 5a1cf67f-4093-40fd-aa6b-b37c506ea402
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4ed20cfa-80bd-4eb1-934c-ff2d54efda01
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T16:02:23.377944Z","retention":7},"created_at":"2023-10-20T16:02:23.377944Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4ed20cfa-80bd-4eb1-934c-ff2d54efda01","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:57:36.054032Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794},"endpoints":[{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794}],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "802"
+      - "1246"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:04:54 GMT
+      - Thu, 02 Nov 2023 19:00:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,45 +561,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3e1012a-b3a7-4dfa-97b6-dbbb49712837
+      - aebca7fd-2fe5-44c8-a8ea-0af44a27194f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4ed20cfa-80bd-4eb1-934c-ff2d54efda01
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T16:02:23.377944Z","retention":7},"created_at":"2023-10-20T16:02:23.377944Z","endpoint":{"id":"16755eae-5ba2-48cf-b121-bda947c7ddb3","ip":"51.158.210.44","load_balancer":{},"name":null,"port":10509},"endpoints":[{"id":"16755eae-5ba2-48cf-b121-bda947c7ddb3","ip":"51.158.210.44","load_balancer":{},"name":null,"port":10509}],"engine":"PostgreSQL-15","id":"4ed20cfa-80bd-4eb1-934c-ff2d54efda01","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1294"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:05:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f1aff094-074a-45ee-a8cd-5ea2b1dd3acf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"backup_schedule_frequency":24,"backup_schedule_retention":7,"is_backup_schedule_disabled":false,"name":null,"tags":null,"logs_policy":null,"backup_same_region":true,"backup_schedule_start_hour":null}'
+    body: '{"backup_schedule_frequency":24,"backup_schedule_retention":7,"is_backup_schedule_disabled":false,"backup_same_region":true}'
     form: {}
     headers:
       Content-Type:
@@ -607,19 +574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4ed20cfa-80bd-4eb1-934c-ff2d54efda01
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
     method: PATCH
   response:
-    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T16:05:25.279453Z","retention":7},"created_at":"2023-10-20T16:02:23.377944Z","endpoint":{"id":"16755eae-5ba2-48cf-b121-bda947c7ddb3","ip":"51.158.210.44","load_balancer":{},"name":null,"port":10509},"endpoints":[{"id":"16755eae-5ba2-48cf-b121-bda947c7ddb3","ip":"51.158.210.44","load_balancer":{},"name":null,"port":10509}],"engine":"PostgreSQL-15","id":"4ed20cfa-80bd-4eb1-934c-ff2d54efda01","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T19:00:07.360312Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794},"endpoints":[{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794}],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:25 GMT
+      - Thu, 02 Nov 2023 19:00:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4efcb2df-ee8a-4fa0-bddf-62635306ccd2
+      - 3d1d71b8-4eb6-4b94-9089-0ad629e03ac7
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4ed20cfa-80bd-4eb1-934c-ff2d54efda01
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
     method: GET
   response:
-    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T16:05:25.279453Z","retention":7},"created_at":"2023-10-20T16:02:23.377944Z","endpoint":{"id":"16755eae-5ba2-48cf-b121-bda947c7ddb3","ip":"51.158.210.44","load_balancer":{},"name":null,"port":10509},"endpoints":[{"id":"16755eae-5ba2-48cf-b121-bda947c7ddb3","ip":"51.158.210.44","load_balancer":{},"name":null,"port":10509}],"engine":"PostgreSQL-15","id":"4ed20cfa-80bd-4eb1-934c-ff2d54efda01","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T19:00:07.360312Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794},"endpoints":[{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794}],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:25 GMT
+      - Thu, 02 Nov 2023 19:00:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 957b2ff3-3fa8-4fb6-a413-25e207fe39ea
+      - 09f464e8-7668-4893-905a-6d3efeb01695
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4ed20cfa-80bd-4eb1-934c-ff2d54efda01/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSWl6TUxzV2MvdzJOdjREYlBhRFlOdmZ2RS9rd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzR5TVRBdU5EUXdIaGNOCk1qTXhNREl3TVRZd01qVTRXaGNOTXpNeE1ERTNNVFl3TWpVNFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqSXhNQzQwTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU8zdWRLMit0M3NDS1lJallTcmNLSjN3YmJFaWE3N245U3JLVURVMlBQUDlqZ2JyNUV3d3kyZ0MKU1B4WUV4MzFkb2Z3SUFaUnpHN3hrZm93d3FDcTNPKzdkUFpxbHU3Zy9SK3FXaTZKVWJTeHI3V2pWcWRtOURvTgpWQjBNeUNMU0NJOXhqTjhVdTJldENMQ1RsSERDbUJ1U3QxZURUUzNLVGlxRStRNVZUOXlsR2ZqQ1NkUzhic3IyCmlrYUhURktCV2FEdVpMZnJSdkhIeEJMeDBHa292a1RkOEpWWmxzeDRUZlVDbGJtd2JWdXNSdHZUV3l6UU9ESGwKU3ArZDNiVGdvOEdUdk5HSWt6N2pOUFlRRVBlc2RhUnBNZ0ZWNEo1a2pTWXdtWjRBdHZ4UXM3bExWTC8waGlCVwpZbWZLSU5sZVRhTjBaZStua2pSL1hMc0ZpR25TcWJNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMakl4TUM0ME5JSThjbmN0TkdWa01qQmpabUV0T0RCaVpDMDBaV0l4TFRrek5HTXRabVl5WkRVMFpXWmsKWVRBeExuSmtZaTV1YkMxaGJYTXVjMk4zTG1Oc2IzVmtod1F6RHp4d2h3UXpudElzTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQzQ0QnNYWjVWa3U3VUNibGkvTjdhaHRldVVkd21nM3JSeEsyaXF1a3hCaVpnQkltUEdxRlFjClJOelRCRVRzQzFwME5SWXkzOWVmSU0vZk5uVGZoN0FDa3RBMnJxVFQ1U1VpNGlXNkNtNnpFRTZNdmtxbHVVWlYKd1RMK2JFN1ZtRkZYd2RmcVZlY09RQWZoenZRSGI1NWxNOEdrdEZaMTJWbEkwOVNrWWJhZWNIREhvcVhpQXFLcQpYNWxKNjBWb1hLRWNqWnd4NjBmdXV4bmxTekY1RDVVSS95K0JpUnUzMDMyNTZTTVdrNE1tN0UzT2JxQjV6YmI0CnVHUTFTbldYZG9qTXFWRlptTS9lMERPdE54WllzWUpyYXZReExtVUYvd3ZPTElwR0J1Wk8zSDNXeGVnMzRPbWUKdndUTXRudndUK1NLKy8yT3JLVXc3TU5oUUpMUkNieDUKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSm90MVRXZUcwRnY1NS9keEpHZ05jL0JwSEs0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpBdU1qQXlNQjRYCkRUSXpNVEV3TWpFNE5UZ3hNVm9YRFRNek1UQXpNREU0TlRneE1Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekF1TWpBeU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXBZKzN5SHdnWUtUM1ppc3hjREppS3p1TCtpc3hEK3FaS0xKMjRlQ0JUSGs4ajkvV3dtWHgKSTNhTFhJMm1LcTRGaDN0MzRLSU1EaWgvL2oyTm9MVVJJbVc4bG5BNHA2MVZKb3FxbUxqNVgweXlwVDg1MEg1ZgpMM2lMYXpPV3FPeElHemxqclNYUUgzZk13bHFPYjNpc0FUMi9XVE4vbzMrRGRVaWdwa21ib3NUaHV3UFVvRGt1Clc5dWQzZ0s4S1dOODRsc0duM0VrVjBqQk5OR1VKaUM1RnNZSzBBNmJVeTVJYnlPd2pHZ3QzMktiVWxod2JJY2MKbEZ1cGVkZWpPZ2ptaEY4dUhoNFArVDUzMnU2QnREN3VObjJlT2kzZlp6ZG9rM0dMeDMxcnkrdkJrVXFFRmFVawpvSFZCUWVDTkR6SmM2YU0xbmI4MWtXcko1Q3k1c1diWVlRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNd0xqSXdNb0k4Y25jdFlUWmtZekl5T0RrdE9UazROQzAwTUdVNUxUbGpObVV0TXpZeE9HTTAKT0RCaE5XUmpMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekQxeTNod1F6bm9MS01BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJTcUl4YzBHbDVab0k3YkxjR1Njb3B3bUF5RUo1eUYzMzlUUndlMGVHZXhIQnRvS1huCk9IYm5VMUQxTTU2UytYK1E1TTVmQ2V3K2hXQ2dIYXh6V1pzY1dGeWRhWS9iTUpaV0REMzZYOUk0bnNvY0NhVlAKc1FRS1dGVVdUWldPRURSMDhkbTNIMldtK0w5aWZuQ2xCczAvVktjSmthTU44c01iaU5pNW5rQlBCbDdiWVZqMgp0Z1BpTUIyWGkxRkc0SndVQlcrRGJpTzAvVFFlZlpDSklsa01sZ2ZOMnc1RWFjdXExRkorRTQ4R29zNmlWd0h2CmJ1VU4wY3BYNVM3RENlU09IcnNZTXNNQjBxejlJbkR2U3BlMXBwRmgyOUVydjhaNVh5VmRER3U0ZkFFQzk1Y0IKb0hXQlZQUnZRKzZScThZUHF6dmJxWXhyWVgwL3hpNGIyTlh4Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1847"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:25 GMT
+      - Thu, 02 Nov 2023 19:00:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf634332-6ddf-4fb3-b49c-ff14e63e43f3
+      - 96b0bd4d-74f1-48d9-a05a-98060df3b1bb
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4ed20cfa-80bd-4eb1-934c-ff2d54efda01
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
     method: GET
   response:
-    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T16:05:25.279453Z","retention":7},"created_at":"2023-10-20T16:02:23.377944Z","endpoint":{"id":"16755eae-5ba2-48cf-b121-bda947c7ddb3","ip":"51.158.210.44","load_balancer":{},"name":null,"port":10509},"endpoints":[{"id":"16755eae-5ba2-48cf-b121-bda947c7ddb3","ip":"51.158.210.44","load_balancer":{},"name":null,"port":10509}],"engine":"PostgreSQL-15","id":"4ed20cfa-80bd-4eb1-934c-ff2d54efda01","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T19:00:07.360312Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794},"endpoints":[{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794}],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:26 GMT
+      - Thu, 02 Nov 2023 19:00:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6d0813d-6a56-40b9-9c24-b93f97cbfe10
+      - 27d3188a-130c-49c9-abce-a688efa94931
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4ed20cfa-80bd-4eb1-934c-ff2d54efda01
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
     method: GET
   response:
-    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T16:05:25.279453Z","retention":7},"created_at":"2023-10-20T16:02:23.377944Z","endpoint":{"id":"16755eae-5ba2-48cf-b121-bda947c7ddb3","ip":"51.158.210.44","load_balancer":{},"name":null,"port":10509},"endpoints":[{"id":"16755eae-5ba2-48cf-b121-bda947c7ddb3","ip":"51.158.210.44","load_balancer":{},"name":null,"port":10509}],"engine":"PostgreSQL-15","id":"4ed20cfa-80bd-4eb1-934c-ff2d54efda01","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T19:00:07.360312Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794},"endpoints":[{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794}],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:26 GMT
+      - Thu, 02 Nov 2023 19:00:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6aa20e99-fd35-484c-9c24-8230cbf6c87e
+      - c1b9a980-2ce5-46aa-a3d3-0e8a08ca1b06
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4ed20cfa-80bd-4eb1-934c-ff2d54efda01/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSWl6TUxzV2MvdzJOdjREYlBhRFlOdmZ2RS9rd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzR5TVRBdU5EUXdIaGNOCk1qTXhNREl3TVRZd01qVTRXaGNOTXpNeE1ERTNNVFl3TWpVNFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqSXhNQzQwTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU8zdWRLMit0M3NDS1lJallTcmNLSjN3YmJFaWE3N245U3JLVURVMlBQUDlqZ2JyNUV3d3kyZ0MKU1B4WUV4MzFkb2Z3SUFaUnpHN3hrZm93d3FDcTNPKzdkUFpxbHU3Zy9SK3FXaTZKVWJTeHI3V2pWcWRtOURvTgpWQjBNeUNMU0NJOXhqTjhVdTJldENMQ1RsSERDbUJ1U3QxZURUUzNLVGlxRStRNVZUOXlsR2ZqQ1NkUzhic3IyCmlrYUhURktCV2FEdVpMZnJSdkhIeEJMeDBHa292a1RkOEpWWmxzeDRUZlVDbGJtd2JWdXNSdHZUV3l6UU9ESGwKU3ArZDNiVGdvOEdUdk5HSWt6N2pOUFlRRVBlc2RhUnBNZ0ZWNEo1a2pTWXdtWjRBdHZ4UXM3bExWTC8waGlCVwpZbWZLSU5sZVRhTjBaZStua2pSL1hMc0ZpR25TcWJNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMakl4TUM0ME5JSThjbmN0TkdWa01qQmpabUV0T0RCaVpDMDBaV0l4TFRrek5HTXRabVl5WkRVMFpXWmsKWVRBeExuSmtZaTV1YkMxaGJYTXVjMk4zTG1Oc2IzVmtod1F6RHp4d2h3UXpudElzTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQzQ0QnNYWjVWa3U3VUNibGkvTjdhaHRldVVkd21nM3JSeEsyaXF1a3hCaVpnQkltUEdxRlFjClJOelRCRVRzQzFwME5SWXkzOWVmSU0vZk5uVGZoN0FDa3RBMnJxVFQ1U1VpNGlXNkNtNnpFRTZNdmtxbHVVWlYKd1RMK2JFN1ZtRkZYd2RmcVZlY09RQWZoenZRSGI1NWxNOEdrdEZaMTJWbEkwOVNrWWJhZWNIREhvcVhpQXFLcQpYNWxKNjBWb1hLRWNqWnd4NjBmdXV4bmxTekY1RDVVSS95K0JpUnUzMDMyNTZTTVdrNE1tN0UzT2JxQjV6YmI0CnVHUTFTbldYZG9qTXFWRlptTS9lMERPdE54WllzWUpyYXZReExtVUYvd3ZPTElwR0J1Wk8zSDNXeGVnMzRPbWUKdndUTXRudndUK1NLKy8yT3JLVXc3TU5oUUpMUkNieDUKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSm90MVRXZUcwRnY1NS9keEpHZ05jL0JwSEs0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpBdU1qQXlNQjRYCkRUSXpNVEV3TWpFNE5UZ3hNVm9YRFRNek1UQXpNREU0TlRneE1Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekF1TWpBeU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXBZKzN5SHdnWUtUM1ppc3hjREppS3p1TCtpc3hEK3FaS0xKMjRlQ0JUSGs4ajkvV3dtWHgKSTNhTFhJMm1LcTRGaDN0MzRLSU1EaWgvL2oyTm9MVVJJbVc4bG5BNHA2MVZKb3FxbUxqNVgweXlwVDg1MEg1ZgpMM2lMYXpPV3FPeElHemxqclNYUUgzZk13bHFPYjNpc0FUMi9XVE4vbzMrRGRVaWdwa21ib3NUaHV3UFVvRGt1Clc5dWQzZ0s4S1dOODRsc0duM0VrVjBqQk5OR1VKaUM1RnNZSzBBNmJVeTVJYnlPd2pHZ3QzMktiVWxod2JJY2MKbEZ1cGVkZWpPZ2ptaEY4dUhoNFArVDUzMnU2QnREN3VObjJlT2kzZlp6ZG9rM0dMeDMxcnkrdkJrVXFFRmFVawpvSFZCUWVDTkR6SmM2YU0xbmI4MWtXcko1Q3k1c1diWVlRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNd0xqSXdNb0k4Y25jdFlUWmtZekl5T0RrdE9UazROQzAwTUdVNUxUbGpObVV0TXpZeE9HTTAKT0RCaE5XUmpMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekQxeTNod1F6bm9MS01BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJTcUl4YzBHbDVab0k3YkxjR1Njb3B3bUF5RUo1eUYzMzlUUndlMGVHZXhIQnRvS1huCk9IYm5VMUQxTTU2UytYK1E1TTVmQ2V3K2hXQ2dIYXh6V1pzY1dGeWRhWS9iTUpaV0REMzZYOUk0bnNvY0NhVlAKc1FRS1dGVVdUWldPRURSMDhkbTNIMldtK0w5aWZuQ2xCczAvVktjSmthTU44c01iaU5pNW5rQlBCbDdiWVZqMgp0Z1BpTUIyWGkxRkc0SndVQlcrRGJpTzAvVFFlZlpDSklsa01sZ2ZOMnc1RWFjdXExRkorRTQ4R29zNmlWd0h2CmJ1VU4wY3BYNVM3RENlU09IcnNZTXNNQjBxejlJbkR2U3BlMXBwRmgyOUVydjhaNVh5VmRER3U0ZkFFQzk1Y0IKb0hXQlZQUnZRKzZScThZUHF6dmJxWXhyWVgwL3hpNGIyTlh4Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1847"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:26 GMT
+      - Thu, 02 Nov 2023 19:00:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9421c8ed-ac67-40bc-87c7-625d9103ee11
+      - a8aaae32-9b33-48f5-bd10-57348c299dc6
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4ed20cfa-80bd-4eb1-934c-ff2d54efda01
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
     method: GET
   response:
-    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T16:05:25.279453Z","retention":7},"created_at":"2023-10-20T16:02:23.377944Z","endpoint":{"id":"16755eae-5ba2-48cf-b121-bda947c7ddb3","ip":"51.158.210.44","load_balancer":{},"name":null,"port":10509},"endpoints":[{"id":"16755eae-5ba2-48cf-b121-bda947c7ddb3","ip":"51.158.210.44","load_balancer":{},"name":null,"port":10509}],"engine":"PostgreSQL-15","id":"4ed20cfa-80bd-4eb1-934c-ff2d54efda01","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T19:00:07.360312Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794},"endpoints":[{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794}],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1293"
+      - "1245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:27 GMT
+      - Thu, 02 Nov 2023 19:00:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bcf10624-e97d-45ee-98fc-d1616ade3763
+      - c92260fc-30ca-4166-9a3a-1cae7c5fcb4b
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4ed20cfa-80bd-4eb1-934c-ff2d54efda01
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
     method: DELETE
   response:
-    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T16:05:25.279453Z","retention":7},"created_at":"2023-10-20T16:02:23.377944Z","endpoint":{"id":"16755eae-5ba2-48cf-b121-bda947c7ddb3","ip":"51.158.210.44","load_balancer":{},"name":null,"port":10509},"endpoints":[{"id":"16755eae-5ba2-48cf-b121-bda947c7ddb3","ip":"51.158.210.44","load_balancer":{},"name":null,"port":10509}],"engine":"PostgreSQL-15","id":"4ed20cfa-80bd-4eb1-934c-ff2d54efda01","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T19:00:07.360312Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794},"endpoints":[{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794}],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1296"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:27 GMT
+      - Thu, 02 Nov 2023 19:00:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4cb2af19-bb49-4941-acc9-a41b93bac261
+      - 363b7ff7-0a86-4f7a-830b-7c136c58a2f4
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4ed20cfa-80bd-4eb1-934c-ff2d54efda01
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
     method: GET
   response:
-    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T16:05:25.279453Z","retention":7},"created_at":"2023-10-20T16:02:23.377944Z","endpoint":{"id":"16755eae-5ba2-48cf-b121-bda947c7ddb3","ip":"51.158.210.44","load_balancer":{},"name":null,"port":10509},"endpoints":[{"id":"16755eae-5ba2-48cf-b121-bda947c7ddb3","ip":"51.158.210.44","load_balancer":{},"name":null,"port":10509}],"engine":"PostgreSQL-15","id":"4ed20cfa-80bd-4eb1-934c-ff2d54efda01","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T19:00:07.360312Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794},"endpoints":[{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794}],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1296"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:27 GMT
+      - Thu, 02 Nov 2023 19:00:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5fef4fa1-6ee1-461e-9374-023807c96f60
+      - 64b8225a-6160-4170-a7ee-49b9b2ee2ac3
     status: 200 OK
     code: 200
     duration: ""
@@ -904,10 +871,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4ed20cfa-80bd-4eb1-934c-ff2d54efda01
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"4ed20cfa-80bd-4eb1-934c-ff2d54efda01","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -916,7 +883,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:58 GMT
+      - Thu, 02 Nov 2023 19:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f58ae583-1887-4899-a27d-b05a2f2ef2ec
+      - 09e0e002-74b2-4c78-9c36-4e150b7f5cb8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -937,10 +904,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4ed20cfa-80bd-4eb1-934c-ff2d54efda01
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"4ed20cfa-80bd-4eb1-934c-ff2d54efda01","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -949,7 +916,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:58 GMT
+      - Thu, 02 Nov 2023 19:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 047f21d6-4631-4eab-b10e-fdd32d17489b
+      - 5838b4ff-4d67-470f-ab1b-9850e2dcf12b
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:05 GMT
+      - Thu, 02 Nov 2023 18:46:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d752f527-a644-4b84-abd6-0eac99d9be8c
+      - 90448ced-6320-4f63-8a81-43c20e992f2e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-basic","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-basic","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:59.450834Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"eed7f110-77a5-4ca9-b410-cee152b5f77d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "783"
+      - "754"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:59 GMT
+      - Thu, 02 Nov 2023 18:50:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e34f9ec3-83e1-4a07-a757-1caa7a42ff9c
+      - 760f742d-c8b9-4afc-b3ec-03635af74e7d
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:59.450834Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"eed7f110-77a5-4ca9-b410-cee152b5f77d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "783"
+      - "754"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:59 GMT
+      - Thu, 02 Nov 2023 18:50:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fcda0019-dbe1-42be-b4df-674c9bc36683
+      - b421bae0-1cf1-4300-a62c-dbe1c97ff030
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:59.450834Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"eed7f110-77a5-4ca9-b410-cee152b5f77d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "783"
+      - "754"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:29 GMT
+      - Thu, 02 Nov 2023 18:50:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 065b94d9-6c61-4361-a233-48a63f7cfdf5
+      - 75551769-3c14-4456-8260-a7290875aa17
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:59.450834Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"eed7f110-77a5-4ca9-b410-cee152b5f77d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "783"
+      - "754"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:00 GMT
+      - Thu, 02 Nov 2023 18:51:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7874ecb-e67f-424c-989c-749bcd30ede7
+      - e78e4441-4b77-4d6b-880a-df7b8dbf3243
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:59.450834Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"eed7f110-77a5-4ca9-b410-cee152b5f77d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "783"
+      - "754"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:30 GMT
+      - Thu, 02 Nov 2023 18:51:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f135a13b-b1b0-4aa8-b5ef-9b2109514a17
+      - 0fe5b4e8-08ef-494c-8fc3-5a49f3a32b4c
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:59.450834Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"eed7f110-77a5-4ca9-b410-cee152b5f77d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "783"
+      - "754"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:01 GMT
+      - Thu, 02 Nov 2023 18:52:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06a2f790-aa71-4633-9e28-6c3c75a9d370
+      - 2890c9d6-9015-4a67-8f55-df69ae721af0
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:59.450834Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"eed7f110-77a5-4ca9-b410-cee152b5f77d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "783"
+      - "754"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:31 GMT
+      - Thu, 02 Nov 2023 18:52:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75370ef2-0c5a-414f-a200-580bf749d972
+      - d76f2e38-8940-4d93-aa26-d2796dac7249
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:59.450834Z","endpoint":{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601},"endpoints":[{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601}],"engine":"PostgreSQL-15","id":"eed7f110-77a5-4ca9-b410-cee152b5f77d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1269"
+      - "1227"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:01 GMT
+      - Thu, 02 Nov 2023 18:53:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f377a950-d93d-4382-ac06-ea0fced5e678
+      - 36c154c7-f0bd-4935-a498-a8c34bab7239
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVUDllQ3UvRm41MmZhaFpaOTI1NXRuejJHaElJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRrek9Gb1hEVE16TVRBeE56RTFOVGt6T0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFzK3NQaUdSRHJmTWZtTGZ1Vngwd2k3ZmVzMFRmeE1FS0NETnJnOUduL3Z4aWRGU3ZKbzVUd3JzUVN1dS8KbWRuMGxYekI3SFpsOGVwSkFKZWcvSldnQVNFZGUwOUlQdXJaZnljM0ZHQkRmY0ovY0VLRk84SWFma3Z0MUY5MgpGNGVveVhiRFRmVWphY0FGNmdwM0FJTmFac0Z4Qzk4TnNzMXVSVWJQWVUzWGRIN0VtT3NLRCtESnplOXd1bC80CjlVVDRFaVI1alphM2FERkZWTGdobjhQNVFCdlVCaGU4UHArQ2NOcU1yRDEzcEpjTlVIZ3VYUFh1aEhZdDFuYysKemFJTzAyMGdQOUwxYThFaUdaaEZDemlnNUxqR05vTVVST3hrVlhMbGxLMFBqS1IyaytaamdBYy9JUHJsWHBaNgpnSm9YNUtFNEx3a2MrTzlCMS9rZjE0d1JNd0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdFpXVmtOMll4TVRBdE56ZGhOUzAwWTJFNUxXSTBNVEF0WTJWbE1UVXlZalZtTnpka0xuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5uNXZod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUE0OWJmWm5lYWFMWW5GRlBHVUVlUlM2TXFyUi9xZTErOVJmYUxTdS90SlE4NHFXaG1nVU9mbHp4enlDRzcvCm9aWEphODRWNFJvelhKTDBmdjVoV2hzeHN1d2U1QjZ3VE01Vy84clhaTDBNYUZRb1pZRk1TQ2pmWnFNQjlXT0MKYVRPVEdqMGs5Zm5YTHJUTXplUXVmaDNhaDdNYWVoYUhzNW1pOTE4NXRjcUZhbmVqWlhwc0NaaUtvRGRzWUVKZQppTC8za2tWdnliamlKbno2NGV4dzNCcEt4N2h2T2hTODZsTDQ0S05mMVgyT1E3RmdFdWIweDdmRHpzUVVNVk1tCmdLMDk4SVVwVEhXRk5sQmk5ajFwMG83V0cvcnVWclZBbS91SGVsVzI3YUtJQzdpYkFkb09lenF3a1VwWTdEQ24KbVl6eUFpNW1KRGE4MklmMjdweHJpVEhECi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUFRoS0RPWEZGU29uMG5vdWxySVREa3l1VmUwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTmk0eU16QXdIaGNOCk1qTXhNVEF5TVRnMU1EVXhXaGNOTXpNeE1ETXdNVGcxTURVeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTJMakl6TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUp2amtlY3hLUmxEMGExQXExV3hqdCtRZWVrWVRjNGpBT3h3OUdobysxVW5DTkNtd0lEWkhvVEIKQUpLWi9xRzg1U0ZPNnFiT0hsSjBaY1NQcndLNU1lMWdWaThWRzJmNGxuSmVkNUlmSUltcHN2VmpsV0orcHNSVQo2dXVmYmlRa2ZqSy9NOFpMV2xIK0VuSGNOU2Yvalk5blJGTFhHSW9MeThHNmlUMkcwRWNTQ0RpK3BZNUdlQTBmCjNmZ3Flb3dLU3NQVWdjVWdIVlY0MmNwZCthWDh6WC9La2ZNZGdtOVk4SHVkOThvb3FsV2N5UzR6UVloRlNCZ2oKdlp1bmdOZE85WUQ1Zm1tOEV3RDg3Q0FBV2lXbnFQYUxxU3NkRFdBd3FhTWcwR1JKbG9RU1k2UjNDSHhNMFRCMgpYckIyLzRqOGxJc3ZZQkdNTjQyNVVWejRGS25mKy9FQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMalUyTGpJek1JSThjbmN0TkdVMVltUXhORGt0Tmpjd01TMDBNakF3TFRrd05EWXROREZrTm1SbE5HUTQKTVRFekxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtSbWh3UXpuamptTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQms3dHl3bzk1SDZpWnp4M0hDaUVwSjhLelRsTUZ5c2xXU0k2TGFnVVh3ZURVbnAxZGcwekRiCllIK3NqRnI3MzBiL055eUFTaGJuRjZIT2JKcllPdjNNZkRNK1ZPb0FNM0tOUU1jRDdFR3BVZk0yd3JmakJkQ2EKY1gyVmFOdG5VMG00b3l4Mm9XSmxHcURSWlZ1UGV2UzNXbkNmZGNlbXpQaEdCdDJTTmpXMTJOUEFyR0t3ZWxsMAo3K0tqSTRoSjJ1WitiOHo5V1NlZEFJZVYvbVNxL2ZHUktvNGlmV0p3bWZFd0phVTJMWWMrMjY2TEVRVTd4aFVTClB4NklsRWl0bEtEaG0vZURsTXVveU5lUzVkS1VFck8vd2FkVk5NMGp4OWtQbS8vTDd1d0tLT0VQZHIwTVZFN2EKTWVYdktsWGgxTFVLSU92NUZjanNraVBvSWc0d1ZSVEkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:01 GMT
+      - Thu, 02 Nov 2023 18:53:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20404880-3ecf-4f8e-8763-13f2aeef5ef6
+      - d26b65ab-0218-4ecb-958c-a9f7c8f4773e
     status: 200 OK
     code: 200
     duration: ""
@@ -638,19 +638,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:59.450834Z","endpoint":{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601},"endpoints":[{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601}],"engine":"PostgreSQL-15","id":"eed7f110-77a5-4ca9-b410-cee152b5f77d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1269"
+      - "1227"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:01 GMT
+      - Thu, 02 Nov 2023 18:53:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -660,7 +660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b0f30f4-bc6e-4b19-b204-9af776dbb2a2
+      - c532895a-bbcf-4ec1-93f4-3ba61e72c0d4
     status: 200 OK
     code: 200
     duration: ""
@@ -671,19 +671,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:59.450834Z","endpoint":{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601},"endpoints":[{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601}],"engine":"PostgreSQL-15","id":"eed7f110-77a5-4ca9-b410-cee152b5f77d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1269"
+      - "1227"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:02 GMT
+      - Thu, 02 Nov 2023 18:53:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -693,7 +693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a26c2a16-8013-4002-886d-368a8ff5899a
+      - cfb041ab-97dd-4058-8f46-63cb3fd626be
     status: 200 OK
     code: 200
     duration: ""
@@ -704,19 +704,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVUDllQ3UvRm41MmZhaFpaOTI1NXRuejJHaElJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRrek9Gb1hEVE16TVRBeE56RTFOVGt6T0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFzK3NQaUdSRHJmTWZtTGZ1Vngwd2k3ZmVzMFRmeE1FS0NETnJnOUduL3Z4aWRGU3ZKbzVUd3JzUVN1dS8KbWRuMGxYekI3SFpsOGVwSkFKZWcvSldnQVNFZGUwOUlQdXJaZnljM0ZHQkRmY0ovY0VLRk84SWFma3Z0MUY5MgpGNGVveVhiRFRmVWphY0FGNmdwM0FJTmFac0Z4Qzk4TnNzMXVSVWJQWVUzWGRIN0VtT3NLRCtESnplOXd1bC80CjlVVDRFaVI1alphM2FERkZWTGdobjhQNVFCdlVCaGU4UHArQ2NOcU1yRDEzcEpjTlVIZ3VYUFh1aEhZdDFuYysKemFJTzAyMGdQOUwxYThFaUdaaEZDemlnNUxqR05vTVVST3hrVlhMbGxLMFBqS1IyaytaamdBYy9JUHJsWHBaNgpnSm9YNUtFNEx3a2MrTzlCMS9rZjE0d1JNd0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdFpXVmtOMll4TVRBdE56ZGhOUzAwWTJFNUxXSTBNVEF0WTJWbE1UVXlZalZtTnpka0xuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5uNXZod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUE0OWJmWm5lYWFMWW5GRlBHVUVlUlM2TXFyUi9xZTErOVJmYUxTdS90SlE4NHFXaG1nVU9mbHp4enlDRzcvCm9aWEphODRWNFJvelhKTDBmdjVoV2hzeHN1d2U1QjZ3VE01Vy84clhaTDBNYUZRb1pZRk1TQ2pmWnFNQjlXT0MKYVRPVEdqMGs5Zm5YTHJUTXplUXVmaDNhaDdNYWVoYUhzNW1pOTE4NXRjcUZhbmVqWlhwc0NaaUtvRGRzWUVKZQppTC8za2tWdnliamlKbno2NGV4dzNCcEt4N2h2T2hTODZsTDQ0S05mMVgyT1E3RmdFdWIweDdmRHpzUVVNVk1tCmdLMDk4SVVwVEhXRk5sQmk5ajFwMG83V0cvcnVWclZBbS91SGVsVzI3YUtJQzdpYkFkb09lenF3a1VwWTdEQ24KbVl6eUFpNW1KRGE4MklmMjdweHJpVEhECi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUFRoS0RPWEZGU29uMG5vdWxySVREa3l1VmUwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTmk0eU16QXdIaGNOCk1qTXhNVEF5TVRnMU1EVXhXaGNOTXpNeE1ETXdNVGcxTURVeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTJMakl6TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUp2amtlY3hLUmxEMGExQXExV3hqdCtRZWVrWVRjNGpBT3h3OUdobysxVW5DTkNtd0lEWkhvVEIKQUpLWi9xRzg1U0ZPNnFiT0hsSjBaY1NQcndLNU1lMWdWaThWRzJmNGxuSmVkNUlmSUltcHN2VmpsV0orcHNSVQo2dXVmYmlRa2ZqSy9NOFpMV2xIK0VuSGNOU2Yvalk5blJGTFhHSW9MeThHNmlUMkcwRWNTQ0RpK3BZNUdlQTBmCjNmZ3Flb3dLU3NQVWdjVWdIVlY0MmNwZCthWDh6WC9La2ZNZGdtOVk4SHVkOThvb3FsV2N5UzR6UVloRlNCZ2oKdlp1bmdOZE85WUQ1Zm1tOEV3RDg3Q0FBV2lXbnFQYUxxU3NkRFdBd3FhTWcwR1JKbG9RU1k2UjNDSHhNMFRCMgpYckIyLzRqOGxJc3ZZQkdNTjQyNVVWejRGS25mKy9FQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMalUyTGpJek1JSThjbmN0TkdVMVltUXhORGt0Tmpjd01TMDBNakF3TFRrd05EWXROREZrTm1SbE5HUTQKTVRFekxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtSbWh3UXpuamptTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQms3dHl3bzk1SDZpWnp4M0hDaUVwSjhLelRsTUZ5c2xXU0k2TGFnVVh3ZURVbnAxZGcwekRiCllIK3NqRnI3MzBiL055eUFTaGJuRjZIT2JKcllPdjNNZkRNK1ZPb0FNM0tOUU1jRDdFR3BVZk0yd3JmakJkQ2EKY1gyVmFOdG5VMG00b3l4Mm9XSmxHcURSWlZ1UGV2UzNXbkNmZGNlbXpQaEdCdDJTTmpXMTJOUEFyR0t3ZWxsMAo3K0tqSTRoSjJ1WitiOHo5V1NlZEFJZVYvbVNxL2ZHUktvNGlmV0p3bWZFd0phVTJMWWMrMjY2TEVRVTd4aFVTClB4NklsRWl0bEtEaG0vZURsTXVveU5lUzVkS1VFck8vd2FkVk5NMGp4OWtQbS8vTDd1d0tLT0VQZHIwTVZFN2EKTWVYdktsWGgxTFVLSU92NUZjanNraVBvSWc0d1ZSVEkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:02 GMT
+      - Thu, 02 Nov 2023 18:53:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -726,7 +726,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9f721ac-5765-4cb7-be2d-e9f8883d3615
+      - 34dece40-d437-4c64-a190-05450fdaa5e2
     status: 200 OK
     code: 200
     duration: ""
@@ -737,19 +737,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:59.450834Z","endpoint":{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601},"endpoints":[{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601}],"engine":"PostgreSQL-15","id":"eed7f110-77a5-4ca9-b410-cee152b5f77d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1269"
+      - "1227"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:02 GMT
+      - Thu, 02 Nov 2023 18:53:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -759,7 +759,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3fa405ef-27c3-49a9-8da5-4c99939124c4
+      - 4680f601-9fce-46c2-9f83-96ac2e1af8df
     status: 200 OK
     code: 200
     duration: ""
@@ -770,19 +770,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVUDllQ3UvRm41MmZhaFpaOTI1NXRuejJHaElJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRrek9Gb1hEVE16TVRBeE56RTFOVGt6T0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFzK3NQaUdSRHJmTWZtTGZ1Vngwd2k3ZmVzMFRmeE1FS0NETnJnOUduL3Z4aWRGU3ZKbzVUd3JzUVN1dS8KbWRuMGxYekI3SFpsOGVwSkFKZWcvSldnQVNFZGUwOUlQdXJaZnljM0ZHQkRmY0ovY0VLRk84SWFma3Z0MUY5MgpGNGVveVhiRFRmVWphY0FGNmdwM0FJTmFac0Z4Qzk4TnNzMXVSVWJQWVUzWGRIN0VtT3NLRCtESnplOXd1bC80CjlVVDRFaVI1alphM2FERkZWTGdobjhQNVFCdlVCaGU4UHArQ2NOcU1yRDEzcEpjTlVIZ3VYUFh1aEhZdDFuYysKemFJTzAyMGdQOUwxYThFaUdaaEZDemlnNUxqR05vTVVST3hrVlhMbGxLMFBqS1IyaytaamdBYy9JUHJsWHBaNgpnSm9YNUtFNEx3a2MrTzlCMS9rZjE0d1JNd0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdFpXVmtOMll4TVRBdE56ZGhOUzAwWTJFNUxXSTBNVEF0WTJWbE1UVXlZalZtTnpka0xuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5uNXZod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUE0OWJmWm5lYWFMWW5GRlBHVUVlUlM2TXFyUi9xZTErOVJmYUxTdS90SlE4NHFXaG1nVU9mbHp4enlDRzcvCm9aWEphODRWNFJvelhKTDBmdjVoV2hzeHN1d2U1QjZ3VE01Vy84clhaTDBNYUZRb1pZRk1TQ2pmWnFNQjlXT0MKYVRPVEdqMGs5Zm5YTHJUTXplUXVmaDNhaDdNYWVoYUhzNW1pOTE4NXRjcUZhbmVqWlhwc0NaaUtvRGRzWUVKZQppTC8za2tWdnliamlKbno2NGV4dzNCcEt4N2h2T2hTODZsTDQ0S05mMVgyT1E3RmdFdWIweDdmRHpzUVVNVk1tCmdLMDk4SVVwVEhXRk5sQmk5ajFwMG83V0cvcnVWclZBbS91SGVsVzI3YUtJQzdpYkFkb09lenF3a1VwWTdEQ24KbVl6eUFpNW1KRGE4MklmMjdweHJpVEhECi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUFRoS0RPWEZGU29uMG5vdWxySVREa3l1VmUwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTmk0eU16QXdIaGNOCk1qTXhNVEF5TVRnMU1EVXhXaGNOTXpNeE1ETXdNVGcxTURVeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTJMakl6TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUp2amtlY3hLUmxEMGExQXExV3hqdCtRZWVrWVRjNGpBT3h3OUdobysxVW5DTkNtd0lEWkhvVEIKQUpLWi9xRzg1U0ZPNnFiT0hsSjBaY1NQcndLNU1lMWdWaThWRzJmNGxuSmVkNUlmSUltcHN2VmpsV0orcHNSVQo2dXVmYmlRa2ZqSy9NOFpMV2xIK0VuSGNOU2Yvalk5blJGTFhHSW9MeThHNmlUMkcwRWNTQ0RpK3BZNUdlQTBmCjNmZ3Flb3dLU3NQVWdjVWdIVlY0MmNwZCthWDh6WC9La2ZNZGdtOVk4SHVkOThvb3FsV2N5UzR6UVloRlNCZ2oKdlp1bmdOZE85WUQ1Zm1tOEV3RDg3Q0FBV2lXbnFQYUxxU3NkRFdBd3FhTWcwR1JKbG9RU1k2UjNDSHhNMFRCMgpYckIyLzRqOGxJc3ZZQkdNTjQyNVVWejRGS25mKy9FQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMalUyTGpJek1JSThjbmN0TkdVMVltUXhORGt0Tmpjd01TMDBNakF3TFRrd05EWXROREZrTm1SbE5HUTQKTVRFekxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtSbWh3UXpuamptTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQms3dHl3bzk1SDZpWnp4M0hDaUVwSjhLelRsTUZ5c2xXU0k2TGFnVVh3ZURVbnAxZGcwekRiCllIK3NqRnI3MzBiL055eUFTaGJuRjZIT2JKcllPdjNNZkRNK1ZPb0FNM0tOUU1jRDdFR3BVZk0yd3JmakJkQ2EKY1gyVmFOdG5VMG00b3l4Mm9XSmxHcURSWlZ1UGV2UzNXbkNmZGNlbXpQaEdCdDJTTmpXMTJOUEFyR0t3ZWxsMAo3K0tqSTRoSjJ1WitiOHo5V1NlZEFJZVYvbVNxL2ZHUktvNGlmV0p3bWZFd0phVTJMWWMrMjY2TEVRVTd4aFVTClB4NklsRWl0bEtEaG0vZURsTXVveU5lUzVkS1VFck8vd2FkVk5NMGp4OWtQbS8vTDd1d0tLT0VQZHIwTVZFN2EKTWVYdktsWGgxTFVLSU92NUZjanNraVBvSWc0d1ZSVEkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:02 GMT
+      - Thu, 02 Nov 2023 18:53:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -792,7 +792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6599a4b-96d4-488f-bc51-dd611ae829a0
+      - 3bf02eae-bd2f-4130-aa20-8e30372ab295
     status: 200 OK
     code: 200
     duration: ""
@@ -803,19 +803,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:59.450834Z","endpoint":{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601},"endpoints":[{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601}],"engine":"PostgreSQL-15","id":"eed7f110-77a5-4ca9-b410-cee152b5f77d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1269"
+      - "1227"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:03 GMT
+      - Thu, 02 Nov 2023 18:53:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -825,12 +825,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbb2b118-adb4-42a3-84a3-bc5788475f7d
+      - 39595319-c1ea-49e0-a541-c56df53233d7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"backup_schedule_frequency":null,"backup_schedule_retention":null,"is_backup_schedule_disabled":null,"name":null,"tags":["terraform-change-tag"],"logs_policy":null,"backup_same_region":null,"backup_schedule_start_hour":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1227"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 42539b7b-acac-4b0b-b9bc-c25128a5f793
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"tags":["terraform-change-tag"]}'
     form: {}
     headers:
       Content-Type:
@@ -838,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:59.450834Z","endpoint":{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601},"endpoints":[{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601}],"engine":"PostgreSQL-15","id":"eed7f110-77a5-4ca9-b410-cee152b5f77d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1239"
+      - "1199"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:03 GMT
+      - Thu, 02 Nov 2023 18:53:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92b4cd89-6a32-4378-bcbb-88e63cc79ba8
+      - 2efaa875-4cf4-41d4-bf58-0576b363f918
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:59.450834Z","endpoint":{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601},"endpoints":[{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601}],"engine":"PostgreSQL-15","id":"eed7f110-77a5-4ca9-b410-cee152b5f77d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1239"
+      - "1199"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:03 GMT
+      - Thu, 02 Nov 2023 18:53:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b722295-3bc0-49a9-b5cc-956cb589ed67
+      - afe7ee28-90b8-4e80-ae2d-6ca2e5a68f8f
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVUDllQ3UvRm41MmZhaFpaOTI1NXRuejJHaElJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRrek9Gb1hEVE16TVRBeE56RTFOVGt6T0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFzK3NQaUdSRHJmTWZtTGZ1Vngwd2k3ZmVzMFRmeE1FS0NETnJnOUduL3Z4aWRGU3ZKbzVUd3JzUVN1dS8KbWRuMGxYekI3SFpsOGVwSkFKZWcvSldnQVNFZGUwOUlQdXJaZnljM0ZHQkRmY0ovY0VLRk84SWFma3Z0MUY5MgpGNGVveVhiRFRmVWphY0FGNmdwM0FJTmFac0Z4Qzk4TnNzMXVSVWJQWVUzWGRIN0VtT3NLRCtESnplOXd1bC80CjlVVDRFaVI1alphM2FERkZWTGdobjhQNVFCdlVCaGU4UHArQ2NOcU1yRDEzcEpjTlVIZ3VYUFh1aEhZdDFuYysKemFJTzAyMGdQOUwxYThFaUdaaEZDemlnNUxqR05vTVVST3hrVlhMbGxLMFBqS1IyaytaamdBYy9JUHJsWHBaNgpnSm9YNUtFNEx3a2MrTzlCMS9rZjE0d1JNd0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdFpXVmtOMll4TVRBdE56ZGhOUzAwWTJFNUxXSTBNVEF0WTJWbE1UVXlZalZtTnpka0xuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5uNXZod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUE0OWJmWm5lYWFMWW5GRlBHVUVlUlM2TXFyUi9xZTErOVJmYUxTdS90SlE4NHFXaG1nVU9mbHp4enlDRzcvCm9aWEphODRWNFJvelhKTDBmdjVoV2hzeHN1d2U1QjZ3VE01Vy84clhaTDBNYUZRb1pZRk1TQ2pmWnFNQjlXT0MKYVRPVEdqMGs5Zm5YTHJUTXplUXVmaDNhaDdNYWVoYUhzNW1pOTE4NXRjcUZhbmVqWlhwc0NaaUtvRGRzWUVKZQppTC8za2tWdnliamlKbno2NGV4dzNCcEt4N2h2T2hTODZsTDQ0S05mMVgyT1E3RmdFdWIweDdmRHpzUVVNVk1tCmdLMDk4SVVwVEhXRk5sQmk5ajFwMG83V0cvcnVWclZBbS91SGVsVzI3YUtJQzdpYkFkb09lenF3a1VwWTdEQ24KbVl6eUFpNW1KRGE4MklmMjdweHJpVEhECi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUFRoS0RPWEZGU29uMG5vdWxySVREa3l1VmUwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTmk0eU16QXdIaGNOCk1qTXhNVEF5TVRnMU1EVXhXaGNOTXpNeE1ETXdNVGcxTURVeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTJMakl6TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUp2amtlY3hLUmxEMGExQXExV3hqdCtRZWVrWVRjNGpBT3h3OUdobysxVW5DTkNtd0lEWkhvVEIKQUpLWi9xRzg1U0ZPNnFiT0hsSjBaY1NQcndLNU1lMWdWaThWRzJmNGxuSmVkNUlmSUltcHN2VmpsV0orcHNSVQo2dXVmYmlRa2ZqSy9NOFpMV2xIK0VuSGNOU2Yvalk5blJGTFhHSW9MeThHNmlUMkcwRWNTQ0RpK3BZNUdlQTBmCjNmZ3Flb3dLU3NQVWdjVWdIVlY0MmNwZCthWDh6WC9La2ZNZGdtOVk4SHVkOThvb3FsV2N5UzR6UVloRlNCZ2oKdlp1bmdOZE85WUQ1Zm1tOEV3RDg3Q0FBV2lXbnFQYUxxU3NkRFdBd3FhTWcwR1JKbG9RU1k2UjNDSHhNMFRCMgpYckIyLzRqOGxJc3ZZQkdNTjQyNVVWejRGS25mKy9FQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMalUyTGpJek1JSThjbmN0TkdVMVltUXhORGt0Tmpjd01TMDBNakF3TFRrd05EWXROREZrTm1SbE5HUTQKTVRFekxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtSbWh3UXpuamptTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQms3dHl3bzk1SDZpWnp4M0hDaUVwSjhLelRsTUZ5c2xXU0k2TGFnVVh3ZURVbnAxZGcwekRiCllIK3NqRnI3MzBiL055eUFTaGJuRjZIT2JKcllPdjNNZkRNK1ZPb0FNM0tOUU1jRDdFR3BVZk0yd3JmakJkQ2EKY1gyVmFOdG5VMG00b3l4Mm9XSmxHcURSWlZ1UGV2UzNXbkNmZGNlbXpQaEdCdDJTTmpXMTJOUEFyR0t3ZWxsMAo3K0tqSTRoSjJ1WitiOHo5V1NlZEFJZVYvbVNxL2ZHUktvNGlmV0p3bWZFd0phVTJMWWMrMjY2TEVRVTd4aFVTClB4NklsRWl0bEtEaG0vZURsTXVveU5lUzVkS1VFck8vd2FkVk5NMGp4OWtQbS8vTDd1d0tLT0VQZHIwTVZFN2EKTWVYdktsWGgxTFVLSU92NUZjanNraVBvSWc0d1ZSVEkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:03 GMT
+      - Thu, 02 Nov 2023 18:53:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7a92b97-d2d9-49a8-992e-56ffde755b8c
+      - d17c9ea5-b98e-44e0-a016-6b83dada38c5
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:59.450834Z","endpoint":{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601},"endpoints":[{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601}],"engine":"PostgreSQL-15","id":"eed7f110-77a5-4ca9-b410-cee152b5f77d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1239"
+      - "1199"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:03 GMT
+      - Thu, 02 Nov 2023 18:53:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c3120e8-7a2f-42dc-9e7d-ddeb0b8f5edb
+      - 20956b46-adcd-4cb8-b31b-bec3af1b3fcf
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +1003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:59.450834Z","endpoint":{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601},"endpoints":[{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601}],"engine":"PostgreSQL-15","id":"eed7f110-77a5-4ca9-b410-cee152b5f77d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1239"
+      - "1199"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:04 GMT
+      - Thu, 02 Nov 2023 18:53:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35933d1e-6f79-4bd4-a9e5-7956e3b153de
+      - b0d12f43-da2b-4287-81de-5cbba83bc75f
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,19 +1036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVUDllQ3UvRm41MmZhaFpaOTI1NXRuejJHaElJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRrek9Gb1hEVE16TVRBeE56RTFOVGt6T0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFzK3NQaUdSRHJmTWZtTGZ1Vngwd2k3ZmVzMFRmeE1FS0NETnJnOUduL3Z4aWRGU3ZKbzVUd3JzUVN1dS8KbWRuMGxYekI3SFpsOGVwSkFKZWcvSldnQVNFZGUwOUlQdXJaZnljM0ZHQkRmY0ovY0VLRk84SWFma3Z0MUY5MgpGNGVveVhiRFRmVWphY0FGNmdwM0FJTmFac0Z4Qzk4TnNzMXVSVWJQWVUzWGRIN0VtT3NLRCtESnplOXd1bC80CjlVVDRFaVI1alphM2FERkZWTGdobjhQNVFCdlVCaGU4UHArQ2NOcU1yRDEzcEpjTlVIZ3VYUFh1aEhZdDFuYysKemFJTzAyMGdQOUwxYThFaUdaaEZDemlnNUxqR05vTVVST3hrVlhMbGxLMFBqS1IyaytaamdBYy9JUHJsWHBaNgpnSm9YNUtFNEx3a2MrTzlCMS9rZjE0d1JNd0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdFpXVmtOMll4TVRBdE56ZGhOUzAwWTJFNUxXSTBNVEF0WTJWbE1UVXlZalZtTnpka0xuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5uNXZod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUE0OWJmWm5lYWFMWW5GRlBHVUVlUlM2TXFyUi9xZTErOVJmYUxTdS90SlE4NHFXaG1nVU9mbHp4enlDRzcvCm9aWEphODRWNFJvelhKTDBmdjVoV2hzeHN1d2U1QjZ3VE01Vy84clhaTDBNYUZRb1pZRk1TQ2pmWnFNQjlXT0MKYVRPVEdqMGs5Zm5YTHJUTXplUXVmaDNhaDdNYWVoYUhzNW1pOTE4NXRjcUZhbmVqWlhwc0NaaUtvRGRzWUVKZQppTC8za2tWdnliamlKbno2NGV4dzNCcEt4N2h2T2hTODZsTDQ0S05mMVgyT1E3RmdFdWIweDdmRHpzUVVNVk1tCmdLMDk4SVVwVEhXRk5sQmk5ajFwMG83V0cvcnVWclZBbS91SGVsVzI3YUtJQzdpYkFkb09lenF3a1VwWTdEQ24KbVl6eUFpNW1KRGE4MklmMjdweHJpVEhECi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUFRoS0RPWEZGU29uMG5vdWxySVREa3l1VmUwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTmk0eU16QXdIaGNOCk1qTXhNVEF5TVRnMU1EVXhXaGNOTXpNeE1ETXdNVGcxTURVeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTJMakl6TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUp2amtlY3hLUmxEMGExQXExV3hqdCtRZWVrWVRjNGpBT3h3OUdobysxVW5DTkNtd0lEWkhvVEIKQUpLWi9xRzg1U0ZPNnFiT0hsSjBaY1NQcndLNU1lMWdWaThWRzJmNGxuSmVkNUlmSUltcHN2VmpsV0orcHNSVQo2dXVmYmlRa2ZqSy9NOFpMV2xIK0VuSGNOU2Yvalk5blJGTFhHSW9MeThHNmlUMkcwRWNTQ0RpK3BZNUdlQTBmCjNmZ3Flb3dLU3NQVWdjVWdIVlY0MmNwZCthWDh6WC9La2ZNZGdtOVk4SHVkOThvb3FsV2N5UzR6UVloRlNCZ2oKdlp1bmdOZE85WUQ1Zm1tOEV3RDg3Q0FBV2lXbnFQYUxxU3NkRFdBd3FhTWcwR1JKbG9RU1k2UjNDSHhNMFRCMgpYckIyLzRqOGxJc3ZZQkdNTjQyNVVWejRGS25mKy9FQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMalUyTGpJek1JSThjbmN0TkdVMVltUXhORGt0Tmpjd01TMDBNakF3TFRrd05EWXROREZrTm1SbE5HUTQKTVRFekxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtSbWh3UXpuamptTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQms3dHl3bzk1SDZpWnp4M0hDaUVwSjhLelRsTUZ5c2xXU0k2TGFnVVh3ZURVbnAxZGcwekRiCllIK3NqRnI3MzBiL055eUFTaGJuRjZIT2JKcllPdjNNZkRNK1ZPb0FNM0tOUU1jRDdFR3BVZk0yd3JmakJkQ2EKY1gyVmFOdG5VMG00b3l4Mm9XSmxHcURSWlZ1UGV2UzNXbkNmZGNlbXpQaEdCdDJTTmpXMTJOUEFyR0t3ZWxsMAo3K0tqSTRoSjJ1WitiOHo5V1NlZEFJZVYvbVNxL2ZHUktvNGlmV0p3bWZFd0phVTJMWWMrMjY2TEVRVTd4aFVTClB4NklsRWl0bEtEaG0vZURsTXVveU5lUzVkS1VFck8vd2FkVk5NMGp4OWtQbS8vTDd1d0tLT0VQZHIwTVZFN2EKTWVYdktsWGgxTFVLSU92NUZjanNraVBvSWc0d1ZSVEkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:04 GMT
+      - Thu, 02 Nov 2023 18:53:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 967f5ca2-4d79-419d-8da2-958c905e625a
+      - 7a05d6b6-8c0b-4fbc-ba70-8b8aa55de961
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,19 +1069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:59.450834Z","endpoint":{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601},"endpoints":[{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601}],"engine":"PostgreSQL-15","id":"eed7f110-77a5-4ca9-b410-cee152b5f77d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1239"
+      - "1199"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:05 GMT
+      - Thu, 02 Nov 2023 18:53:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1058,7 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8395051f-e151-4ebc-a01f-3cc7dbed6cc2
+      - aa38ecb9-a4d0-429f-8ef1-e1b1cfa0dcf6
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,19 +1102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:59.450834Z","endpoint":{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601},"endpoints":[{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601}],"engine":"PostgreSQL-15","id":"eed7f110-77a5-4ca9-b410-cee152b5f77d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1242"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:05 GMT
+      - Thu, 02 Nov 2023 18:53:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1091,7 +1124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64398ee4-409c-4912-8a14-bca6ca48de04
+      - f48e4b4b-c633-469b-aa5b-fb5d00757959
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,19 +1135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:59.450834Z","endpoint":{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601},"endpoints":[{"id":"fbf77513-508d-4a14-a7c6-42fd44daffdc","ip":"51.159.9.88","load_balancer":{},"name":null,"port":5601}],"engine":"PostgreSQL-15","id":"eed7f110-77a5-4ca9-b410-cee152b5f77d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1242"
+      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:05 GMT
+      - Thu, 02 Nov 2023 18:53:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1124,7 +1157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ce6437e-196a-42c3-ae6e-8cbb6559665e
+      - 6fca5fec-8e32-4271-8ee0-eb9f4bd14122
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,10 +1168,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"eed7f110-77a5-4ca9-b410-cee152b5f77d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"4e5bd149-6701-4200-9046-41d6de4d8113","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1147,7 +1180,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:35 GMT
+      - Thu, 02 Nov 2023 18:53:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1157,7 +1190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b77b8ff-dc65-4bb0-b691-4f4acb3b7910
+      - d2f50ec8-5364-4027-9d78-e93d885b5a55
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1168,10 +1201,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eed7f110-77a5-4ca9-b410-cee152b5f77d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"eed7f110-77a5-4ca9-b410-cee152b5f77d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"4e5bd149-6701-4200-9046-41d6de4d8113","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1180,7 +1213,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:35 GMT
+      - Thu, 02 Nov 2023 18:53:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14c09328-6c62-4ca2-b028-e55c0a3e1710
+      - f038daf4-9af1-49ce-acb6-44f55d739548
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-capitalize.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-capitalize.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:06 GMT
+      - Thu, 02 Nov 2023 18:46:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 035f1ec6-4798-42ca-bbd9-9ae564a10973
+      - 17876c81-3e62-4858-8ff1-0d83cd3c13e4
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"DB-DEV-S","is_ha_cluster":false,"disable_backup":true,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"DB-DEV-S","is_ha_cluster":false,"disable_backup":true,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.318388Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b3feb06b-27df-4000-966d-022d668d9e60","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "725"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:10 GMT
+      - Thu, 02 Nov 2023 18:46:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26412a6e-07de-42a7-90ec-a74ac9673398
+      - 5bbddad3-774d-4637-b96d-54fa8640b270
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b3feb06b-27df-4000-966d-022d668d9e60
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.318388Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b3feb06b-27df-4000-966d-022d668d9e60","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "725"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:10 GMT
+      - Thu, 02 Nov 2023 18:46:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68b4bca6-e78f-41de-ba9f-51f3da0e0ea4
+      - 7c41fc23-6e8f-4b7f-bdd5-dc32c3ecc68c
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b3feb06b-27df-4000-966d-022d668d9e60
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.318388Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b3feb06b-27df-4000-966d-022d668d9e60","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "725"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:40 GMT
+      - Thu, 02 Nov 2023 18:47:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5ee5f25-ce30-414b-9748-e0ba1317d3f6
+      - 8d9e9676-928d-4705-8b51-5719841fc82d
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b3feb06b-27df-4000-966d-022d668d9e60
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.318388Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b3feb06b-27df-4000-966d-022d668d9e60","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "725"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:52:11 GMT
+      - Thu, 02 Nov 2023 18:47:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5aefd26-8817-4890-adbf-6bce6c2e13ad
+      - 6cec3901-d7ff-47aa-9cf2-c47bce034483
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b3feb06b-27df-4000-966d-022d668d9e60
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.318388Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b3feb06b-27df-4000-966d-022d668d9e60","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "725"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:52:41 GMT
+      - Thu, 02 Nov 2023 18:48:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5caf8d81-7f68-4d83-922d-b119a4f94800
+      - d36ebbc3-f8b1-47d0-b5ae-1210f0ba9700
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b3feb06b-27df-4000-966d-022d668d9e60
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.318388Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b3feb06b-27df-4000-966d-022d668d9e60","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "725"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:53:11 GMT
+      - Thu, 02 Nov 2023 18:48:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae18cc42-d5b4-43b2-b0c3-86e5b10ca22a
+      - 0c8f7e6c-f63e-4ff3-b244-8f4770a8b093
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b3feb06b-27df-4000-966d-022d668d9e60
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.318388Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b3feb06b-27df-4000-966d-022d668d9e60","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "725"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:53:41 GMT
+      - Thu, 02 Nov 2023 18:49:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe286d35-dc71-4bb3-954d-4450c2cd54bb
+      - e2aeee37-c0bf-48d4-aceb-8d68c3795b72
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b3feb06b-27df-4000-966d-022d668d9e60
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.318388Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b3feb06b-27df-4000-966d-022d668d9e60","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681},"endpoints":[{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681}],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "725"
+      - "1171"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1dd5eb26-c588-418f-a77e-7c3ad78c3b8c
+      - 53d10831-9710-4fde-a66c-f332917a6d00
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b3feb06b-27df-4000-966d-022d668d9e60
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.318388Z","endpoint":{"id":"2b9845fa-75e2-432c-9ffb-7cdf1d55c70b","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19069},"endpoints":[{"id":"2b9845fa-75e2-432c-9ffb-7cdf1d55c70b","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19069}],"engine":"PostgreSQL-15","id":"b3feb06b-27df-4000-966d-022d668d9e60","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVRzB2M3RWL25JVEVsNEZVa25jdnBGaW5wdjZRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56STRXaGNOTXpNeE1ETXdNVGcwTnpJNFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxmT3l3RkNDODUwOG5sMDZmWlh0YnNGN3NJVzJ6eFlFeFZwOEF4TXIxMklxalNxaU1sMmhnSU0KSUltR1ZhWlQ0ZEZmMENvaFNPMGZMNmR0Snd0Zk9XV0VRVzRzdHpCZGFpVm1vdk5NaWVaV2RFeUxZNkpUcGtXYgphbld0RUF0U1dHTUc5VllNQy9GbW9NclVaenZIVWVyeEVNNEh2R0o4eVlSMmNFbzJUc2VpcGptblhjdUpxQkpNCkQ0T0FDbnVIWGNwWC9iM21ac2hwTTRpanpxNlJyclhuTk5od1h0d0ZRTFpFOHl1U0hZdk94ci9QSm1SaGhGTWQKYk1WVThFaUMwakNSOG9pSG5XRGs1bysvdHkyRDZFd0lUTTR1N2ZCUlQyaFRBdkRsMmRTTGphRkJ4VXd1SUJCTwpvd1NVNU1haHUyOE9uMTNINmFCRjJmdnd1Z2tqWkI4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0TVRZd1pXUTFOekl0WkRkbU55MDBOalUxTFdFeU5qQXRZamc1TnpBeE5XVmgKTURjeExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpocWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQWkxc2pTS3pKOWNSRnFVUEU5QnBtN2JnK0NFUnVIaUpnMXdRSE1uWHRVSVptL0JrYm9xSWZ5CmxyaEdDb1phK2FQYktYWWN0VTdJK1U3Zkx4NzMveHJVcmZSR0dIcVpEYy9PNHNCTFlwSHFmTFNQRmZHNXdRMFEKZXY0eFNpc0c0UzBweEpQY3hiSXBpTVl1WTV3MThzamJXUTg4STJjbmdzR1pIU3ZNOW01ZEVKeUo0OWc5Mmp5ZwpPMSt4dm9NTEI4NnYrcGszbmEza3dMRFpaSm5NLzVBT1Y5UmdLOFRROENaNVhTb2RXL2t3alZ0dTJSWUZyRmowCmFFYS9WeWtkVGhLQXFkWUNiVWovQmRNRmpRZTJQWFpPYmZ6NWl0YXZ5R04vU1VNQmxYM1ZDeGUzbHZ1bFhsdmQKc3AyTk1WMEVTUzU5OU5OeXhlNnZQM3VPN2VtaUNYYXEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1213"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:41 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7a199c6-cb3a-4e14-a67a-2bdc3fe470f6
+      - 35554a88-e0f1-4e1b-bdc9-dde45bb1e211
     status: 200 OK
     code: 200
     duration: ""
@@ -638,19 +638,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b3feb06b-27df-4000-966d-022d668d9e60/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVTVJCaEw5QnZWck14SHZIaU9KQU8rM2pBR2ZVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU9Gb1hEVE16TVRBeE56RTFOVEUxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUExOWZ0MXpCQ1ZiTjk3cE1oYytHSmRWdXdwcEJJLzRaR2VXOVNlV3FOUHVCcEY1MEp2RHEzVHUzSDlORXUKNER4U3R3OXBLSzBIRXlMc1RTU0pvNEFrb2JESUkvUW9IdWhRR25ZamZwV09NVjg5TmpYWVl0NXJBdGtSSEFycQo0TTdLVDZUY0xjSEN3S21NQit2SjFDbDZZbW1xbzdPYXZmdjJ5c1QySGtWd1ZhQzRYckdKL0x6YUUrbElWb2tSCnVnMVBlSG9BMGJkNU1NZmNvMTQ4K0EvR1dLdVVoeUhlcUh3dmhoNlgraWwvQ1lUZWk4TGNjeW5PT05xRVI0bWEKNlNEVWxIRnEvZlhKODVOTnZaYVNsSCs5aksvTU5YZVZvVjZvQml0KzM4a0VISjNXQ2xISDN4cEYrTVdIVTlxRwpnZDU1VlRPUHpXYktPdEtYaDFNZEpLUFZrd0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdFlqTm1aV0l3Tm1JdE1qZGtaaTAwTURBd0xUazJObVF0TURJeVpEWTJPR1E1WlRZd0xuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJJMkhod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUF0N2xwSzhmVWpRMWphN1ZoVHYrZzBaRjFHNWF3RjBNbDZ5SVJyZnAzU3pQU0lUMG1tOE13dmlLQTNDNEhMCkFtbERvR0FJSlpEU0hhUjRjQnQ1ODRtQ3Vha0k3VGFtZXhHa0JUOFVCL2NBeGkzcjI3UERxSkZ6RGpqU00rdC8KVk5tRmRFWDRzdmZEWTF6eTYzN29KWGVuTk5zNVQxSERseUlYSklOaDlLaTVtcVFPWGEwTlZUUHBMV050eE1vUApVSzFwM1FiTzFUOWc3aW4yVzJHd2tCYzAzbmNOVHZBc1d3YjllSTErSm1JblNHa2wrUjRsOUZmVmh2NmNHZzNlCm9zc1p3bG5lSGR5WkhUeDk2MlVoajh2OFk0cW9zMTBDcExnRWJhRkNRbUJiZjBuMGNacllnRnRDR0xZTTNWVzgKZU5jVGFBS2pRWWpjOVp6ZGNYeEIyU1ZiCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681},"endpoints":[{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681}],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1833"
+      - "1171"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:41 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -660,7 +660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 942b235d-7e0f-44cf-879a-b8edf23eef65
+      - ed7a308a-4371-4893-b728-264622fa9009
     status: 200 OK
     code: 200
     duration: ""
@@ -671,19 +671,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b3feb06b-27df-4000-966d-022d668d9e60
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.318388Z","endpoint":{"id":"2b9845fa-75e2-432c-9ffb-7cdf1d55c70b","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19069},"endpoints":[{"id":"2b9845fa-75e2-432c-9ffb-7cdf1d55c70b","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19069}],"engine":"PostgreSQL-15","id":"b3feb06b-27df-4000-966d-022d668d9e60","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681},"endpoints":[{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681}],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1213"
+      - "1171"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:41 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -693,7 +693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b8ec66a-3528-4fb2-af08-350c2e3841ac
+      - 7be87144-4d82-4a50-b03e-869e82c87db3
     status: 200 OK
     code: 200
     duration: ""
@@ -704,19 +704,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b3feb06b-27df-4000-966d-022d668d9e60
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.318388Z","endpoint":{"id":"2b9845fa-75e2-432c-9ffb-7cdf1d55c70b","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19069},"endpoints":[{"id":"2b9845fa-75e2-432c-9ffb-7cdf1d55c70b","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19069}],"engine":"PostgreSQL-15","id":"b3feb06b-27df-4000-966d-022d668d9e60","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVRzB2M3RWL25JVEVsNEZVa25jdnBGaW5wdjZRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56STRXaGNOTXpNeE1ETXdNVGcwTnpJNFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxmT3l3RkNDODUwOG5sMDZmWlh0YnNGN3NJVzJ6eFlFeFZwOEF4TXIxMklxalNxaU1sMmhnSU0KSUltR1ZhWlQ0ZEZmMENvaFNPMGZMNmR0Snd0Zk9XV0VRVzRzdHpCZGFpVm1vdk5NaWVaV2RFeUxZNkpUcGtXYgphbld0RUF0U1dHTUc5VllNQy9GbW9NclVaenZIVWVyeEVNNEh2R0o4eVlSMmNFbzJUc2VpcGptblhjdUpxQkpNCkQ0T0FDbnVIWGNwWC9iM21ac2hwTTRpanpxNlJyclhuTk5od1h0d0ZRTFpFOHl1U0hZdk94ci9QSm1SaGhGTWQKYk1WVThFaUMwakNSOG9pSG5XRGs1bysvdHkyRDZFd0lUTTR1N2ZCUlQyaFRBdkRsMmRTTGphRkJ4VXd1SUJCTwpvd1NVNU1haHUyOE9uMTNINmFCRjJmdnd1Z2tqWkI4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0TVRZd1pXUTFOekl0WkRkbU55MDBOalUxTFdFeU5qQXRZamc1TnpBeE5XVmgKTURjeExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpocWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQWkxc2pTS3pKOWNSRnFVUEU5QnBtN2JnK0NFUnVIaUpnMXdRSE1uWHRVSVptL0JrYm9xSWZ5CmxyaEdDb1phK2FQYktYWWN0VTdJK1U3Zkx4NzMveHJVcmZSR0dIcVpEYy9PNHNCTFlwSHFmTFNQRmZHNXdRMFEKZXY0eFNpc0c0UzBweEpQY3hiSXBpTVl1WTV3MThzamJXUTg4STJjbmdzR1pIU3ZNOW01ZEVKeUo0OWc5Mmp5ZwpPMSt4dm9NTEI4NnYrcGszbmEza3dMRFpaSm5NLzVBT1Y5UmdLOFRROENaNVhTb2RXL2t3alZ0dTJSWUZyRmowCmFFYS9WeWtkVGhLQXFkWUNiVWovQmRNRmpRZTJQWFpPYmZ6NWl0YXZ5R04vU1VNQmxYM1ZDeGUzbHZ1bFhsdmQKc3AyTk1WMEVTUzU5OU5OeXhlNnZQM3VPN2VtaUNYYXEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1213"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:42 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -726,7 +726,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98b013a3-9555-43bb-b2af-7c20425fbb4d
+      - b7e4c482-d33d-4c88-9ae1-069c4aa09ff9
     status: 200 OK
     code: 200
     duration: ""
@@ -737,19 +737,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b3feb06b-27df-4000-966d-022d668d9e60/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVTVJCaEw5QnZWck14SHZIaU9KQU8rM2pBR2ZVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU9Gb1hEVE16TVRBeE56RTFOVEUxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUExOWZ0MXpCQ1ZiTjk3cE1oYytHSmRWdXdwcEJJLzRaR2VXOVNlV3FOUHVCcEY1MEp2RHEzVHUzSDlORXUKNER4U3R3OXBLSzBIRXlMc1RTU0pvNEFrb2JESUkvUW9IdWhRR25ZamZwV09NVjg5TmpYWVl0NXJBdGtSSEFycQo0TTdLVDZUY0xjSEN3S21NQit2SjFDbDZZbW1xbzdPYXZmdjJ5c1QySGtWd1ZhQzRYckdKL0x6YUUrbElWb2tSCnVnMVBlSG9BMGJkNU1NZmNvMTQ4K0EvR1dLdVVoeUhlcUh3dmhoNlgraWwvQ1lUZWk4TGNjeW5PT05xRVI0bWEKNlNEVWxIRnEvZlhKODVOTnZaYVNsSCs5aksvTU5YZVZvVjZvQml0KzM4a0VISjNXQ2xISDN4cEYrTVdIVTlxRwpnZDU1VlRPUHpXYktPdEtYaDFNZEpLUFZrd0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdFlqTm1aV0l3Tm1JdE1qZGtaaTAwTURBd0xUazJObVF0TURJeVpEWTJPR1E1WlRZd0xuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJJMkhod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUF0N2xwSzhmVWpRMWphN1ZoVHYrZzBaRjFHNWF3RjBNbDZ5SVJyZnAzU3pQU0lUMG1tOE13dmlLQTNDNEhMCkFtbERvR0FJSlpEU0hhUjRjQnQ1ODRtQ3Vha0k3VGFtZXhHa0JUOFVCL2NBeGkzcjI3UERxSkZ6RGpqU00rdC8KVk5tRmRFWDRzdmZEWTF6eTYzN29KWGVuTk5zNVQxSERseUlYSklOaDlLaTVtcVFPWGEwTlZUUHBMV050eE1vUApVSzFwM1FiTzFUOWc3aW4yVzJHd2tCYzAzbmNOVHZBc1d3YjllSTErSm1JblNHa2wrUjRsOUZmVmh2NmNHZzNlCm9zc1p3bG5lSGR5WkhUeDk2MlVoajh2OFk0cW9zMTBDcExnRWJhRkNRbUJiZjBuMGNacllnRnRDR0xZTTNWVzgKZU5jVGFBS2pRWWpjOVp6ZGNYeEIyU1ZiCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681},"endpoints":[{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681}],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1833"
+      - "1171"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:42 GMT
+      - Thu, 02 Nov 2023 18:49:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -759,7 +759,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf65eb21-8704-44bf-87bd-5111c016ac53
+      - 940c56cc-26e6-496a-a885-b14351efb306
     status: 200 OK
     code: 200
     duration: ""
@@ -770,52 +770,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b3feb06b-27df-4000-966d-022d668d9e60
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.318388Z","endpoint":{"id":"2b9845fa-75e2-432c-9ffb-7cdf1d55c70b","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19069},"endpoints":[{"id":"2b9845fa-75e2-432c-9ffb-7cdf1d55c70b","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19069}],"engine":"PostgreSQL-15","id":"b3feb06b-27df-4000-966d-022d668d9e60","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1213"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 37123bd1-d326-41cb-ac2d-ee23ca87d610
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b3feb06b-27df-4000-966d-022d668d9e60
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.318388Z","endpoint":{"id":"2b9845fa-75e2-432c-9ffb-7cdf1d55c70b","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19069},"endpoints":[{"id":"2b9845fa-75e2-432c-9ffb-7cdf1d55c70b","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19069}],"engine":"PostgreSQL-15","id":"b3feb06b-27df-4000-966d-022d668d9e60","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681},"endpoints":[{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681}],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1216"
+      - "1174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:43 GMT
+      - Thu, 02 Nov 2023 18:49:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -825,7 +792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d798520-43db-4c4c-89b5-73f4d5fa525d
+      - 8afb83fc-420f-4466-bb64-48a2a7fe7d72
     status: 200 OK
     code: 200
     duration: ""
@@ -836,19 +803,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b3feb06b-27df-4000-966d-022d668d9e60
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.318388Z","endpoint":{"id":"2b9845fa-75e2-432c-9ffb-7cdf1d55c70b","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19069},"endpoints":[{"id":"2b9845fa-75e2-432c-9ffb-7cdf1d55c70b","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19069}],"engine":"PostgreSQL-15","id":"b3feb06b-27df-4000-966d-022d668d9e60","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681},"endpoints":[{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681}],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1216"
+      - "1174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:43 GMT
+      - Thu, 02 Nov 2023 18:49:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -858,7 +825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 471ff8b5-30d3-43db-a91a-19dd1f3c4623
+      - 26edf8e7-74e2-4df0-bdc4-9fb2e58b4c07
     status: 200 OK
     code: 200
     duration: ""
@@ -869,10 +836,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b3feb06b-27df-4000-966d-022d668d9e60
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"b3feb06b-27df-4000-966d-022d668d9e60","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"160ed572-d7f7-4655-a260-b897015ea071","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -881,7 +848,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:13 GMT
+      - Thu, 02 Nov 2023 18:50:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -891,7 +858,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66559559-dbeb-4ff7-9bfc-0f2f5f2f4ae5
+      - 6fbd92b8-288f-452f-b27a-ce7470a387c4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -902,10 +869,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b3feb06b-27df-4000-966d-022d668d9e60
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"b3feb06b-27df-4000-966d-022d668d9e60","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"160ed572-d7f7-4655-a260-b897015ea071","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -914,7 +881,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:14 GMT
+      - Thu, 02 Nov 2023 18:50:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -924,7 +891,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f7de776-cc61-4101-af6b-9dc76eb2b1fb
+      - e0a05ede-e1b1-4c2e-b41d-39ab0039e0e1
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-init-settings.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-init-settings.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:05 GMT
+      - Thu, 02 Nov 2023 18:46:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31b35057-0197-4fc1-a66c-eb6649977575
+      - 29399ff7-c93c-4b9f-aa54-794dd6347fb5
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-init-settings","engine":"MySQL-8","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":null,"init_settings":[{"name":"lower_case_table_names","value":"1"}],"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-init-settings","engine":"MySQL-8","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":null,"init_settings":[{"name":"lower_case_table_names","value":"1"}],"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.197459Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"0a534bd8-e7c0-4edc-835d-660b6d785cb5","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "779"
+      - "751"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:10 GMT
+      - Thu, 02 Nov 2023 18:46:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76ebf4af-7af8-4530-9751-b67e8ab3722c
+      - 89967ef5-89f3-4c21-89be-bb667ca9497d
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a534bd8-e7c0-4edc-835d-660b6d785cb5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.197459Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"0a534bd8-e7c0-4edc-835d-660b6d785cb5","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "779"
+      - "751"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:10 GMT
+      - Thu, 02 Nov 2023 18:46:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc91fcbf-4f13-452d-86a6-8b8c06571ffb
+      - ae1d7c73-7f00-481b-870b-7849bfecf4e4
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a534bd8-e7c0-4edc-835d-660b6d785cb5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.197459Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"0a534bd8-e7c0-4edc-835d-660b6d785cb5","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "779"
+      - "751"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:40 GMT
+      - Thu, 02 Nov 2023 18:47:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e9c6471-3bf5-45e3-a964-4bfe9e31b837
+      - 7e7cabbc-0ae2-4162-a262-b0ee7430bc50
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a534bd8-e7c0-4edc-835d-660b6d785cb5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.197459Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"0a534bd8-e7c0-4edc-835d-660b6d785cb5","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "779"
+      - "751"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:52:10 GMT
+      - Thu, 02 Nov 2023 18:47:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be516104-8c40-4b79-b3d8-064b78dbbd28
+      - 1da24bc3-5351-453a-89bf-20a14d4343f1
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a534bd8-e7c0-4edc-835d-660b6d785cb5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.197459Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"0a534bd8-e7c0-4edc-835d-660b6d785cb5","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "779"
+      - "751"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:52:41 GMT
+      - Thu, 02 Nov 2023 18:48:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1ef2c4e-3036-4797-b910-6526f9db7c49
+      - 7e8071a3-a142-4485-b973-e5e1de222be2
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a534bd8-e7c0-4edc-835d-660b6d785cb5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.197459Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"0a534bd8-e7c0-4edc-835d-660b6d785cb5","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "779"
+      - "751"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:53:11 GMT
+      - Thu, 02 Nov 2023 18:48:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64f8ad29-60bd-48a9-890e-366c86181747
+      - abec11fa-1a0b-406e-8993-f1af03f83d5e
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a534bd8-e7c0-4edc-835d-660b6d785cb5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.197459Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"0a534bd8-e7c0-4edc-835d-660b6d785cb5","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "779"
+      - "751"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:53:41 GMT
+      - Thu, 02 Nov 2023 18:49:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b159c70e-985c-445c-a2cc-7b0e7d18eda6
+      - 0fef20a2-c8b3-4e8a-9927-bf09a7a7834b
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a534bd8-e7c0-4edc-835d-660b6d785cb5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.197459Z","endpoint":{"id":"4fe4421e-05ba-4faa-9d89-64e4aea77162","ip":"51.159.9.88","load_balancer":{},"name":null,"port":6018},"endpoints":[{"id":"4fe4421e-05ba-4faa-9d89-64e4aea77162","ip":"51.159.9.88","load_balancer":{},"name":null,"port":6018}],"engine":"MySQL-8","id":"0a534bd8-e7c0-4edc-835d-660b6d785cb5","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"100"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787},"endpoints":[{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787}],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"100"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1031"
+      - "1000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd9e4bd9-cdd0-4bc9-aa67-ca121615cd6f
+      - 0f54251f-1421-4ffc-b661-cce41407cea3
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a534bd8-e7c0-4edc-835d-660b6d785cb5/settings
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7/settings
     method: PUT
   response:
     body: '{"settings":[{"name":"max_connections","value":"350"}]}'
     headers:
       Content-Length:
-      - "56"
+      - "55"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ca8d7e5-dc82-4a58-b060-5896ea24e23e
+      - 785bda7b-1605-4580-bcc0-b824d9f4407d
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a534bd8-e7c0-4edc-835d-660b6d785cb5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.197459Z","endpoint":{"id":"4fe4421e-05ba-4faa-9d89-64e4aea77162","ip":"51.159.9.88","load_balancer":{},"name":null,"port":6018},"endpoints":[{"id":"4fe4421e-05ba-4faa-9d89-64e4aea77162","ip":"51.159.9.88","load_balancer":{},"name":null,"port":6018}],"engine":"MySQL-8","id":"0a534bd8-e7c0-4edc-835d-660b6d785cb5","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787},"endpoints":[{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787}],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1037"
+      - "1006"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c594c211-3073-4313-beef-efc3df8d3f40
+      - 9eadd1e1-7aee-47d4-b8d9-fc71666ca5e4
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a534bd8-e7c0-4edc-835d-660b6d785cb5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.197459Z","endpoint":{"id":"4fe4421e-05ba-4faa-9d89-64e4aea77162","ip":"51.159.9.88","load_balancer":{},"name":null,"port":6018},"endpoints":[{"id":"4fe4421e-05ba-4faa-9d89-64e4aea77162","ip":"51.159.9.88","load_balancer":{},"name":null,"port":6018}],"engine":"MySQL-8","id":"0a534bd8-e7c0-4edc-835d-660b6d785cb5","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787},"endpoints":[{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787}],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1031"
+      - "1000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:41 GMT
+      - Thu, 02 Nov 2023 18:50:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48d2d9ca-57fd-4abb-b7d3-d9969f1eaab1
+      - 6b39d9c7-b14a-4c4e-a2bb-ca0425a4b0e0
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a534bd8-e7c0-4edc-835d-660b6d785cb5/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVQ1dHczBFU3NUUGY4QTYzeitXWnREZzJMU3pBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU4xb1hEVE16TVRBeE56RTFOVEUxTjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFzUmp4aEc5bTN2dzN3UHMvMi9rK3dRZlZ3ZGVmZnNMWTNpcDBaZnBRNm5MNXhvZnAvTXdkMTZxbTloSmMKVzdJZUtRdTRMajN5YTNsbE1CMnNDT0JkVUl2Y3RwMlR0aVRCMUd6QjEyNVlaZXFXWjBoYVN5cW11cEVtRDVudQpLb1J1eUFDYnRKUW14WCtyaEdwTHdCZmpqSHJXUWpQOHgyOWJXSVhwa09LNHM0NEpPeUZTaExLY0ovRUN4N043Clh0YkV2S3JQMjkrRWJ2TkJWZHN4VktmK1RmRkpVUVdmamp5cS9mWGM2TjN4U2xveHBPc293aTJEVVJNazNkKzYKWE1iWUtIMTdtV0poY3RNQzl6NC9zNmhYemZMNktQOWVod0g2dFFaWlAzdFg5VklyejRxdGxzcEFWQ1hJVlA4dApVVUJVcFQrZkkvYU5mc21Cc1lLUEIzdThWUUlEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdE1HRTFNelJpWkRndFpUZGpNQzAwWldSakxUZ3pOV1F0TmpZd1lqWmtOemcxWTJJMUxuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJKOHZod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUNRM0ZndG5xOEJKZGV2NzQvQmJoL3M4Qm53ek5BRjA5dVZlamNmSUxzVzMxM2NPMWtySWtCQVZGSGNKR0EwCk5Bb2xYSUJGSml2NG5CMUF4QzFQVGVIRzdwaUNxQ3lzSDh1OTJVcjQ4MVU0cWpSYzVPbnoveDZ6ZmN2b2E2QVIKQStpMmwrRUs4eUZxdDQ4aDdqVHp0ZTF0RjBSMEI5RW9KaHhoaDNCSlh5Yk0zbDY0UnZmRm5hUVZJMWcwWXZRYwpWYlRLakpjcFZSQkFaUWdFUmIrR1hnQkxoZnY2SFdTUVFoS2NIQjFFcVQ3NCtNZnBsdkxFZGNoN05BbFVCR0ZYCjJ1UGRBdFpHeDMvTG1Lck1wQW51Q1paSi8xRjNwUjdpdTZLMkxPK0c5MlR5N1RWcHpKL3U5L1MrUXN2U2pXWEwKb21SM1VTSXE2Vk11dGt3YkNJOTVyVEVYCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTE1wNjJJWjBIVEtGQ3hWY2dEZVVjbXhXaGdrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56TXdXaGNOTXpNeE1ETXdNVGcwTnpNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU0vNktDUnZlUlZ6U1FETWFsenByN3NHWGc2U1lhV04rVGZzQW9lY3gvbEZPTjB3RkdxNXlTRGsKRkxqQzFWbE42OTEyT1JiWHdCRitJSGdEaDBQYmtSd0Z2TnpkYnp0QXA0MWp6YUxyd3d4ekpORzYxVFZiNnRXQgpEN0ZDaXk0WUtGdXVYQ1lHZURzS3JTZVpXSlFpSG50NUszeXFOTytKb0pJN3BIQ3NSR0NxY0dwclhKM0F1Mkc2ClZjQmVQRDRKQWVvaDJhNmZXVXZmVzNqdDlIQkZob284dnFoUklYb0xNeUlPVDltbFF6Z2dSZ3RmS3pMYW4xWTQKbmdHNWJTdXU5T2ZJRWJRRXZjYWIwNXhzVk1IZ091Uks0bjZqKzhMWUwreGJwVUJOR29RYWFhdE5OUW4rU1ZWQQphcTdlV09KRzcyTndVcnk5czNjQUMycUcvRmhtT2JFQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WVRBMFpUQm1NREF0TWpFMFpDMDBZamhsTFdJMFkyRXRZV0V3Wm1Vd1pHUXkKTUdJM0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1Nqckt0Z2h3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQzQzM2o0dEp5MWZ1TUE3Z2pBMlpvOS8rT00xRGZlWGYrUlJ2a2V5OENCRHdDMkMwSXBBcVAzClNEcW1YZ3BvTVNVL3J3ek5ORlZuL1BwUzgwSE53WEtXZW9oZTh6Qys5V0ZBdVBaalVYdjVSL0FXVlZublV0disKVmcwNm11dWFCQXFSK3JUV292YjA0Nk1xYXNkeUtOU0xJaUFpRXFLeStidjR6aFlxQ2VDakEwaENPMVJ4VmJWTApnN2ZCcUY3SFZXNXFnOGZKM2RHeDg3blZQRDgxNGlRd29wQ0toQkZWbzdPMFBhOW1Ta1cyUmFyNXNrQ2UveUxOCmMyMlA1VUNNUWlTTTVscjk1U2tTNklpc2d4Y0NiS1J5RURzR2xlbC9IOVRxWlFnOURqZXJmbGl1M1RMY2xHRDAKbW1BSVZLOWg2THprRVc0cVlJWjIwcUNRMzlIRUd1em0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:41 GMT
+      - Thu, 02 Nov 2023 18:50:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c56b1b0-e326-4eab-a5b2-8b2e3a33e8ce
+      - 5640477e-8723-4fe1-bc33-f614885c9f5e
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a534bd8-e7c0-4edc-835d-660b6d785cb5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.197459Z","endpoint":{"id":"4fe4421e-05ba-4faa-9d89-64e4aea77162","ip":"51.159.9.88","load_balancer":{},"name":null,"port":6018},"endpoints":[{"id":"4fe4421e-05ba-4faa-9d89-64e4aea77162","ip":"51.159.9.88","load_balancer":{},"name":null,"port":6018}],"engine":"MySQL-8","id":"0a534bd8-e7c0-4edc-835d-660b6d785cb5","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787},"endpoints":[{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787}],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1031"
+      - "1000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:42 GMT
+      - Thu, 02 Nov 2023 18:50:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89c73e3f-7c7d-4087-a797-0cc91cf70eed
+      - e4fe7e42-f5b7-4f39-a30c-c22a30056b0e
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a534bd8-e7c0-4edc-835d-660b6d785cb5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.197459Z","endpoint":{"id":"4fe4421e-05ba-4faa-9d89-64e4aea77162","ip":"51.159.9.88","load_balancer":{},"name":null,"port":6018},"endpoints":[{"id":"4fe4421e-05ba-4faa-9d89-64e4aea77162","ip":"51.159.9.88","load_balancer":{},"name":null,"port":6018}],"engine":"MySQL-8","id":"0a534bd8-e7c0-4edc-835d-660b6d785cb5","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787},"endpoints":[{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787}],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1031"
+      - "1000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:42 GMT
+      - Thu, 02 Nov 2023 18:50:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8258d419-ce6c-4431-9021-a830643a65a4
+      - ca71fff1-e337-4abe-a4f3-031dfbd30392
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a534bd8-e7c0-4edc-835d-660b6d785cb5/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVQ1dHczBFU3NUUGY4QTYzeitXWnREZzJMU3pBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU4xb1hEVE16TVRBeE56RTFOVEUxTjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFzUmp4aEc5bTN2dzN3UHMvMi9rK3dRZlZ3ZGVmZnNMWTNpcDBaZnBRNm5MNXhvZnAvTXdkMTZxbTloSmMKVzdJZUtRdTRMajN5YTNsbE1CMnNDT0JkVUl2Y3RwMlR0aVRCMUd6QjEyNVlaZXFXWjBoYVN5cW11cEVtRDVudQpLb1J1eUFDYnRKUW14WCtyaEdwTHdCZmpqSHJXUWpQOHgyOWJXSVhwa09LNHM0NEpPeUZTaExLY0ovRUN4N043Clh0YkV2S3JQMjkrRWJ2TkJWZHN4VktmK1RmRkpVUVdmamp5cS9mWGM2TjN4U2xveHBPc293aTJEVVJNazNkKzYKWE1iWUtIMTdtV0poY3RNQzl6NC9zNmhYemZMNktQOWVod0g2dFFaWlAzdFg5VklyejRxdGxzcEFWQ1hJVlA4dApVVUJVcFQrZkkvYU5mc21Cc1lLUEIzdThWUUlEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdE1HRTFNelJpWkRndFpUZGpNQzAwWldSakxUZ3pOV1F0TmpZd1lqWmtOemcxWTJJMUxuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJKOHZod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUNRM0ZndG5xOEJKZGV2NzQvQmJoL3M4Qm53ek5BRjA5dVZlamNmSUxzVzMxM2NPMWtySWtCQVZGSGNKR0EwCk5Bb2xYSUJGSml2NG5CMUF4QzFQVGVIRzdwaUNxQ3lzSDh1OTJVcjQ4MVU0cWpSYzVPbnoveDZ6ZmN2b2E2QVIKQStpMmwrRUs4eUZxdDQ4aDdqVHp0ZTF0RjBSMEI5RW9KaHhoaDNCSlh5Yk0zbDY0UnZmRm5hUVZJMWcwWXZRYwpWYlRLakpjcFZSQkFaUWdFUmIrR1hnQkxoZnY2SFdTUVFoS2NIQjFFcVQ3NCtNZnBsdkxFZGNoN05BbFVCR0ZYCjJ1UGRBdFpHeDMvTG1Lck1wQW51Q1paSi8xRjNwUjdpdTZLMkxPK0c5MlR5N1RWcHpKL3U5L1MrUXN2U2pXWEwKb21SM1VTSXE2Vk11dGt3YkNJOTVyVEVYCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTE1wNjJJWjBIVEtGQ3hWY2dEZVVjbXhXaGdrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56TXdXaGNOTXpNeE1ETXdNVGcwTnpNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU0vNktDUnZlUlZ6U1FETWFsenByN3NHWGc2U1lhV04rVGZzQW9lY3gvbEZPTjB3RkdxNXlTRGsKRkxqQzFWbE42OTEyT1JiWHdCRitJSGdEaDBQYmtSd0Z2TnpkYnp0QXA0MWp6YUxyd3d4ekpORzYxVFZiNnRXQgpEN0ZDaXk0WUtGdXVYQ1lHZURzS3JTZVpXSlFpSG50NUszeXFOTytKb0pJN3BIQ3NSR0NxY0dwclhKM0F1Mkc2ClZjQmVQRDRKQWVvaDJhNmZXVXZmVzNqdDlIQkZob284dnFoUklYb0xNeUlPVDltbFF6Z2dSZ3RmS3pMYW4xWTQKbmdHNWJTdXU5T2ZJRWJRRXZjYWIwNXhzVk1IZ091Uks0bjZqKzhMWUwreGJwVUJOR29RYWFhdE5OUW4rU1ZWQQphcTdlV09KRzcyTndVcnk5czNjQUMycUcvRmhtT2JFQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WVRBMFpUQm1NREF0TWpFMFpDMDBZamhsTFdJMFkyRXRZV0V3Wm1Vd1pHUXkKTUdJM0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1Nqckt0Z2h3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQzQzM2o0dEp5MWZ1TUE3Z2pBMlpvOS8rT00xRGZlWGYrUlJ2a2V5OENCRHdDMkMwSXBBcVAzClNEcW1YZ3BvTVNVL3J3ek5ORlZuL1BwUzgwSE53WEtXZW9oZTh6Qys5V0ZBdVBaalVYdjVSL0FXVlZublV0disKVmcwNm11dWFCQXFSK3JUV292YjA0Nk1xYXNkeUtOU0xJaUFpRXFLeStidjR6aFlxQ2VDakEwaENPMVJ4VmJWTApnN2ZCcUY3SFZXNXFnOGZKM2RHeDg3blZQRDgxNGlRd29wQ0toQkZWbzdPMFBhOW1Ta1cyUmFyNXNrQ2UveUxOCmMyMlA1VUNNUWlTTTVscjk1U2tTNklpc2d4Y0NiS1J5RURzR2xlbC9IOVRxWlFnOURqZXJmbGl1M1RMY2xHRDAKbW1BSVZLOWg2THprRVc0cVlJWjIwcUNRMzlIRUd1em0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:42 GMT
+      - Thu, 02 Nov 2023 18:50:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1266b87c-3157-40c2-8fef-4ab4dbb54574
+      - 81325a3a-ffc9-4628-8a16-9ce2fe39d308
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a534bd8-e7c0-4edc-835d-660b6d785cb5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.197459Z","endpoint":{"id":"4fe4421e-05ba-4faa-9d89-64e4aea77162","ip":"51.159.9.88","load_balancer":{},"name":null,"port":6018},"endpoints":[{"id":"4fe4421e-05ba-4faa-9d89-64e4aea77162","ip":"51.159.9.88","load_balancer":{},"name":null,"port":6018}],"engine":"MySQL-8","id":"0a534bd8-e7c0-4edc-835d-660b6d785cb5","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787},"endpoints":[{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787}],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1031"
+      - "1000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:43 GMT
+      - Thu, 02 Nov 2023 18:50:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c3162fe-0b8e-4b96-8aa3-50dc474d9f71
+      - 8d7f06b4-86ed-44a2-940b-fb06c632d4e3
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a534bd8-e7c0-4edc-835d-660b6d785cb5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.197459Z","endpoint":{"id":"4fe4421e-05ba-4faa-9d89-64e4aea77162","ip":"51.159.9.88","load_balancer":{},"name":null,"port":6018},"endpoints":[{"id":"4fe4421e-05ba-4faa-9d89-64e4aea77162","ip":"51.159.9.88","load_balancer":{},"name":null,"port":6018}],"engine":"MySQL-8","id":"0a534bd8-e7c0-4edc-835d-660b6d785cb5","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787},"endpoints":[{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787}],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1034"
+      - "1003"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:43 GMT
+      - Thu, 02 Nov 2023 18:50:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e467ace-9337-422d-a3f1-472027fb0310
+      - 571fb242-c5ab-4a01-89a4-f50b10d0cce3
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a534bd8-e7c0-4edc-835d-660b6d785cb5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.197459Z","endpoint":{"id":"4fe4421e-05ba-4faa-9d89-64e4aea77162","ip":"51.159.9.88","load_balancer":{},"name":null,"port":6018},"endpoints":[{"id":"4fe4421e-05ba-4faa-9d89-64e4aea77162","ip":"51.159.9.88","load_balancer":{},"name":null,"port":6018}],"engine":"MySQL-8","id":"0a534bd8-e7c0-4edc-835d-660b6d785cb5","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787},"endpoints":[{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787}],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1034"
+      - "1003"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:43 GMT
+      - Thu, 02 Nov 2023 18:50:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e32fd35a-8a04-49d3-a35b-d6c4ab835a24
+      - d97783b8-1475-4209-ae47-86ddcb4a0142
     status: 200 OK
     code: 200
     duration: ""
@@ -937,10 +937,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a534bd8-e7c0-4edc-835d-660b6d785cb5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"0a534bd8-e7c0-4edc-835d-660b6d785cb5","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -949,7 +949,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:14 GMT
+      - Thu, 02 Nov 2023 18:50:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b869f0e-cc92-4e1b-bf50-5ca73d6fc22c
+      - a8d6129b-9f07-4b46-bb04-5e8299fdb7b4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -970,10 +970,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a534bd8-e7c0-4edc-835d-660b6d785cb5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"0a534bd8-e7c0-4edc-835d-660b6d785cb5","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -982,7 +982,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:14 GMT
+      - Thu, 02 Nov 2023 18:50:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08bdd813-ebf6-4471-a6cd-5ae738cf66f7
+      - 4292792e-bb79-479a-bd61-826e1eee64d1
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-private-network-dhcp.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-private-network-dhcp.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:06 GMT
+      - Thu, 02 Nov 2023 18:46:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25d782b1-5d92-4561-8698-9fda4905e31f
+      - b7fb5bf4-669a-4234-bb2d-f9dbc457f83f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"192.168.1.0/24","address":null,"pool_low":null,"pool_high":null,"enable_dynamic":null,"valid_lifetime":null,"renew_timer":null,"rebind_timer":null,"push_default_route":null,"push_dns_server":null,"dns_servers_override":null,"dns_search":null,"dns_local_name":null}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"192.168.1.0/24"}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps
     method: POST
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "586"
+      - "568"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:16 GMT
+      - Thu, 02 Nov 2023 18:59:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7dd3596-3d36-401f-b772-6a093ef29c9f
+      - a432dedc-89fd-4d23-8a6e-47d1e07f8a1a
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/1ecb07a7-844b-458e-a893-be410ea56490
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/f664ab2c-301f-4cbd-9d28-cf56fe37db7d
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "586"
+      - "568"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:16 GMT
+      - Thu, 02 Nov 2023 18:59:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8daa6ae5-5a3f-426e-8352-443b42257f7b
+      - 912d9355-4893-4057-a228-0f86cb67e941
     status: 200 OK
     code: 200
     duration: ""
@@ -412,16 +412,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips
     method: POST
   response:
-    body: '{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":null,"id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"}'
+    body: '{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":null,"id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "365"
+      - "356"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:16 GMT
+      - Thu, 02 Nov 2023 18:59:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -431,7 +431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 093924d1-40f0-4d09-a8c6-20453f670872
+      - 80ce42f7-f2b9-4105-9ce9-0c87fc878f26
     status: 200 OK
     code: 200
     duration: ""
@@ -442,19 +442,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/2cf2fb1a-dc30-4838-881b-4d9639e53108
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e
     method: GET
   response:
-    body: '{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":null,"id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"}'
+    body: '{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":null,"id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "365"
+      - "356"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:16 GMT
+      - Thu, 02 Nov 2023 18:59:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -464,80 +464,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d17db1d7-15f1-4a8c-96cd-c7380239ca5e
+      - ea43283f-d0d9-4c1c-a24f-cb41235dbb4c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","enable_smtp":false,"enable_bastion":false,"bastion_port":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways
-    method: POST
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:00:16.659798Z","gateway_networks":[],"id":"70f4a360-5c98-4da0-90f8-33534072da05","ip":{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:00:16.659798Z","upstream_dns_servers":[],"version":null,"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "967"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:00:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7a2545fa-9c92-425e-85aa-692ed048bbe0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/70f4a360-5c98-4da0-90f8-33534072da05
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:00:16.659798Z","gateway_networks":[],"id":"70f4a360-5c98-4da0-90f8-33534072da05","ip":{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:00:16.721377Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "970"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:00:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - aea43ade-71a1-478b-9f75-4133379df301
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"my_private_network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"my_private_network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -548,16 +480,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-20T16:00:15.991080Z","dhcp_enabled":true,"id":"842ffa16-429a-4504-83a5-17f6c7633931","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:00:15.991080Z","id":"97f2ce37-69b4-4668-89f6-009be46ff1e4","subnet":"172.16.16.0/22","updated_at":"2023-10-20T16:00:15.991080Z"},{"created_at":"2023-10-20T16:00:15.991080Z","id":"3350edd7-5e16-40d0-be33-ee90ccce8393","subnet":"fd68:d440:21c4:62ce::/64","updated_at":"2023-10-20T16:00:15.991080Z"}],"tags":[],"updated_at":"2023-10-20T16:00:15.991080Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-02T18:59:00.881462Z","dhcp_enabled":true,"id":"0fc899b5-fd8e-408d-91d8-d0c477185680","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T18:59:00.881462Z","id":"a739db4b-6d5c-408e-ae89-80c252c0961f","subnet":"172.16.0.0/22","updated_at":"2023-11-02T18:59:00.881462Z"},{"created_at":"2023-11-02T18:59:00.881462Z","id":"be07ed5e-b85b-4c20-80e1-2012ddce8863","subnet":"fd68:d440:21c4:a8a7::/64","updated_at":"2023-11-02T18:59:00.881462Z"}],"tags":[],"updated_at":"2023-11-02T18:59:00.881462Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "719"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:17 GMT
+      - Thu, 02 Nov 2023 18:59:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -567,7 +499,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0176aed1-e371-4b9b-b734-fe172c3cae25
+      - 287d9142-e5f1-454b-87a9-da4c0e842133
     status: 200 OK
     code: 200
     duration: ""
@@ -578,19 +510,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/842ffa16-429a-4504-83a5-17f6c7633931
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/0fc899b5-fd8e-408d-91d8-d0c477185680
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:00:15.991080Z","dhcp_enabled":true,"id":"842ffa16-429a-4504-83a5-17f6c7633931","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:00:15.991080Z","id":"97f2ce37-69b4-4668-89f6-009be46ff1e4","subnet":"172.16.16.0/22","updated_at":"2023-10-20T16:00:15.991080Z"},{"created_at":"2023-10-20T16:00:15.991080Z","id":"3350edd7-5e16-40d0-be33-ee90ccce8393","subnet":"fd68:d440:21c4:62ce::/64","updated_at":"2023-10-20T16:00:15.991080Z"}],"tags":[],"updated_at":"2023-10-20T16:00:15.991080Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-02T18:59:00.881462Z","dhcp_enabled":true,"id":"0fc899b5-fd8e-408d-91d8-d0c477185680","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T18:59:00.881462Z","id":"a739db4b-6d5c-408e-ae89-80c252c0961f","subnet":"172.16.0.0/22","updated_at":"2023-11-02T18:59:00.881462Z"},{"created_at":"2023-11-02T18:59:00.881462Z","id":"be07ed5e-b85b-4c20-80e1-2012ddce8863","subnet":"fd68:d440:21c4:a8a7::/64","updated_at":"2023-11-02T18:59:00.881462Z"}],"tags":[],"updated_at":"2023-11-02T18:59:00.881462Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "719"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:17 GMT
+      - Thu, 02 Nov 2023 18:59:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -600,12 +532,80 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2d97047-2343-43a9-8642-f1a09888652e
+      - 6edac651-cda2-48c1-b5b4-66ce1bc9a88f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","service_ip":"192.168.1.254/24"}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","enable_smtp":false,"enable_bastion":false}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways
+    method: POST
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:01.565830Z","upstream_dns_servers":[],"version":null,"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "938"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:59:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7670081d-3866-4302-a7aa-f6fb09d56066
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:01.623189Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "941"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:59:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b31fffa7-f202-4a18-8e72-ef1c25899a54
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24"}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -616,16 +616,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:00:18.086500Z","endpoint":null,"endpoints":[{"id":"be00b33e-a6b1-4468-b534-a3921b4dda3c","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":null,"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1013"
+      - "977"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:18 GMT
+      - Thu, 02 Nov 2023 18:59:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -635,7 +635,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92798d1c-c9bc-4411-a8a9-0f9e2d7b3a7f
+      - 2e34b416-bbe4-4f23-add9-7101f29e6da6
     status: 200 OK
     code: 200
     duration: ""
@@ -646,19 +646,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:00:18.086500Z","endpoint":null,"endpoints":[{"id":"be00b33e-a6b1-4468-b534-a3921b4dda3c","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":null,"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1013"
+      - "977"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:18 GMT
+      - Thu, 02 Nov 2023 18:59:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -668,7 +668,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e67fe68f-3426-4e34-b346-a44750a7208a
+      - 9418eee5-6ed1-43fd-8ec0-cf7441f86b4a
     status: 200 OK
     code: 200
     duration: ""
@@ -679,19 +679,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/70f4a360-5c98-4da0-90f8-33534072da05
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:00:16.659798Z","gateway_networks":[],"id":"70f4a360-5c98-4da0-90f8-33534072da05","ip":{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:00:17.427647Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:02.295207Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "967"
+      - "938"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:21 GMT
+      - Thu, 02 Nov 2023 18:59:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -701,7 +701,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5059f56-da95-4118-97ed-5d0aba3a90bd
+      - 09b35c99-9eb6-4178-846d-d3e87c056d1c
     status: 200 OK
     code: 200
     duration: ""
@@ -712,19 +712,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/70f4a360-5c98-4da0-90f8-33534072da05
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:00:16.659798Z","gateway_networks":[],"id":"70f4a360-5c98-4da0-90f8-33534072da05","ip":{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:00:17.427647Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:02.295207Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "967"
+      - "938"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:21 GMT
+      - Thu, 02 Nov 2023 18:59:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -734,7 +734,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66eae39b-f211-4ad3-942c-fbd8989c3842
+      - e4c3dbd3-2fb1-4e68-b9b0-4c43b084807f
     status: 200 OK
     code: 200
     duration: ""
@@ -745,19 +745,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/70f4a360-5c98-4da0-90f8-33534072da05
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:00:16.659798Z","gateway_networks":[],"id":"70f4a360-5c98-4da0-90f8-33534072da05","ip":{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:00:17.427647Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:02.295207Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "967"
+      - "938"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:22 GMT
+      - Thu, 02 Nov 2023 18:59:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -767,12 +767,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dcc91a6b-c698-4b2c-8513-edcd9e115d1f
+      - ad389005-99dc-4517-b7c0-4dc2fe924bcf
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"1ecb07a7-844b-458e-a893-be410ea56490"}'
+    body: '{"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d"}'
     form: {}
     headers:
       Content-Type:
@@ -783,16 +783,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":null,"private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"created","updated_at":"2023-10-20T16:00:24.579267Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":null,"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"created","updated_at":"2023-11-02T18:59:08.412434Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "983"
+      - "953"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:24 GMT
+      - Thu, 02 Nov 2023 18:59:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -802,7 +802,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 086be1a3-3cd8-44ea-aa70-8198d7ac16b6
+      - 2743ed17-106f-488a-99d8-951afe7bb4a8
     status: 200 OK
     code: 200
     duration: ""
@@ -813,19 +813,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/70f4a360-5c98-4da0-90f8-33534072da05
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:00:16.659798Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":null,"private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"created","updated_at":"2023-10-20T16:00:24.579267Z","zone":"nl-ams-1"}],"id":"70f4a360-5c98-4da0-90f8-33534072da05","ip":{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:00:24.800658Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":null,"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"created","updated_at":"2023-11-02T18:59:08.412434Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:08.607849Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1953"
+      - "1894"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:25 GMT
+      - Thu, 02 Nov 2023 18:59:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -835,7 +835,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84df11cd-390f-4abb-8836-4fe587717c4a
+      - cbdb536a-e1bf-428f-ae04-c3197c2b824d
     status: 200 OK
     code: 200
     duration: ""
@@ -846,19 +846,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/70f4a360-5c98-4da0-90f8-33534072da05
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:00:16.659798Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":null,"private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"created","updated_at":"2023-10-20T16:00:24.579267Z","zone":"nl-ams-1"}],"id":"70f4a360-5c98-4da0-90f8-33534072da05","ip":{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:00:24.800658Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":null,"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"created","updated_at":"2023-11-02T18:59:08.412434Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:08.607849Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1953"
+      - "1894"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:30 GMT
+      - Thu, 02 Nov 2023 18:59:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -868,7 +868,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c1f12a6-82c0-4cea-8986-fd9de0d0143a
+      - 52b3c7e7-a9b5-4b95-8154-f4ec8099e984
     status: 200 OK
     code: 200
     duration: ""
@@ -879,19 +879,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/70f4a360-5c98-4da0-90f8-33534072da05
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:00:16.659798Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":"02:00:00:11:D8:03","private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"ready","updated_at":"2023-10-20T16:00:31.970952Z","zone":"nl-ams-1"}],"id":"70f4a360-5c98-4da0-90f8-33534072da05","ip":{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:00:32.094756Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1962"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:35 GMT
+      - Thu, 02 Nov 2023 18:59:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -901,7 +901,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20568974-612e-4d1b-8cba-b147e0d65990
+      - 97796922-6d5e-4e62-a6e2-d607d602b031
     status: 200 OK
     code: 200
     duration: ""
@@ -912,19 +912,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/6be64811-513c-49cc-bb48-b5509f5fa44c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":"02:00:00:11:D8:03","private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"ready","updated_at":"2023-10-20T16:00:31.970952Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "996"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:35 GMT
+      - Thu, 02 Nov 2023 18:59:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -934,7 +934,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d012f4f5-6fd4-4fa9-898a-5e026780356a
+      - eadc99d1-68d6-4825-a33d-79a24be16394
     status: 200 OK
     code: 200
     duration: ""
@@ -945,19 +945,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/6be64811-513c-49cc-bb48-b5509f5fa44c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":"02:00:00:11:D8:03","private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"ready","updated_at":"2023-10-20T16:00:31.970952Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "996"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:35 GMT
+      - Thu, 02 Nov 2023 18:59:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -967,7 +967,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 102969a5-f392-4665-b213-602cca33de02
+      - a2462c83-2ad1-4d62-9cbd-63ae7e849b9f
     status: 200 OK
     code: 200
     duration: ""
@@ -978,19 +978,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/70f4a360-5c98-4da0-90f8-33534072da05
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:00:16.659798Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":"02:00:00:11:D8:03","private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"ready","updated_at":"2023-10-20T16:00:31.970952Z","zone":"nl-ams-1"}],"id":"70f4a360-5c98-4da0-90f8-33534072da05","ip":{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:00:32.094756Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1962"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:35 GMT
+      - Thu, 02 Nov 2023 18:59:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1000,7 +1000,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a4ed479-2a72-47bd-9951-ead7599e7406
+      - f46769cc-c151-4ffe-84fe-ac733365f7d1
     status: 200 OK
     code: 200
     duration: ""
@@ -1011,19 +1011,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/6be64811-513c-49cc-bb48-b5509f5fa44c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":"02:00:00:11:D8:03","private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"ready","updated_at":"2023-10-20T16:00:31.970952Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "996"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:35 GMT
+      - Thu, 02 Nov 2023 18:59:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1033,7 +1033,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15f4e412-7651-4255-ad22-44d98c502e38
+      - 2cfd47bc-f7db-43c9-a2a1-5a61dd31a0fa
     status: 200 OK
     code: 200
     duration: ""
@@ -1044,19 +1044,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:00:18.086500Z","endpoint":null,"endpoints":[{"id":"be00b33e-a6b1-4468-b534-a3921b4dda3c","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":null,"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1013"
+      - "977"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:49 GMT
+      - Thu, 02 Nov 2023 18:59:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1066,7 +1066,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dcf4a87b-f20b-492b-8224-c8547715f2b3
+      - fde46197-94a8-4b80-bfc4-a2178f36375c
     status: 200 OK
     code: 200
     duration: ""
@@ -1077,19 +1077,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:00:18.086500Z","endpoint":null,"endpoints":[{"id":"be00b33e-a6b1-4468-b534-a3921b4dda3c","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":null,"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1013"
+      - "977"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:19 GMT
+      - Thu, 02 Nov 2023 19:00:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1099,7 +1099,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 773a9287-875b-4bc8-b435-00040d0f6a9f
+      - 4fe3e26b-bb55-4dc7-a67e-1cb530353e3d
     status: 200 OK
     code: 200
     duration: ""
@@ -1110,19 +1110,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:00:18.086500Z","endpoint":null,"endpoints":[{"id":"be00b33e-a6b1-4468-b534-a3921b4dda3c","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":null,"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1013"
+      - "977"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:49 GMT
+      - Thu, 02 Nov 2023 19:00:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1132,7 +1132,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52778441-8790-4386-8901-6dd9decd35fd
+      - d7fc5d08-c7cf-413d-9afb-572e99b8c313
     status: 200 OK
     code: 200
     duration: ""
@@ -1143,19 +1143,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:00:18.086500Z","endpoint":null,"endpoints":[{"id":"be00b33e-a6b1-4468-b534-a3921b4dda3c","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":null,"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1013"
+      - "977"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:19 GMT
+      - Thu, 02 Nov 2023 19:01:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1165,7 +1165,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e05e30b-5e52-45ab-89f0-4c651d47768a
+      - f31751f0-d922-452c-923e-0dffffaa48c8
     status: 200 OK
     code: 200
     duration: ""
@@ -1176,19 +1176,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:00:18.086500Z","endpoint":null,"endpoints":[{"id":"be00b33e-a6b1-4468-b534-a3921b4dda3c","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":null,"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1013"
+      - "977"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:50 GMT
+      - Thu, 02 Nov 2023 19:01:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1198,7 +1198,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fcddb904-da5e-4729-86ac-1f54deb080f3
+      - 91ab974b-8239-46fc-b683-f7a976666ca9
     status: 200 OK
     code: 200
     duration: ""
@@ -1209,19 +1209,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:00:18.086500Z","endpoint":{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700},"endpoints":[{"id":"be00b33e-a6b1-4468-b534-a3921b4dda3c","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700}],"engine":"PostgreSQL-15","id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1507"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:20 GMT
+      - Thu, 02 Nov 2023 19:02:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1231,7 +1231,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2dcb658-47ff-48b2-896e-bec5d7606eea
+      - 0d9c6a49-f1c5-4140-a7ae-51c349db89d3
     status: 200 OK
     code: 200
     duration: ""
@@ -1242,19 +1242,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1VENDQXFHZ0F3SUJBZ0lVY0puZEtPdytzZktveExpZWQwWjZqMUFFZ2lFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNREl3TVRZd01USTFXaGNOTXpNeE1ERTNNVFl3TVRJMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1tcnlvSEdaODZkaGFtZGlqdzFHQjFETU1jczhhV1JqSWtESmlxRUs0SGNqRk1LUHozcFN2RXcKdWFiYXY2RHFyTXd5bE1TZkViaUtud3JWVHdiVWlRVC8xNGFBVGZvaU1XWm9ocHl2N0d0dkVCbUErbDBVSmx3dAp3NjZPeCtlNlI2Ri9DK3UycFNvaUdlcjA4Y0plcVFueEo3TllqOXNBRzZtUFNlRE04ZnhkYU5NNmptUlBVM3ZSCmdXYkhMdWltSnR2bXg3TEx1UEwzcTlPb3ViT1JYNHRNeHB6SjVCNkh4cnpxUzRPTkt3TmxkdkRtQWJlQ3AxQnUKK1RWMmJXbGxwMXVpUkZ5Qi9qaUhaWTNrMGxmbzh3TEpwL2NKMUU2eEQvQVdZY2NmaUJERTBaZEFIQzk5bXVLMApQV21oT0JibGRZbjlPdTFsRDg2OVRpMmFpU293SzhjQ0F3RUFBYU43TUhrd2R3WURWUjBSQkhBd2JvSU5NVGt5CkxqRTJPQzR4TGpJMU5JSU5OVEV1TVRVNExqRXlPUzR5Tm9JOGNuY3ROMlF6T0Rsa05qa3Raams0WmkwME1UUTEKTFdJMk9EWXRObVJtTmpSaU5tWmxOV1kwTG5Ka1lpNXViQzFoYlhNdWMyTjNMbU5zYjNWa2h3UXpEMmxpaHdUQQpxQUgraHdRem5vRWFNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUFheC8xZmJZMTZyRHNieUVMUXVySDN1UXpMClRQU2pBMmlNSnY3SWNMbkxlQmZoQUxDZVQ3V2JHMzN5ZVA3ZVhVQ1FqUm1TN0czRnRheE9JOFJ1eWRGSW1CVHQKbWc5bEZIRVJONHl2VVBBa3JkQXRBck83Z0JSZGVZVXVGV25IS3pWOXcxc1pLbVRUdWpQTmRucWU4VlhEaXVKUgowdmNTMFpOQkpOZVo0QkpWdzNIa1Z0REx0Q1lJVDh4MFczTG9nOVZ4Wmtxc2NxUDh5Q2xOQldyQkxlc3ptQUhWCkVYNlJJczlaWjhEWDBLWEhRVlhzekpUV0NSMFVUcFhUc1RPRDNLUTE3S0pkOW9sT0NFSEtJY2xPaWFOaDgrLzYKbGNPUDUzcXdia3l0L1N4U3JTczFTQnpSM2RTNTNQeklTSjk4NlZSR1VkL0hTMmdMOXhvZW5pdUpJbEtJCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1akNDQXFLZ0F3SUJBZ0lVWnVBWFRNTEpxOExXZ3VHRVE0dExhdXdlUVZNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNVEF5TVRrd01ERXdXaGNOTXpNeE1ETXdNVGt3TURFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQVBDSGVseFVmUG9hQlRZSHFUbzEvR1cxaVhKay9MczhlUkJrR2daL0RhdEVrMEN4bkJYaUI2SjkKNXNsQVhwSUdBd2xOK29TWDJVK1BpK1NUcFBTQzJheU9NenFNczRpbVd1ckhoamR3WmNVd0hqTnplc1JHS05VagppcEJlcVBDbHk0Uy8yNHhUaWFlTUdwWFdqTlNtb1hNc3BXNG90aGNpd0FlejV0T0RCTkZsN2cvd3lUNVczSnJPCjhULzNmMzErbHkwVlZETHlHNnI3bG1DY3FVWnNWSDhIT3VSN0pLcnYwTjBjWmlQTVhXZnAwbEpqWDlhK2xmb0IKeTg4ZmRRbUJEMytVTThNRFBEVExHTWxDOW5OQ054YzJhcUVNQXlKRFhLbWFwUHdteFFBMElWT1VMNjNQTTdWbwpIaWFMcllNZVExUU4wLzNvVlNCMXNVWWRXL09MaFE4Q0F3RUFBYU44TUhvd2VBWURWUjBSQkhFd2I0SU5NVGt5CkxqRTJPQzR4TGpJMU5JSU9OVEV1TVRVNExqRXpNQzR5TURLQ1BISjNMVE14TlRJd05XSTBMVFUyTVdFdE5EWmwKTnkxaE5qazFMV1ptWTJFeE5USTFaR0U0TkM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpJY0VNdzljZW9jRQp3S2dCL29jRU01NkN5akFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBdGphYW5WRjJyaGVSYlhiSm8xSUoyUk9FClFiLzVKVjJvclpTMVA5V0Z5MEd5dDZXNWV3QzJqSTBxQzZxK0Vya3lXNVg2VzlHTk9JNnc3QUtPQmhtSFYza3EKQm9IZjlYVjZ0ZVI4SkxFbnlLODUrQWN2RUxyQXBTczAwZlcwOEhkQ2NPUGNxeFpIRUUxcHZ0RlZuckV2NE0vMwoxYzhVcFVNT0F6Ri9PQnRDWnRYUXVTTEpjS3NCNDNDRVZ3SklydFQzTjhvdlJmVUk3dTlyUk5zcHJ6eE4xZytuCk53YzhGUzR1QnVZTDJpRE5NWU1YNGk3NHgzTm0zakF3OUZTK24yZ2xRQ1dPeEFTTGt3R2xwQzRiSjZkdkhyQjcKWlZKSlFORnM2V3FXajd2YUtsNGtjcUQ4Wis2QTJlNnNTTWRILzgwZlk5OGRpUTdPVk8wb21tNjlzcTZrZXc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1881"
+      - "1887"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:20 GMT
+      - Thu, 02 Nov 2023 19:02:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1264,7 +1264,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51cd173c-f5ff-47cf-874f-fb2ba33968e9
+      - 553653e8-0bf8-4783-ace7-985951d8c45a
     status: 200 OK
     code: 200
     duration: ""
@@ -1275,19 +1275,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/70f4a360-5c98-4da0-90f8-33534072da05
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:00:16.659798Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":"02:00:00:11:D8:03","private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"ready","updated_at":"2023-10-20T16:00:31.970952Z","zone":"nl-ams-1"}],"id":"70f4a360-5c98-4da0-90f8-33534072da05","ip":{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:00:32.094756Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1962"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:20 GMT
+      - Thu, 02 Nov 2023 19:02:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1297,7 +1297,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68978f73-357c-44ae-b653-a7a60cf543be
+      - e7bd4953-83d1-45e5-bd58-b6f96d25c728
     status: 200 OK
     code: 200
     duration: ""
@@ -1308,19 +1308,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/70f4a360-5c98-4da0-90f8-33534072da05
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:00:16.659798Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":"02:00:00:11:D8:03","private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"ready","updated_at":"2023-10-20T16:00:31.970952Z","zone":"nl-ams-1"}],"id":"70f4a360-5c98-4da0-90f8-33534072da05","ip":{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:00:32.094756Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1962"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:20 GMT
+      - Thu, 02 Nov 2023 19:02:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1330,12 +1330,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6db139e8-4668-48d2-a997-fd0b275d0b8b
+      - ed65de23-7cd7-44d6-b7ce-439fe0c9e78a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both"}'
+    body: '{"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both"}'
     form: {}
     headers:
       Content-Type:
@@ -1346,16 +1346,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules
     method: POST
   response:
-    body: '{"created_at":"2023-10-20T16:03:20.725429Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"3513169c-6393-4a83-bfbb-5705212d8e65","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-10-20T16:03:20.725429Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-02T19:02:03.927209Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"caa010cd-8c5a-4afc-9a78-63dda87e714b","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-02T19:02:03.927209Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "291"
+      - "283"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:20 GMT
+      - Thu, 02 Nov 2023 19:02:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1365,7 +1365,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94b65eae-4caa-48d7-994f-c289634f1894
+      - c204e648-d3f1-498f-bad2-d3ecc6ea2ee8
     status: 200 OK
     code: 200
     duration: ""
@@ -1376,19 +1376,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/70f4a360-5c98-4da0-90f8-33534072da05
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:00:16.659798Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":"02:00:00:11:D8:03","private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"ready","updated_at":"2023-10-20T16:00:31.970952Z","zone":"nl-ams-1"}],"id":"70f4a360-5c98-4da0-90f8-33534072da05","ip":{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:00:32.094756Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1962"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:20 GMT
+      - Thu, 02 Nov 2023 19:02:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1398,7 +1398,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37b43e06-1d23-42da-9659-acc31fd2f0e3
+      - f205ffe6-ce3e-4ef2-aa47-50b5386fa56e
     status: 200 OK
     code: 200
     duration: ""
@@ -1409,19 +1409,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/3513169c-6393-4a83-bfbb-5705212d8e65
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/caa010cd-8c5a-4afc-9a78-63dda87e714b
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:03:20.725429Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"3513169c-6393-4a83-bfbb-5705212d8e65","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-10-20T16:03:20.725429Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-02T19:02:03.927209Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"caa010cd-8c5a-4afc-9a78-63dda87e714b","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-02T19:02:03.927209Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "291"
+      - "283"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:20 GMT
+      - Thu, 02 Nov 2023 19:02:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1431,7 +1431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4ab6130-e427-482e-8cbd-0be544229ad5
+      - 529718c0-7d71-4ec7-9a8a-759f3dda6b10
     status: 200 OK
     code: 200
     duration: ""
@@ -1442,19 +1442,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:00:18.086500Z","endpoint":{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700},"endpoints":[{"id":"be00b33e-a6b1-4468-b534-a3921b4dda3c","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700}],"engine":"PostgreSQL-15","id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1507"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:21 GMT
+      - Thu, 02 Nov 2023 19:02:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1464,7 +1464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d207d4b-7f6c-40f6-9660-b31088572e8a
+      - 14abae39-4f97-491f-8164-a2694f705796
     status: 200 OK
     code: 200
     duration: ""
@@ -1475,19 +1475,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/2cf2fb1a-dc30-4838-881b-4d9639e53108
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e
     method: GET
   response:
-    body: '{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"}'
+    body: '{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "399"
+      - "390"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:22 GMT
+      - Thu, 02 Nov 2023 19:02:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1497,7 +1497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 476abb65-cee8-4ff2-858b-074e3a7b9e84
+      - f9f46e93-3147-4ad9-bc81-023effa8fc92
     status: 200 OK
     code: 200
     duration: ""
@@ -1508,19 +1508,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/1ecb07a7-844b-458e-a893-be410ea56490
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/0fc899b5-fd8e-408d-91d8-d0c477185680
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-02T18:59:00.881462Z","dhcp_enabled":true,"id":"0fc899b5-fd8e-408d-91d8-d0c477185680","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T18:59:00.881462Z","id":"a739db4b-6d5c-408e-ae89-80c252c0961f","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:07.391460Z"},{"created_at":"2023-11-02T18:59:00.881462Z","id":"be07ed5e-b85b-4c20-80e1-2012ddce8863","subnet":"fd68:d440:21c4:a8a7::/64","updated_at":"2023-11-02T18:59:07.394943Z"}],"tags":[],"updated_at":"2023-11-02T18:59:15.278924Z","vpc_id":"1633022c-3fa1-431a-b398-1c67551e922c"}'
     headers:
       Content-Length:
-      - "586"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:22 GMT
+      - Thu, 02 Nov 2023 19:02:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1530,7 +1530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2093923-f8c4-48dc-9201-ab6d6c47ddd4
+      - debdde4c-6e0a-4ac0-a9fb-a667474d2f4c
     status: 200 OK
     code: 200
     duration: ""
@@ -1541,19 +1541,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/842ffa16-429a-4504-83a5-17f6c7633931
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/f664ab2c-301f-4cbd-9d28-cf56fe37db7d
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:00:15.991080Z","dhcp_enabled":true,"id":"842ffa16-429a-4504-83a5-17f6c7633931","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:00:15.991080Z","id":"97f2ce37-69b4-4668-89f6-009be46ff1e4","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:22.440490Z"},{"created_at":"2023-10-20T16:00:15.991080Z","id":"3350edd7-5e16-40d0-be33-ee90ccce8393","subnet":"fd68:d440:21c4:62ce::/64","updated_at":"2023-10-20T16:00:22.444731Z"}],"tags":[],"updated_at":"2023-10-20T16:00:31.694725Z","vpc_id":"9cb8396b-8328-412b-a866-e0c275b320a1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "719"
+      - "568"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:22 GMT
+      - Thu, 02 Nov 2023 19:02:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1563,7 +1563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - feee954e-c68f-4d67-856c-e372dc2f7b1b
+      - a42f51aa-bc12-4f1b-9e99-8cb00c5c3f2f
     status: 200 OK
     code: 200
     duration: ""
@@ -1574,19 +1574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/70f4a360-5c98-4da0-90f8-33534072da05
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:00:16.659798Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":"02:00:00:11:D8:03","private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"ready","updated_at":"2023-10-20T16:00:31.970952Z","zone":"nl-ams-1"}],"id":"70f4a360-5c98-4da0-90f8-33534072da05","ip":{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:00:32.094756Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1962"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:22 GMT
+      - Thu, 02 Nov 2023 19:02:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1596,7 +1596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3a36ec3-5cc4-401f-9879-47b706897449
+      - 7e581846-4691-4a1c-8a13-6d81c2854991
     status: 200 OK
     code: 200
     duration: ""
@@ -1607,19 +1607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:00:18.086500Z","endpoint":{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700},"endpoints":[{"id":"be00b33e-a6b1-4468-b534-a3921b4dda3c","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700}],"engine":"PostgreSQL-15","id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1507"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:22 GMT
+      - Thu, 02 Nov 2023 19:02:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1629,7 +1629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ac03c3b-a633-45c0-b0cd-b29aedc31b4f
+      - ebeefca3-4fd1-4ffb-ad7f-81d768e11abe
     status: 200 OK
     code: 200
     duration: ""
@@ -1640,19 +1640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/6be64811-513c-49cc-bb48-b5509f5fa44c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":"02:00:00:11:D8:03","private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"ready","updated_at":"2023-10-20T16:00:31.970952Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "996"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:22 GMT
+      - Thu, 02 Nov 2023 19:02:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1662,7 +1662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07a23a7b-48fb-4d00-8bd1-6d75f6095f5e
+      - 5a7f9cea-6a86-4540-86d4-4245ac2c6e1b
     status: 200 OK
     code: 200
     duration: ""
@@ -1673,19 +1673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/70f4a360-5c98-4da0-90f8-33534072da05
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:00:16.659798Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":"02:00:00:11:D8:03","private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"ready","updated_at":"2023-10-20T16:00:31.970952Z","zone":"nl-ams-1"}],"id":"70f4a360-5c98-4da0-90f8-33534072da05","ip":{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:00:32.094756Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1962"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:22 GMT
+      - Thu, 02 Nov 2023 19:02:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1695,7 +1695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e45c66de-8f1c-4a5c-a74a-f59af6426a02
+      - b046d710-1ae8-48c3-9184-6e5ffa567f0c
     status: 200 OK
     code: 200
     duration: ""
@@ -1706,19 +1706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1VENDQXFHZ0F3SUJBZ0lVY0puZEtPdytzZktveExpZWQwWjZqMUFFZ2lFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNREl3TVRZd01USTFXaGNOTXpNeE1ERTNNVFl3TVRJMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1tcnlvSEdaODZkaGFtZGlqdzFHQjFETU1jczhhV1JqSWtESmlxRUs0SGNqRk1LUHozcFN2RXcKdWFiYXY2RHFyTXd5bE1TZkViaUtud3JWVHdiVWlRVC8xNGFBVGZvaU1XWm9ocHl2N0d0dkVCbUErbDBVSmx3dAp3NjZPeCtlNlI2Ri9DK3UycFNvaUdlcjA4Y0plcVFueEo3TllqOXNBRzZtUFNlRE04ZnhkYU5NNmptUlBVM3ZSCmdXYkhMdWltSnR2bXg3TEx1UEwzcTlPb3ViT1JYNHRNeHB6SjVCNkh4cnpxUzRPTkt3TmxkdkRtQWJlQ3AxQnUKK1RWMmJXbGxwMXVpUkZ5Qi9qaUhaWTNrMGxmbzh3TEpwL2NKMUU2eEQvQVdZY2NmaUJERTBaZEFIQzk5bXVLMApQV21oT0JibGRZbjlPdTFsRDg2OVRpMmFpU293SzhjQ0F3RUFBYU43TUhrd2R3WURWUjBSQkhBd2JvSU5NVGt5CkxqRTJPQzR4TGpJMU5JSU5OVEV1TVRVNExqRXlPUzR5Tm9JOGNuY3ROMlF6T0Rsa05qa3Raams0WmkwME1UUTEKTFdJMk9EWXRObVJtTmpSaU5tWmxOV1kwTG5Ka1lpNXViQzFoYlhNdWMyTjNMbU5zYjNWa2h3UXpEMmxpaHdUQQpxQUgraHdRem5vRWFNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUFheC8xZmJZMTZyRHNieUVMUXVySDN1UXpMClRQU2pBMmlNSnY3SWNMbkxlQmZoQUxDZVQ3V2JHMzN5ZVA3ZVhVQ1FqUm1TN0czRnRheE9JOFJ1eWRGSW1CVHQKbWc5bEZIRVJONHl2VVBBa3JkQXRBck83Z0JSZGVZVXVGV25IS3pWOXcxc1pLbVRUdWpQTmRucWU4VlhEaXVKUgowdmNTMFpOQkpOZVo0QkpWdzNIa1Z0REx0Q1lJVDh4MFczTG9nOVZ4Wmtxc2NxUDh5Q2xOQldyQkxlc3ptQUhWCkVYNlJJczlaWjhEWDBLWEhRVlhzekpUV0NSMFVUcFhUc1RPRDNLUTE3S0pkOW9sT0NFSEtJY2xPaWFOaDgrLzYKbGNPUDUzcXdia3l0L1N4U3JTczFTQnpSM2RTNTNQeklTSjk4NlZSR1VkL0hTMmdMOXhvZW5pdUpJbEtJCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1akNDQXFLZ0F3SUJBZ0lVWnVBWFRNTEpxOExXZ3VHRVE0dExhdXdlUVZNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNVEF5TVRrd01ERXdXaGNOTXpNeE1ETXdNVGt3TURFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQVBDSGVseFVmUG9hQlRZSHFUbzEvR1cxaVhKay9MczhlUkJrR2daL0RhdEVrMEN4bkJYaUI2SjkKNXNsQVhwSUdBd2xOK29TWDJVK1BpK1NUcFBTQzJheU9NenFNczRpbVd1ckhoamR3WmNVd0hqTnplc1JHS05VagppcEJlcVBDbHk0Uy8yNHhUaWFlTUdwWFdqTlNtb1hNc3BXNG90aGNpd0FlejV0T0RCTkZsN2cvd3lUNVczSnJPCjhULzNmMzErbHkwVlZETHlHNnI3bG1DY3FVWnNWSDhIT3VSN0pLcnYwTjBjWmlQTVhXZnAwbEpqWDlhK2xmb0IKeTg4ZmRRbUJEMytVTThNRFBEVExHTWxDOW5OQ054YzJhcUVNQXlKRFhLbWFwUHdteFFBMElWT1VMNjNQTTdWbwpIaWFMcllNZVExUU4wLzNvVlNCMXNVWWRXL09MaFE4Q0F3RUFBYU44TUhvd2VBWURWUjBSQkhFd2I0SU5NVGt5CkxqRTJPQzR4TGpJMU5JSU9OVEV1TVRVNExqRXpNQzR5TURLQ1BISjNMVE14TlRJd05XSTBMVFUyTVdFdE5EWmwKTnkxaE5qazFMV1ptWTJFeE5USTFaR0U0TkM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpJY0VNdzljZW9jRQp3S2dCL29jRU01NkN5akFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBdGphYW5WRjJyaGVSYlhiSm8xSUoyUk9FClFiLzVKVjJvclpTMVA5V0Z5MEd5dDZXNWV3QzJqSTBxQzZxK0Vya3lXNVg2VzlHTk9JNnc3QUtPQmhtSFYza3EKQm9IZjlYVjZ0ZVI4SkxFbnlLODUrQWN2RUxyQXBTczAwZlcwOEhkQ2NPUGNxeFpIRUUxcHZ0RlZuckV2NE0vMwoxYzhVcFVNT0F6Ri9PQnRDWnRYUXVTTEpjS3NCNDNDRVZ3SklydFQzTjhvdlJmVUk3dTlyUk5zcHJ6eE4xZytuCk53YzhGUzR1QnVZTDJpRE5NWU1YNGk3NHgzTm0zakF3OUZTK24yZ2xRQ1dPeEFTTGt3R2xwQzRiSjZkdkhyQjcKWlZKSlFORnM2V3FXajd2YUtsNGtjcUQ4Wis2QTJlNnNTTWRILzgwZlk5OGRpUTdPVk8wb21tNjlzcTZrZXc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1881"
+      - "1887"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:22 GMT
+      - Thu, 02 Nov 2023 19:02:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1728,7 +1728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 005cd4f1-2d42-4c34-a03d-3c4951febe92
+      - d220b97d-5a7d-419f-8a46-95ac3326d7cc
     status: 200 OK
     code: 200
     duration: ""
@@ -1739,19 +1739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/6be64811-513c-49cc-bb48-b5509f5fa44c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":"02:00:00:11:D8:03","private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"ready","updated_at":"2023-10-20T16:00:31.970952Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "996"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:22 GMT
+      - Thu, 02 Nov 2023 19:02:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1761,7 +1761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a468071d-3074-4619-a153-5abc35540d32
+      - 91ca4f34-a10d-499d-b0e7-ab0797f87c3f
     status: 200 OK
     code: 200
     duration: ""
@@ -1772,19 +1772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/3513169c-6393-4a83-bfbb-5705212d8e65
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/caa010cd-8c5a-4afc-9a78-63dda87e714b
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:03:20.725429Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"3513169c-6393-4a83-bfbb-5705212d8e65","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-10-20T16:03:20.725429Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-02T19:02:03.927209Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"caa010cd-8c5a-4afc-9a78-63dda87e714b","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-02T19:02:03.927209Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "291"
+      - "283"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:22 GMT
+      - Thu, 02 Nov 2023 19:02:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1794,7 +1794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc61e40a-83e4-467b-af79-43b2cd0d59da
+      - 6a355282-0b35-4488-94f4-260741682419
     status: 200 OK
     code: 200
     duration: ""
@@ -1805,19 +1805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/3513169c-6393-4a83-bfbb-5705212d8e65
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/f664ab2c-301f-4cbd-9d28-cf56fe37db7d
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:03:20.725429Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"3513169c-6393-4a83-bfbb-5705212d8e65","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-10-20T16:03:20.725429Z","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "291"
+      - "568"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:23 GMT
+      - Thu, 02 Nov 2023 19:02:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1827,7 +1827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95629ebd-5dde-4dda-a219-065f5190d70c
+      - baa0881b-5e6e-4773-97e8-90b4d5dd5ca6
     status: 200 OK
     code: 200
     duration: ""
@@ -1838,19 +1838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/70f4a360-5c98-4da0-90f8-33534072da05
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/caa010cd-8c5a-4afc-9a78-63dda87e714b
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:00:16.659798Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":"02:00:00:11:D8:03","private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"ready","updated_at":"2023-10-20T16:00:31.970952Z","zone":"nl-ams-1"}],"id":"70f4a360-5c98-4da0-90f8-33534072da05","ip":{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:00:32.094756Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-02T19:02:03.927209Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"caa010cd-8c5a-4afc-9a78-63dda87e714b","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-02T19:02:03.927209Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1962"
+      - "283"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:23 GMT
+      - Thu, 02 Nov 2023 19:02:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1860,7 +1860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26719ebb-d00c-4028-84e8-b78c22a29727
+      - 11eddec8-cac8-4932-bf07-b29d306b3af4
     status: 200 OK
     code: 200
     duration: ""
@@ -1871,19 +1871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/2cf2fb1a-dc30-4838-881b-4d9639e53108
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/0fc899b5-fd8e-408d-91d8-d0c477185680
     method: GET
   response:
-    body: '{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-02T18:59:00.881462Z","dhcp_enabled":true,"id":"0fc899b5-fd8e-408d-91d8-d0c477185680","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T18:59:00.881462Z","id":"a739db4b-6d5c-408e-ae89-80c252c0961f","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:07.391460Z"},{"created_at":"2023-11-02T18:59:00.881462Z","id":"be07ed5e-b85b-4c20-80e1-2012ddce8863","subnet":"fd68:d440:21c4:a8a7::/64","updated_at":"2023-11-02T18:59:07.394943Z"}],"tags":[],"updated_at":"2023-11-02T18:59:15.278924Z","vpc_id":"1633022c-3fa1-431a-b398-1c67551e922c"}'
     headers:
       Content-Length:
-      - "399"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:23 GMT
+      - Thu, 02 Nov 2023 19:02:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1893,7 +1893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba4473d3-db62-42f0-9dca-345b03ba0d0d
+      - 2feff567-f891-4656-87b4-7a37776da3b0
     status: 200 OK
     code: 200
     duration: ""
@@ -1904,19 +1904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/842ffa16-429a-4504-83a5-17f6c7633931
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:00:15.991080Z","dhcp_enabled":true,"id":"842ffa16-429a-4504-83a5-17f6c7633931","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:00:15.991080Z","id":"97f2ce37-69b4-4668-89f6-009be46ff1e4","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:22.440490Z"},{"created_at":"2023-10-20T16:00:15.991080Z","id":"3350edd7-5e16-40d0-be33-ee90ccce8393","subnet":"fd68:d440:21c4:62ce::/64","updated_at":"2023-10-20T16:00:22.444731Z"}],"tags":[],"updated_at":"2023-10-20T16:00:31.694725Z","vpc_id":"9cb8396b-8328-412b-a866-e0c275b320a1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "719"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:23 GMT
+      - Thu, 02 Nov 2023 19:02:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1926,7 +1926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 759613ff-b3b8-4bdf-82cd-2e8868f7638a
+      - b79182f1-4e13-4097-a4b9-f5ee40fcb236
     status: 200 OK
     code: 200
     duration: ""
@@ -1937,19 +1937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/1ecb07a7-844b-458e-a893-be410ea56490
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "586"
+      - "390"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:23 GMT
+      - Thu, 02 Nov 2023 19:02:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1959,7 +1959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07dfd87f-9b94-4ae9-803d-cf22c186aa4c
+      - 73b08587-2fe1-406c-865e-874cfa47f0fb
     status: 200 OK
     code: 200
     duration: ""
@@ -1970,19 +1970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/6be64811-513c-49cc-bb48-b5509f5fa44c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":"02:00:00:11:D8:03","private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"ready","updated_at":"2023-10-20T16:00:31.970952Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "996"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:23 GMT
+      - Thu, 02 Nov 2023 19:02:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1992,7 +1992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2879481-f34a-4689-b666-bb237a690d5f
+      - 73a08e38-a74a-4dbd-8b53-f654ee3e3c18
     status: 200 OK
     code: 200
     duration: ""
@@ -2003,19 +2003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/70f4a360-5c98-4da0-90f8-33534072da05
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:00:16.659798Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":"02:00:00:11:D8:03","private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"ready","updated_at":"2023-10-20T16:00:31.970952Z","zone":"nl-ams-1"}],"id":"70f4a360-5c98-4da0-90f8-33534072da05","ip":{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:00:32.094756Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1962"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:23 GMT
+      - Thu, 02 Nov 2023 19:02:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2025,7 +2025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4d468fb-4ee2-4658-b424-911d62dc81cb
+      - e94cd6d0-d35c-42f2-932a-034af9adac7e
     status: 200 OK
     code: 200
     duration: ""
@@ -2036,19 +2036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:00:18.086500Z","endpoint":{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700},"endpoints":[{"id":"be00b33e-a6b1-4468-b534-a3921b4dda3c","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700}],"engine":"PostgreSQL-15","id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1507"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:23 GMT
+      - Thu, 02 Nov 2023 19:02:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2058,7 +2058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bd86113-4d72-4409-bad8-b68e42060534
+      - 85bc0abd-ea93-4350-9c8a-ad808a76fc64
     status: 200 OK
     code: 200
     duration: ""
@@ -2069,19 +2069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/6be64811-513c-49cc-bb48-b5509f5fa44c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84/certificate
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":"02:00:00:11:D8:03","private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"ready","updated_at":"2023-10-20T16:00:31.970952Z","zone":"nl-ams-1"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1akNDQXFLZ0F3SUJBZ0lVWnVBWFRNTEpxOExXZ3VHRVE0dExhdXdlUVZNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNVEF5TVRrd01ERXdXaGNOTXpNeE1ETXdNVGt3TURFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQVBDSGVseFVmUG9hQlRZSHFUbzEvR1cxaVhKay9MczhlUkJrR2daL0RhdEVrMEN4bkJYaUI2SjkKNXNsQVhwSUdBd2xOK29TWDJVK1BpK1NUcFBTQzJheU9NenFNczRpbVd1ckhoamR3WmNVd0hqTnplc1JHS05VagppcEJlcVBDbHk0Uy8yNHhUaWFlTUdwWFdqTlNtb1hNc3BXNG90aGNpd0FlejV0T0RCTkZsN2cvd3lUNVczSnJPCjhULzNmMzErbHkwVlZETHlHNnI3bG1DY3FVWnNWSDhIT3VSN0pLcnYwTjBjWmlQTVhXZnAwbEpqWDlhK2xmb0IKeTg4ZmRRbUJEMytVTThNRFBEVExHTWxDOW5OQ054YzJhcUVNQXlKRFhLbWFwUHdteFFBMElWT1VMNjNQTTdWbwpIaWFMcllNZVExUU4wLzNvVlNCMXNVWWRXL09MaFE4Q0F3RUFBYU44TUhvd2VBWURWUjBSQkhFd2I0SU5NVGt5CkxqRTJPQzR4TGpJMU5JSU9OVEV1TVRVNExqRXpNQzR5TURLQ1BISjNMVE14TlRJd05XSTBMVFUyTVdFdE5EWmwKTnkxaE5qazFMV1ptWTJFeE5USTFaR0U0TkM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpJY0VNdzljZW9jRQp3S2dCL29jRU01NkN5akFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBdGphYW5WRjJyaGVSYlhiSm8xSUoyUk9FClFiLzVKVjJvclpTMVA5V0Z5MEd5dDZXNWV3QzJqSTBxQzZxK0Vya3lXNVg2VzlHTk9JNnc3QUtPQmhtSFYza3EKQm9IZjlYVjZ0ZVI4SkxFbnlLODUrQWN2RUxyQXBTczAwZlcwOEhkQ2NPUGNxeFpIRUUxcHZ0RlZuckV2NE0vMwoxYzhVcFVNT0F6Ri9PQnRDWnRYUXVTTEpjS3NCNDNDRVZ3SklydFQzTjhvdlJmVUk3dTlyUk5zcHJ6eE4xZytuCk53YzhGUzR1QnVZTDJpRE5NWU1YNGk3NHgzTm0zakF3OUZTK24yZ2xRQ1dPeEFTTGt3R2xwQzRiSjZkdkhyQjcKWlZKSlFORnM2V3FXajd2YUtsNGtjcUQ4Wis2QTJlNnNTTWRILzgwZlk5OGRpUTdPVk8wb21tNjlzcTZrZXc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "996"
+      - "1887"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:23 GMT
+      - Thu, 02 Nov 2023 19:02:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2091,7 +2091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 658dd37f-91e9-47f3-914c-a9b4b52ceb7e
+      - 8ae7e12a-bb75-4297-8033-cc60638f06ce
     status: 200 OK
     code: 200
     duration: ""
@@ -2102,19 +2102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4/certificate
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1VENDQXFHZ0F3SUJBZ0lVY0puZEtPdytzZktveExpZWQwWjZqMUFFZ2lFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNREl3TVRZd01USTFXaGNOTXpNeE1ERTNNVFl3TVRJMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1tcnlvSEdaODZkaGFtZGlqdzFHQjFETU1jczhhV1JqSWtESmlxRUs0SGNqRk1LUHozcFN2RXcKdWFiYXY2RHFyTXd5bE1TZkViaUtud3JWVHdiVWlRVC8xNGFBVGZvaU1XWm9ocHl2N0d0dkVCbUErbDBVSmx3dAp3NjZPeCtlNlI2Ri9DK3UycFNvaUdlcjA4Y0plcVFueEo3TllqOXNBRzZtUFNlRE04ZnhkYU5NNmptUlBVM3ZSCmdXYkhMdWltSnR2bXg3TEx1UEwzcTlPb3ViT1JYNHRNeHB6SjVCNkh4cnpxUzRPTkt3TmxkdkRtQWJlQ3AxQnUKK1RWMmJXbGxwMXVpUkZ5Qi9qaUhaWTNrMGxmbzh3TEpwL2NKMUU2eEQvQVdZY2NmaUJERTBaZEFIQzk5bXVLMApQV21oT0JibGRZbjlPdTFsRDg2OVRpMmFpU293SzhjQ0F3RUFBYU43TUhrd2R3WURWUjBSQkhBd2JvSU5NVGt5CkxqRTJPQzR4TGpJMU5JSU5OVEV1TVRVNExqRXlPUzR5Tm9JOGNuY3ROMlF6T0Rsa05qa3Raams0WmkwME1UUTEKTFdJMk9EWXRObVJtTmpSaU5tWmxOV1kwTG5Ka1lpNXViQzFoYlhNdWMyTjNMbU5zYjNWa2h3UXpEMmxpaHdUQQpxQUgraHdRem5vRWFNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUFheC8xZmJZMTZyRHNieUVMUXVySDN1UXpMClRQU2pBMmlNSnY3SWNMbkxlQmZoQUxDZVQ3V2JHMzN5ZVA3ZVhVQ1FqUm1TN0czRnRheE9JOFJ1eWRGSW1CVHQKbWc5bEZIRVJONHl2VVBBa3JkQXRBck83Z0JSZGVZVXVGV25IS3pWOXcxc1pLbVRUdWpQTmRucWU4VlhEaXVKUgowdmNTMFpOQkpOZVo0QkpWdzNIa1Z0REx0Q1lJVDh4MFczTG9nOVZ4Wmtxc2NxUDh5Q2xOQldyQkxlc3ptQUhWCkVYNlJJczlaWjhEWDBLWEhRVlhzekpUV0NSMFVUcFhUc1RPRDNLUTE3S0pkOW9sT0NFSEtJY2xPaWFOaDgrLzYKbGNPUDUzcXdia3l0L1N4U3JTczFTQnpSM2RTNTNQeklTSjk4NlZSR1VkL0hTMmdMOXhvZW5pdUpJbEtJCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1881"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:23 GMT
+      - Thu, 02 Nov 2023 19:02:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2124,7 +2124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd136fa7-ca4b-45c1-9488-830b4ff474c9
+      - 109fdb67-b563-4e5c-ad4e-bb00cbb0d066
     status: 200 OK
     code: 200
     duration: ""
@@ -2135,19 +2135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/3513169c-6393-4a83-bfbb-5705212d8e65
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/caa010cd-8c5a-4afc-9a78-63dda87e714b
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:03:20.725429Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"3513169c-6393-4a83-bfbb-5705212d8e65","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-10-20T16:03:20.725429Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-02T19:02:03.927209Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"caa010cd-8c5a-4afc-9a78-63dda87e714b","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-02T19:02:03.927209Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "291"
+      - "283"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:24 GMT
+      - Thu, 02 Nov 2023 19:02:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2157,7 +2157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04045db2-8fa5-4255-aa7a-c706c3a32341
+      - 43725f18-1e20-4bd4-9d52-6cac4fb4772e
     status: 200 OK
     code: 200
     duration: ""
@@ -2168,19 +2168,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/70f4a360-5c98-4da0-90f8-33534072da05
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:00:16.659798Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":"02:00:00:11:D8:03","private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"ready","updated_at":"2023-10-20T16:00:31.970952Z","zone":"nl-ams-1"}],"id":"70f4a360-5c98-4da0-90f8-33534072da05","ip":{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:00:32.094756Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1962"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:24 GMT
+      - Thu, 02 Nov 2023 19:02:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2190,7 +2190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71f9a850-6ecb-4eb3-8c80-cbde3e33accf
+      - a62088dc-4d76-4be6-b035-6d79f096143d
     status: 200 OK
     code: 200
     duration: ""
@@ -2201,7 +2201,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/3513169c-6393-4a83-bfbb-5705212d8e65
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/caa010cd-8c5a-4afc-9a78-63dda87e714b
     method: DELETE
   response:
     body: ""
@@ -2211,7 +2211,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:24 GMT
+      - Thu, 02 Nov 2023 19:02:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2221,7 +2221,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 277fabe8-a7c0-46cb-b83f-d316d8c6843e
+      - 7611484b-410d-4778-bf71-9befa88d9c79
     status: 204 No Content
     code: 204
     duration: ""
@@ -2232,19 +2232,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/70f4a360-5c98-4da0-90f8-33534072da05
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:00:16.659798Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":"02:00:00:11:D8:03","private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"ready","updated_at":"2023-10-20T16:00:31.970952Z","zone":"nl-ams-1"}],"id":"70f4a360-5c98-4da0-90f8-33534072da05","ip":{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:00:32.094756Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1962"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:24 GMT
+      - Thu, 02 Nov 2023 19:02:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2254,7 +2254,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40465b75-9381-4b5b-9032-ed2081464c6e
+      - 24ea96c3-a343-4d66-9107-9e1f9d5a5dfc
     status: 200 OK
     code: 200
     duration: ""
@@ -2265,19 +2265,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/6be64811-513c-49cc-bb48-b5509f5fa44c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":"02:00:00:11:D8:03","private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"ready","updated_at":"2023-10-20T16:00:31.970952Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "996"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:24 GMT
+      - Thu, 02 Nov 2023 19:02:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2287,7 +2287,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4560f23-469b-4d90-aa3f-5620ec3dbf70
+      - 21362d06-ac47-40be-a8c0-186873ac9b9b
     status: 200 OK
     code: 200
     duration: ""
@@ -2298,19 +2298,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:00:18.086500Z","endpoint":{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700},"endpoints":[{"id":"be00b33e-a6b1-4468-b534-a3921b4dda3c","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700}],"engine":"PostgreSQL-15","id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1507"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:24 GMT
+      - Thu, 02 Nov 2023 19:02:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2320,7 +2320,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d29e3b8-f695-447a-a9ed-4a418eb1a056
+      - 6c13c2cd-92b8-4857-a910-c3f8701e7b55
     status: 200 OK
     code: 200
     duration: ""
@@ -2331,7 +2331,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/6be64811-513c-49cc-bb48-b5509f5fa44c?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -2341,7 +2341,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:24 GMT
+      - Thu, 02 Nov 2023 19:02:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2351,7 +2351,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae175e37-0f46-4a27-8b9c-897cdd347134
+      - a5db8eae-8e81-47ec-93e4-de010931a7f2
     status: 204 No Content
     code: 204
     duration: ""
@@ -2362,19 +2362,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/6be64811-513c-49cc-bb48-b5509f5fa44c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-20T16:00:24.579267Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:00:15.998031Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecb07a7-844b-458e-a893-be410ea56490","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:15.998031Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"6be64811-513c-49cc-bb48-b5509f5fa44c","ipam_config":null,"mac_address":"02:00:00:11:D8:03","private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","status":"detaching","updated_at":"2023-10-20T16:03:24.681199Z","zone":"nl-ams-1"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1000"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:24 GMT
+      - Thu, 02 Nov 2023 19:02:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2384,12 +2384,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d70bded7-9e0a-40db-bfd7-17ee49355f4d
+      - 832c3f0e-f63e-40ad-9d02-b29429483f2b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"backup_schedule_frequency":null,"backup_schedule_retention":null,"is_backup_schedule_disabled":null,"name":null,"tags":null,"logs_policy":null,"backup_same_region":null,"backup_schedule_start_hour":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"detaching","updated_at":"2023-11-02T19:02:08.326586Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "970"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 19:02:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3249ecb0-f677-4c50-a528-bd526ad024eb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{}'
     form: {}
     headers:
       Content-Type:
@@ -2397,19 +2430,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:00:18.086500Z","endpoint":{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700},"endpoints":[{"id":"be00b33e-a6b1-4468-b534-a3921b4dda3c","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700}],"engine":"PostgreSQL-15","id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1507"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:24 GMT
+      - Thu, 02 Nov 2023 19:02:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2419,7 +2452,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 292969f3-9910-4063-8356-f2cf45b38647
+      - 899d0e9f-f389-411e-a463-dd4b291692ce
     status: 200 OK
     code: 200
     duration: ""
@@ -2430,19 +2463,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:00:18.086500Z","endpoint":{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700},"endpoints":[{"id":"be00b33e-a6b1-4468-b534-a3921b4dda3c","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700}],"engine":"PostgreSQL-15","id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1507"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:24 GMT
+      - Thu, 02 Nov 2023 19:02:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2452,7 +2485,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a402693e-8152-4959-ab10-59020828ead8
+      - 2ad98245-c483-4855-ab1a-8e2bd01da213
     status: 200 OK
     code: 200
     duration: ""
@@ -2463,7 +2496,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/be00b33e-a6b1-4468-b534-a3921b4dda3c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/107453ea-e500-4318-ad8e-04cc72f93b76
     method: DELETE
   response:
     body: ""
@@ -2473,7 +2506,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:25 GMT
+      - Thu, 02 Nov 2023 19:02:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2483,7 +2516,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27cfaa7c-44e6-4d45-b3a0-7b6b53ed43a3
+      - 7edbd3f8-ab1d-4d85-abfd-20297e172313
     status: 204 No Content
     code: 204
     duration: ""
@@ -2494,19 +2527,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:00:18.086500Z","endpoint":{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700},"endpoints":[{"id":"be00b33e-a6b1-4468-b534-a3921b4dda3c","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"842ffa16-429a-4504-83a5-17f6c7633931","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700}],"engine":"PostgreSQL-15","id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1513"
+      - "1459"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:25 GMT
+      - Thu, 02 Nov 2023 19:02:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2516,7 +2549,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df5511b9-7844-486f-8737-b2404bde5bd3
+      - 2c9f43ba-43eb-499a-8592-07e510da6d71
     status: 200 OK
     code: 200
     duration: ""
@@ -2527,10 +2560,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/6be64811-513c-49cc-bb48-b5509f5fa44c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"6be64811-513c-49cc-bb48-b5509f5fa44c","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2539,7 +2572,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:29 GMT
+      - Thu, 02 Nov 2023 19:02:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2549,7 +2582,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5fa7569f-38f2-4ba1-b611-384885f78849
+      - be0eebd2-e656-482b-b6c9-8d2dd273bda6
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2560,19 +2593,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/70f4a360-5c98-4da0-90f8-33534072da05
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:00:16.659798Z","gateway_networks":[],"id":"70f4a360-5c98-4da0-90f8-33534072da05","ip":{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:00:32.094756Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "937"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:29 GMT
+      - Thu, 02 Nov 2023 19:02:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2582,7 +2615,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7ca15ce-3832-47cb-90f3-ebd12788ccd9
+      - 91c02283-aa21-4c9e-9fb7-39519ce5fcce
     status: 200 OK
     code: 200
     duration: ""
@@ -2593,10 +2626,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/1ecb07a7-844b-458e-a893-be410ea56490
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/f664ab2c-301f-4cbd-9d28-cf56fe37db7d
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"1ecb07a7-844b-458e-a893-be410ea56490","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -2605,7 +2638,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:29 GMT
+      - Thu, 02 Nov 2023 19:02:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2615,7 +2648,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c4fa750-f691-42de-bc03-cc5f6f27c37c
+      - 38f0e63a-061a-4764-9dc7-7f2c3b38a09c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2626,19 +2659,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/70f4a360-5c98-4da0-90f8-33534072da05
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:00:16.659798Z","gateway_networks":[],"id":"70f4a360-5c98-4da0-90f8-33534072da05","ip":{"address":"51.15.103.31","created_at":"2023-10-20T16:00:16.377351Z","gateway_id":"70f4a360-5c98-4da0-90f8-33534072da05","id":"2cf2fb1a-dc30-4838-881b-4d9639e53108","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"31-103-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:00:16.377351Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:00:32.094756Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "937"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:29 GMT
+      - Thu, 02 Nov 2023 19:02:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2648,7 +2681,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a43957d-e898-4663-8cbe-02b97360256a
+      - 0fa8de67-0b39-45af-879a-eae6766a6043
     status: 200 OK
     code: 200
     duration: ""
@@ -2659,7 +2692,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/70f4a360-5c98-4da0-90f8-33534072da05?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -2669,7 +2702,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:30 GMT
+      - Thu, 02 Nov 2023 19:02:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2679,7 +2712,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6826362-7f4e-426c-b301-07ba425c6f6a
+      - 1bd40f51-ece9-4b97-9b6c-cf1baa434d70
     status: 204 No Content
     code: 204
     duration: ""
@@ -2690,10 +2723,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/70f4a360-5c98-4da0-90f8-33534072da05
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"70f4a360-5c98-4da0-90f8-33534072da05","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"95a53bae-54e0-4384-8790-ba31b580b6af","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2702,7 +2735,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:30 GMT
+      - Thu, 02 Nov 2023 19:02:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2712,7 +2745,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60766d6c-d45d-4f9a-a335-aa854335b3ea
+      - bb552811-aaea-4df7-8627-85dbbcfaff52
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2723,7 +2756,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/2cf2fb1a-dc30-4838-881b-4d9639e53108
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e
     method: DELETE
   response:
     body: ""
@@ -2733,7 +2766,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:30 GMT
+      - Thu, 02 Nov 2023 19:02:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2743,7 +2776,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f1c1db3-8170-43a8-bd8d-9a6ac1849136
+      - debb9c30-9c94-4485-aac7-e398714f5a56
     status: 204 No Content
     code: 204
     duration: ""
@@ -2754,19 +2787,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:00:18.086500Z","endpoint":{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700},"endpoints":[{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700}],"engine":"PostgreSQL-15","id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1279"
+      - "1232"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:55 GMT
+      - Thu, 02 Nov 2023 19:02:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2776,7 +2809,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 077ff657-e821-4320-ac83-43be51396c43
+      - 93da8eed-57cf-456b-8e41-c28efd5701e7
     status: 200 OK
     code: 200
     duration: ""
@@ -2787,19 +2820,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:00:18.086500Z","endpoint":{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700},"endpoints":[{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700}],"engine":"PostgreSQL-15","id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1279"
+      - "1232"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:55 GMT
+      - Thu, 02 Nov 2023 19:02:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2809,7 +2842,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85c1163e-7600-41ce-a6c7-40686fb1172b
+      - 1d1ea08e-2882-4ef3-b455-759e8e18f6c3
     status: 200 OK
     code: 200
     duration: ""
@@ -2820,19 +2853,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1VENDQXFHZ0F3SUJBZ0lVY0puZEtPdytzZktveExpZWQwWjZqMUFFZ2lFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNREl3TVRZd01USTFXaGNOTXpNeE1ERTNNVFl3TVRJMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1tcnlvSEdaODZkaGFtZGlqdzFHQjFETU1jczhhV1JqSWtESmlxRUs0SGNqRk1LUHozcFN2RXcKdWFiYXY2RHFyTXd5bE1TZkViaUtud3JWVHdiVWlRVC8xNGFBVGZvaU1XWm9ocHl2N0d0dkVCbUErbDBVSmx3dAp3NjZPeCtlNlI2Ri9DK3UycFNvaUdlcjA4Y0plcVFueEo3TllqOXNBRzZtUFNlRE04ZnhkYU5NNmptUlBVM3ZSCmdXYkhMdWltSnR2bXg3TEx1UEwzcTlPb3ViT1JYNHRNeHB6SjVCNkh4cnpxUzRPTkt3TmxkdkRtQWJlQ3AxQnUKK1RWMmJXbGxwMXVpUkZ5Qi9qaUhaWTNrMGxmbzh3TEpwL2NKMUU2eEQvQVdZY2NmaUJERTBaZEFIQzk5bXVLMApQV21oT0JibGRZbjlPdTFsRDg2OVRpMmFpU293SzhjQ0F3RUFBYU43TUhrd2R3WURWUjBSQkhBd2JvSU5NVGt5CkxqRTJPQzR4TGpJMU5JSU5OVEV1TVRVNExqRXlPUzR5Tm9JOGNuY3ROMlF6T0Rsa05qa3Raams0WmkwME1UUTEKTFdJMk9EWXRObVJtTmpSaU5tWmxOV1kwTG5Ka1lpNXViQzFoYlhNdWMyTjNMbU5zYjNWa2h3UXpEMmxpaHdUQQpxQUgraHdRem5vRWFNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUFheC8xZmJZMTZyRHNieUVMUXVySDN1UXpMClRQU2pBMmlNSnY3SWNMbkxlQmZoQUxDZVQ3V2JHMzN5ZVA3ZVhVQ1FqUm1TN0czRnRheE9JOFJ1eWRGSW1CVHQKbWc5bEZIRVJONHl2VVBBa3JkQXRBck83Z0JSZGVZVXVGV25IS3pWOXcxc1pLbVRUdWpQTmRucWU4VlhEaXVKUgowdmNTMFpOQkpOZVo0QkpWdzNIa1Z0REx0Q1lJVDh4MFczTG9nOVZ4Wmtxc2NxUDh5Q2xOQldyQkxlc3ptQUhWCkVYNlJJczlaWjhEWDBLWEhRVlhzekpUV0NSMFVUcFhUc1RPRDNLUTE3S0pkOW9sT0NFSEtJY2xPaWFOaDgrLzYKbGNPUDUzcXdia3l0L1N4U3JTczFTQnpSM2RTNTNQeklTSjk4NlZSR1VkL0hTMmdMOXhvZW5pdUpJbEtJCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1akNDQXFLZ0F3SUJBZ0lVWnVBWFRNTEpxOExXZ3VHRVE0dExhdXdlUVZNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNVEF5TVRrd01ERXdXaGNOTXpNeE1ETXdNVGt3TURFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQVBDSGVseFVmUG9hQlRZSHFUbzEvR1cxaVhKay9MczhlUkJrR2daL0RhdEVrMEN4bkJYaUI2SjkKNXNsQVhwSUdBd2xOK29TWDJVK1BpK1NUcFBTQzJheU9NenFNczRpbVd1ckhoamR3WmNVd0hqTnplc1JHS05VagppcEJlcVBDbHk0Uy8yNHhUaWFlTUdwWFdqTlNtb1hNc3BXNG90aGNpd0FlejV0T0RCTkZsN2cvd3lUNVczSnJPCjhULzNmMzErbHkwVlZETHlHNnI3bG1DY3FVWnNWSDhIT3VSN0pLcnYwTjBjWmlQTVhXZnAwbEpqWDlhK2xmb0IKeTg4ZmRRbUJEMytVTThNRFBEVExHTWxDOW5OQ054YzJhcUVNQXlKRFhLbWFwUHdteFFBMElWT1VMNjNQTTdWbwpIaWFMcllNZVExUU4wLzNvVlNCMXNVWWRXL09MaFE4Q0F3RUFBYU44TUhvd2VBWURWUjBSQkhFd2I0SU5NVGt5CkxqRTJPQzR4TGpJMU5JSU9OVEV1TVRVNExqRXpNQzR5TURLQ1BISjNMVE14TlRJd05XSTBMVFUyTVdFdE5EWmwKTnkxaE5qazFMV1ptWTJFeE5USTFaR0U0TkM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpJY0VNdzljZW9jRQp3S2dCL29jRU01NkN5akFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBdGphYW5WRjJyaGVSYlhiSm8xSUoyUk9FClFiLzVKVjJvclpTMVA5V0Z5MEd5dDZXNWV3QzJqSTBxQzZxK0Vya3lXNVg2VzlHTk9JNnc3QUtPQmhtSFYza3EKQm9IZjlYVjZ0ZVI4SkxFbnlLODUrQWN2RUxyQXBTczAwZlcwOEhkQ2NPUGNxeFpIRUUxcHZ0RlZuckV2NE0vMwoxYzhVcFVNT0F6Ri9PQnRDWnRYUXVTTEpjS3NCNDNDRVZ3SklydFQzTjhvdlJmVUk3dTlyUk5zcHJ6eE4xZytuCk53YzhGUzR1QnVZTDJpRE5NWU1YNGk3NHgzTm0zakF3OUZTK24yZ2xRQ1dPeEFTTGt3R2xwQzRiSjZkdkhyQjcKWlZKSlFORnM2V3FXajd2YUtsNGtjcUQ4Wis2QTJlNnNTTWRILzgwZlk5OGRpUTdPVk8wb21tNjlzcTZrZXc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1881"
+      - "1887"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:56 GMT
+      - Thu, 02 Nov 2023 19:02:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2842,7 +2875,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aeebc1f2-c36f-4c96-b1ca-1eaa0ca2129c
+      - aaf5e6de-3729-4bad-92f0-1b1bf852e5a8
     status: 200 OK
     code: 200
     duration: ""
@@ -2853,19 +2886,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/842ffa16-429a-4504-83a5-17f6c7633931
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/0fc899b5-fd8e-408d-91d8-d0c477185680
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:00:15.991080Z","dhcp_enabled":true,"id":"842ffa16-429a-4504-83a5-17f6c7633931","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:00:15.991080Z","id":"97f2ce37-69b4-4668-89f6-009be46ff1e4","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:00:22.440490Z"},{"created_at":"2023-10-20T16:00:15.991080Z","id":"3350edd7-5e16-40d0-be33-ee90ccce8393","subnet":"fd68:d440:21c4:62ce::/64","updated_at":"2023-10-20T16:00:22.444731Z"}],"tags":[],"updated_at":"2023-10-20T16:03:24.882121Z","vpc_id":"9cb8396b-8328-412b-a866-e0c275b320a1"}'
+    body: '{"created_at":"2023-11-02T18:59:00.881462Z","dhcp_enabled":true,"id":"0fc899b5-fd8e-408d-91d8-d0c477185680","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T18:59:00.881462Z","id":"a739db4b-6d5c-408e-ae89-80c252c0961f","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:07.391460Z"},{"created_at":"2023-11-02T18:59:00.881462Z","id":"be07ed5e-b85b-4c20-80e1-2012ddce8863","subnet":"fd68:d440:21c4:a8a7::/64","updated_at":"2023-11-02T18:59:07.394943Z"}],"tags":[],"updated_at":"2023-11-02T19:02:08.539167Z","vpc_id":"1633022c-3fa1-431a-b398-1c67551e922c"}'
     headers:
       Content-Length:
-      - "719"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:56 GMT
+      - Thu, 02 Nov 2023 19:02:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2875,7 +2908,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbbbe507-31aa-4645-9efa-fd52fc608dcb
+      - 705f449e-8971-45e5-9857-23b1093d0a1f
     status: 200 OK
     code: 200
     duration: ""
@@ -2886,19 +2919,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:00:18.086500Z","endpoint":{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700},"endpoints":[{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700}],"engine":"PostgreSQL-15","id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1279"
+      - "1232"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:56 GMT
+      - Thu, 02 Nov 2023 19:02:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2908,7 +2941,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 690823c5-0050-44ec-abd2-dbb717a54ed3
+      - fdca7cdb-18a3-4c53-9633-bee543947e33
     status: 200 OK
     code: 200
     duration: ""
@@ -2919,19 +2952,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1VENDQXFHZ0F3SUJBZ0lVY0puZEtPdytzZktveExpZWQwWjZqMUFFZ2lFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNREl3TVRZd01USTFXaGNOTXpNeE1ERTNNVFl3TVRJMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1tcnlvSEdaODZkaGFtZGlqdzFHQjFETU1jczhhV1JqSWtESmlxRUs0SGNqRk1LUHozcFN2RXcKdWFiYXY2RHFyTXd5bE1TZkViaUtud3JWVHdiVWlRVC8xNGFBVGZvaU1XWm9ocHl2N0d0dkVCbUErbDBVSmx3dAp3NjZPeCtlNlI2Ri9DK3UycFNvaUdlcjA4Y0plcVFueEo3TllqOXNBRzZtUFNlRE04ZnhkYU5NNmptUlBVM3ZSCmdXYkhMdWltSnR2bXg3TEx1UEwzcTlPb3ViT1JYNHRNeHB6SjVCNkh4cnpxUzRPTkt3TmxkdkRtQWJlQ3AxQnUKK1RWMmJXbGxwMXVpUkZ5Qi9qaUhaWTNrMGxmbzh3TEpwL2NKMUU2eEQvQVdZY2NmaUJERTBaZEFIQzk5bXVLMApQV21oT0JibGRZbjlPdTFsRDg2OVRpMmFpU293SzhjQ0F3RUFBYU43TUhrd2R3WURWUjBSQkhBd2JvSU5NVGt5CkxqRTJPQzR4TGpJMU5JSU5OVEV1TVRVNExqRXlPUzR5Tm9JOGNuY3ROMlF6T0Rsa05qa3Raams0WmkwME1UUTEKTFdJMk9EWXRObVJtTmpSaU5tWmxOV1kwTG5Ka1lpNXViQzFoYlhNdWMyTjNMbU5zYjNWa2h3UXpEMmxpaHdUQQpxQUgraHdRem5vRWFNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUFheC8xZmJZMTZyRHNieUVMUXVySDN1UXpMClRQU2pBMmlNSnY3SWNMbkxlQmZoQUxDZVQ3V2JHMzN5ZVA3ZVhVQ1FqUm1TN0czRnRheE9JOFJ1eWRGSW1CVHQKbWc5bEZIRVJONHl2VVBBa3JkQXRBck83Z0JSZGVZVXVGV25IS3pWOXcxc1pLbVRUdWpQTmRucWU4VlhEaXVKUgowdmNTMFpOQkpOZVo0QkpWdzNIa1Z0REx0Q1lJVDh4MFczTG9nOVZ4Wmtxc2NxUDh5Q2xOQldyQkxlc3ptQUhWCkVYNlJJczlaWjhEWDBLWEhRVlhzekpUV0NSMFVUcFhUc1RPRDNLUTE3S0pkOW9sT0NFSEtJY2xPaWFOaDgrLzYKbGNPUDUzcXdia3l0L1N4U3JTczFTQnpSM2RTNTNQeklTSjk4NlZSR1VkL0hTMmdMOXhvZW5pdUpJbEtJCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1akNDQXFLZ0F3SUJBZ0lVWnVBWFRNTEpxOExXZ3VHRVE0dExhdXdlUVZNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNVEF5TVRrd01ERXdXaGNOTXpNeE1ETXdNVGt3TURFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQVBDSGVseFVmUG9hQlRZSHFUbzEvR1cxaVhKay9MczhlUkJrR2daL0RhdEVrMEN4bkJYaUI2SjkKNXNsQVhwSUdBd2xOK29TWDJVK1BpK1NUcFBTQzJheU9NenFNczRpbVd1ckhoamR3WmNVd0hqTnplc1JHS05VagppcEJlcVBDbHk0Uy8yNHhUaWFlTUdwWFdqTlNtb1hNc3BXNG90aGNpd0FlejV0T0RCTkZsN2cvd3lUNVczSnJPCjhULzNmMzErbHkwVlZETHlHNnI3bG1DY3FVWnNWSDhIT3VSN0pLcnYwTjBjWmlQTVhXZnAwbEpqWDlhK2xmb0IKeTg4ZmRRbUJEMytVTThNRFBEVExHTWxDOW5OQ054YzJhcUVNQXlKRFhLbWFwUHdteFFBMElWT1VMNjNQTTdWbwpIaWFMcllNZVExUU4wLzNvVlNCMXNVWWRXL09MaFE4Q0F3RUFBYU44TUhvd2VBWURWUjBSQkhFd2I0SU5NVGt5CkxqRTJPQzR4TGpJMU5JSU9OVEV1TVRVNExqRXpNQzR5TURLQ1BISjNMVE14TlRJd05XSTBMVFUyTVdFdE5EWmwKTnkxaE5qazFMV1ptWTJFeE5USTFaR0U0TkM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpJY0VNdzljZW9jRQp3S2dCL29jRU01NkN5akFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBdGphYW5WRjJyaGVSYlhiSm8xSUoyUk9FClFiLzVKVjJvclpTMVA5V0Z5MEd5dDZXNWV3QzJqSTBxQzZxK0Vya3lXNVg2VzlHTk9JNnc3QUtPQmhtSFYza3EKQm9IZjlYVjZ0ZVI4SkxFbnlLODUrQWN2RUxyQXBTczAwZlcwOEhkQ2NPUGNxeFpIRUUxcHZ0RlZuckV2NE0vMwoxYzhVcFVNT0F6Ri9PQnRDWnRYUXVTTEpjS3NCNDNDRVZ3SklydFQzTjhvdlJmVUk3dTlyUk5zcHJ6eE4xZytuCk53YzhGUzR1QnVZTDJpRE5NWU1YNGk3NHgzTm0zakF3OUZTK24yZ2xRQ1dPeEFTTGt3R2xwQzRiSjZkdkhyQjcKWlZKSlFORnM2V3FXajd2YUtsNGtjcUQ4Wis2QTJlNnNTTWRILzgwZlk5OGRpUTdPVk8wb21tNjlzcTZrZXc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1881"
+      - "1887"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:56 GMT
+      - Thu, 02 Nov 2023 19:02:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2941,7 +2974,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8adaae6f-7386-4394-8383-64e2400cc679
+      - 85f28416-bb82-41a2-907f-0375ac4d760d
     status: 200 OK
     code: 200
     duration: ""
@@ -2952,19 +2985,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:00:18.086500Z","endpoint":{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700},"endpoints":[{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700}],"engine":"PostgreSQL-15","id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1279"
+      - "1232"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:57 GMT
+      - Thu, 02 Nov 2023 19:02:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2974,7 +3007,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09a7cc7d-e4c7-4e47-848e-4bb6b5e24082
+      - c0612154-6488-4fcb-a091-991a94724272
     status: 200 OK
     code: 200
     duration: ""
@@ -2985,7 +3018,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/842ffa16-429a-4504-83a5-17f6c7633931
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/0fc899b5-fd8e-408d-91d8-d0c477185680
     method: DELETE
   response:
     body: ""
@@ -2995,7 +3028,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:57 GMT
+      - Thu, 02 Nov 2023 19:02:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3005,7 +3038,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5b001fe-8bfd-404c-915e-ff5e3fa2927c
+      - 3f4e533a-5a91-4410-ad3d-12a62bc72c6e
     status: 204 No Content
     code: 204
     duration: ""
@@ -3016,19 +3049,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:00:18.086500Z","endpoint":{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700},"endpoints":[{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700}],"engine":"PostgreSQL-15","id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1282"
+      - "1235"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:57 GMT
+      - Thu, 02 Nov 2023 19:02:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3038,7 +3071,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 798649a3-9fdb-40f5-b559-2bfb615b028a
+      - e7cbadc9-8628-4716-8a4a-ad4c7064d108
     status: 200 OK
     code: 200
     duration: ""
@@ -3049,19 +3082,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:00:18.086500Z","endpoint":{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700},"endpoints":[{"id":"65057d36-9aa8-429e-8415-96246bd83776","ip":"51.158.129.26","load_balancer":{},"name":null,"port":13700}],"engine":"PostgreSQL-15","id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1282"
+      - "1235"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:58 GMT
+      - Thu, 02 Nov 2023 19:02:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3071,7 +3104,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd4e28cf-c760-41df-827d-3569a2bf943f
+      - 3ce97740-0185-49e8-a300-85a59ca1ed38
     status: 200 OK
     code: 200
     duration: ""
@@ -3082,10 +3115,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"315205b4-561a-46e7-a695-ffca1525da84","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -3094,7 +3127,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:04:28 GMT
+      - Thu, 02 Nov 2023 19:03:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3104,7 +3137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 453d8f61-3535-4840-8779-cdda781c8c15
+      - f8a848c2-082d-4b7f-b53a-0ef1170e9c61
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3115,10 +3148,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d389d69-f98f-4145-b686-6df64b6fe5f4
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"7d389d69-f98f-4145-b686-6df64b6fe5f4","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"315205b4-561a-46e7-a695-ffca1525da84","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -3127,7 +3160,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:04:28 GMT
+      - Thu, 02 Nov 2023 19:03:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3137,7 +3170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14a0f225-fd67-4682-b897-12f0bb61b287
+      - 79a20325-90c3-4346-bab1-19e159f54ed2
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-private-network-update.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-private-network-update.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:06 GMT
+      - Thu, 02 Nov 2023 18:46:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7cd3d9b7-71ef-4811-bca5-6c97307b94d4
+      - 7792c2b1-9719-4722-996e-0c710d5448f9
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"my_private_network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"my_private_network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-20T16:02:36.282773Z","dhcp_enabled":true,"id":"00224fac-6e27-4cce-b116-a57161979766","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T16:02:36.282773Z","id":"937b0e0f-a128-4446-873c-ec3d8603c914","subnet":"172.16.8.0/22","updated_at":"2023-10-20T16:02:36.282773Z"},{"created_at":"2023-10-20T16:02:36.282773Z","id":"1ccc70b4-3179-47b2-be11-e3b5d102fd2a","subnet":"fd63:256c:45f7:36ec::/64","updated_at":"2023-10-20T16:02:36.282773Z"}],"tags":[],"updated_at":"2023-10-20T16:02:36.282773Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-02T18:54:14.471840Z","dhcp_enabled":true,"id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:54:14.471840Z","id":"b0f881ce-49c1-444e-84db-f850334ca776","subnet":"172.16.32.0/22","updated_at":"2023-11-02T18:54:14.471840Z"},{"created_at":"2023-11-02T18:54:14.471840Z","id":"75f86e7a-3bc6-4192-96aa-21738d7a98de","subnet":"fd63:256c:45f7:a79::/64","updated_at":"2023-11-02T18:54:14.471840Z"}],"tags":[],"updated_at":"2023-11-02T18:54:14.471840Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "718"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:37 GMT
+      - Thu, 02 Nov 2023 18:54:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d814f11-98c0-4654-8f21-bc28b425e6f6
+      - 2681a710-3796-4938-b9c8-68bbf12f74e1
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/00224fac-6e27-4cce-b116-a57161979766
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/600f1eb9-da64-404e-bb12-feb4930dbcdb
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:02:36.282773Z","dhcp_enabled":true,"id":"00224fac-6e27-4cce-b116-a57161979766","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T16:02:36.282773Z","id":"937b0e0f-a128-4446-873c-ec3d8603c914","subnet":"172.16.8.0/22","updated_at":"2023-10-20T16:02:36.282773Z"},{"created_at":"2023-10-20T16:02:36.282773Z","id":"1ccc70b4-3179-47b2-be11-e3b5d102fd2a","subnet":"fd63:256c:45f7:36ec::/64","updated_at":"2023-10-20T16:02:36.282773Z"}],"tags":[],"updated_at":"2023-10-20T16:02:36.282773Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-02T18:54:14.471840Z","dhcp_enabled":true,"id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:54:14.471840Z","id":"b0f881ce-49c1-444e-84db-f850334ca776","subnet":"172.16.32.0/22","updated_at":"2023-11-02T18:54:14.471840Z"},{"created_at":"2023-11-02T18:54:14.471840Z","id":"75f86e7a-3bc6-4192-96aa-21738d7a98de","subnet":"fd63:256c:45f7:a79::/64","updated_at":"2023-11-02T18:54:14.471840Z"}],"tags":[],"updated_at":"2023-11-02T18:54:14.471840Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "718"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:37 GMT
+      - Thu, 02 Nov 2023 18:54:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e163f46-6090-494e-a007-946c75414186
+      - f3f963f1-33dc-4614-9d17-4451a9afac8e
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/00224fac-6e27-4cce-b116-a57161979766
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/600f1eb9-da64-404e-bb12-feb4930dbcdb
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:02:36.282773Z","dhcp_enabled":true,"id":"00224fac-6e27-4cce-b116-a57161979766","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T16:02:36.282773Z","id":"937b0e0f-a128-4446-873c-ec3d8603c914","subnet":"172.16.8.0/22","updated_at":"2023-10-20T16:02:36.282773Z"},{"created_at":"2023-10-20T16:02:36.282773Z","id":"1ccc70b4-3179-47b2-be11-e3b5d102fd2a","subnet":"fd63:256c:45f7:36ec::/64","updated_at":"2023-10-20T16:02:36.282773Z"}],"tags":[],"updated_at":"2023-10-20T16:02:36.282773Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-02T18:54:14.471840Z","dhcp_enabled":true,"id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:54:14.471840Z","id":"b0f881ce-49c1-444e-84db-f850334ca776","subnet":"172.16.32.0/22","updated_at":"2023-11-02T18:54:14.471840Z"},{"created_at":"2023-11-02T18:54:14.471840Z","id":"75f86e7a-3bc6-4192-96aa-21738d7a98de","subnet":"fd63:256c:45f7:a79::/64","updated_at":"2023-11-02T18:54:14.471840Z"}],"tags":[],"updated_at":"2023-11-02T18:54:14.471840Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "718"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:38 GMT
+      - Thu, 02 Nov 2023 18:54:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6298be37-9323-431b-812a-73e2d5530dd1
+      - 246bf86b-6178-4dc9-b56a-441eb59ee418
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/00224fac-6e27-4cce-b116-a57161979766
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/600f1eb9-da64-404e-bb12-feb4930dbcdb
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:02:36.282773Z","dhcp_enabled":true,"id":"00224fac-6e27-4cce-b116-a57161979766","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T16:02:36.282773Z","id":"937b0e0f-a128-4446-873c-ec3d8603c914","subnet":"172.16.8.0/22","updated_at":"2023-10-20T16:02:36.282773Z"},{"created_at":"2023-10-20T16:02:36.282773Z","id":"1ccc70b4-3179-47b2-be11-e3b5d102fd2a","subnet":"fd63:256c:45f7:36ec::/64","updated_at":"2023-10-20T16:02:36.282773Z"}],"tags":[],"updated_at":"2023-10-20T16:02:36.282773Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-02T18:54:14.471840Z","dhcp_enabled":true,"id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:54:14.471840Z","id":"b0f881ce-49c1-444e-84db-f850334ca776","subnet":"172.16.32.0/22","updated_at":"2023-11-02T18:54:14.471840Z"},{"created_at":"2023-11-02T18:54:14.471840Z","id":"75f86e7a-3bc6-4192-96aa-21738d7a98de","subnet":"fd63:256c:45f7:a79::/64","updated_at":"2023-11-02T18:54:14.471840Z"}],"tags":[],"updated_at":"2023-11-02T18:54:14.471840Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "718"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:38 GMT
+      - Thu, 02 Nov 2023 18:54:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,12 +462,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8257816-c3f6-4c4b-8b5d-2548bc8b56d3
+      - e1dded89-861a-4ee8-8f43-d3467f5f18b3
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","ipam_config":{}}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","ipam_config":{}}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -478,16 +478,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":null,"endpoints":[{"id":"3102cad1-1c0b-435e-ab40-c935a00cbcbc","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":null,"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1007"
+      - "973"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:39 GMT
+      - Thu, 02 Nov 2023 18:54:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -497,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db8566bc-24ff-44f1-96b7-7088266ad737
+      - 887c7204-f1d0-4e51-874c-cccbc5054c18
     status: 200 OK
     code: 200
     duration: ""
@@ -508,19 +508,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":null,"endpoints":[{"id":"3102cad1-1c0b-435e-ab40-c935a00cbcbc","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":null,"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1007"
+      - "973"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:40 GMT
+      - Thu, 02 Nov 2023 18:54:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -530,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 689c8ece-1ef3-4743-a92a-47a57defce87
+      - ec605c69-52dd-4991-8815-53d1006ff81d
     status: 200 OK
     code: 200
     duration: ""
@@ -541,19 +541,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":null,"endpoints":[{"id":"3102cad1-1c0b-435e-ab40-c935a00cbcbc","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":null,"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1007"
+      - "973"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:10 GMT
+      - Thu, 02 Nov 2023 18:54:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -563,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1fa8753-5886-4146-be2c-6fa6900151fc
+      - 6ba2c34e-5ec8-4959-8309-492157b0b804
     status: 200 OK
     code: 200
     duration: ""
@@ -574,19 +574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":null,"endpoints":[{"id":"3102cad1-1c0b-435e-ab40-c935a00cbcbc","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":null,"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1007"
+      - "973"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:40 GMT
+      - Thu, 02 Nov 2023 18:55:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76c43afe-9c25-4b63-96ae-fc5dbda370c3
+      - 1f575401-e3ca-41f6-99e3-a9ba963de557
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":null,"endpoints":[{"id":"3102cad1-1c0b-435e-ab40-c935a00cbcbc","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":null,"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1007"
+      - "973"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:04:10 GMT
+      - Thu, 02 Nov 2023 18:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa7c626e-ab97-4e34-b8ae-a05b5eb5198a
+      - 0a7c21f3-9b87-4ae1-82fd-cb5c1c9fa7ea
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":null,"endpoints":[{"id":"3102cad1-1c0b-435e-ab40-c935a00cbcbc","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":null,"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1007"
+      - "973"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:04:40 GMT
+      - Thu, 02 Nov 2023 18:56:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 255c37b1-35e8-4791-8698-b754b2ca2e8c
+      - f5109a24-c577-4e65-86ae-e24b104998a4
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":null,"endpoints":[{"id":"3102cad1-1c0b-435e-ab40-c935a00cbcbc","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":null,"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1007"
+      - "973"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:10 GMT
+      - Thu, 02 Nov 2023 18:56:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e60ff47-21b5-4127-abe4-5a34120c4836
+      - 1c7a5e29-7fa2-4166-8608-c1166be22025
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819},"endpoints":[{"id":"3102cad1-1c0b-435e-ab40-c935a00cbcbc","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.2/22","zone":"fr-par-1"}},{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1499"
+      - "1447"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:41 GMT
+      - Thu, 02 Nov 2023 18:57:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94173693-60e5-42ab-8083-781aa3d67dd2
+      - a07629d6-a584-47e2-b9a7-ef1eff24aa98
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURyekNDQXBlZ0F3SUJBZ0lVT2I0OVIzUmwvN3NmMkp5M3BFeHp4UUF0K2trd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RXpBUkJnTlZCQU1NQ2pFM01pNHhOaTQ0TGpJd0hoY05Nak14Ck1ESXdNVFl3TXpReldoY05Nek14TURFM01UWXdNelF6V2pCVk1Rc3dDUVlEVlFRR0V3SkdVakVPTUF3R0ExVUUKQ0F3RlVHRnlhWE14RGpBTUJnTlZCQWNNQlZCaGNtbHpNUkV3RHdZRFZRUUtEQWhUWTJGc1pYZGhlVEVUTUJFRwpBMVVFQXd3S01UY3lMakUyTGpndU1qQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCCkFLWU9YWnlnNDBZWjFNR2VQeWtZcFRjUjVIeGZZQktEdFlpU3loYTdGQStkNUdGdkU1K0huTTEza1dkWjRjY1UKNXhVQUJiL0JUZmtlZWxzMEZ0TElLR2F1VnVhUHR6NHYxODNtcXRoVVkvTjltQmtwcVFZRjhNSGZ1akVvS3pnKwpURmp1RXBoMFVqM0Z5WEhod0JPeWw3a2NqYkhTdTFSNDk3TW5DVXdGampiTWh0SnQwcDRZM1Y5L1lmcXhxZlVQCmRpaCtucVVTRHdTNDFrSSswZktUWkhQdEF1TVZBdS92L1loL2JhYlNvTUFQRm10L0FBdHpBdUMzUGRtRk1icjgKMU5BUDN0cytncmoycXpnbGdJRUJWYTN5NmQyRXdaSUprTTF0OVdXOTBCUEZleVVrY09tOC9HWk5RSmM5V255eQpyeTlLSEdQQWZsb1duckdYWDJacW9VOENBd0VBQWFOM01IVXdjd1lEVlIwUkJHd3dhb0lLTVRjeUxqRTJMamd1Ck1vSU1OVEV1TVRVNExqVTVMakUwZ2p4eWR5MDVOMkZqWVRWbE5TMDNNemsyTFRRek0yWXRZalZpTWkwM01XRTEKT0RjME5tSTJNREl1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTSEJLT3NqbWlIQkt3UUNBS0hCRE9lT3c0dwpEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBSXV2OGtMSDdJZmhYby9GVGtWZGxQN21KUWFhKzA3eHNGVzhiSUFaCnZ4STR3U1VEdUFuMmpjdzFwc200ZlYzOFlWMXBzTjZZc0Jpb3poVGZjb0tJbk4wTEM4VEh4bTBmaURTYTYzY0IKN203ZkhwY0RDUTlXdThCazhiajF3bUwzei9EYlRIQ3BXM094U2ZFK1RWaGpEQVRpWUNXTjRUQ3ZNZWZTQTE1TgpNT25EUnJGTStqUlMzQXE2NStvcHBLanhqWUZiRkJMS05sVGxyc3Y5SXZBS1lkUUpqaFZiS25nZVNXVk5tZGVPCldUTHorOFNtSWQrVXJ0VDlKdVFabjJCRVlOeHZmRi9UekdTY05CRlQ3WklBcDFlWXRtSitWZWF2WC9FZEpvUHMKNTBCc0tZbkFiK3E0QTFDVUQ0OUtuRWxrNkwyTGVHdFZDMlBNR3hvWTFXaURoL3c9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURzekNDQXB1Z0F3SUJBZ0lVUUswK3dOR2w4UEtTeGpxYU1jV1ZiNzRUTzdvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1URXdNakU0TlRVeU9Wb1hEVE16TVRBek1ERTROVFV5T1Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF3VDF4OHNKaVk5TVBtaGZBUklISnlsK2xRTVV1SnJhTVJ1eTRJVmMzYnlSdFVtbGRNUHlTeUlBaW51ZlYKdDRIZFFMWHNHNkkvYkZ3Y084SGJTclBMN01nRS8vbnVFSXBTRlZsSCttZWtuMXdyS0ZiVEtmU01RN0NJbkJDYQpKVVJveXh4SjhqYXJnYlhzZFM4VEhOVm13amdIQlZyRVlROFFjdGFzajFidWVlVXBSSWVoVHR1NXFLRVk0V1c4CnI4aGJHNVphcm04OXRPbWZyN3hZckxUR2NTekQ4TXY1RGkxKzNPbmtMSFZZQWRQOHd0QmVtaFFTS2ZrRXZ5SUgKaS9VT0NQVTNwQjdtUHowQ1hlK1h6eHBybUVHakpzZHIxUllVOWpyeEJuc3pweGhqVkxQS25Pdk5ROURnN0ZLcwpzUGhuZ1hkV0t3ZDRjbkNaSDZoV3JpQWVpd0lEQVFBQm8za3dkekIxQmdOVkhSRUViakJzZ2dzeE56SXVNVFl1Ck16SXVNb0lOTlRFdU1UVTVMakV3TGpJeE00SThjbmN0TWpJeVpXSTBaRE10TXprd05DMDBZbVpoTFRneE56Z3QKWkRBMk5UQTBNekkzTWpaaExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpocWh3U3NFQ0FDaHdRegpud3JWTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBTldldDliMlB4emFEaStyNm8xQTBLb21pUWVkWSt3OGNpCndEaGJKWkoxL0xGRTJQSnpSVjdWT0tFYklWbmE2eHdXaXNhRE9sNnlsQmZVR3BXdmVSWkF2VWhXTUdlTEd0UXoKNHR1cFJUckE0Z2Joem5YSkgzY01RUlkyb3JuL2orU2Raa1pDRS9nN2NmNko4QlJUalVvV0thWmprVEY5d1BlUApIYU1NZ25BMUJ4L2JCcVhSTGVoZHJtRW8rY01DN1hDcjVxODNTTThvM2hObG5vNERvdmRqSkw4bktTT2YvaWlzCjNaL1hTTHA0L2pna2FhL0VuZXlOWWlFR3E1eFN3OG5YUEcvNmpwZlpLdktYSjU3Z0prRk5qZlZYQ2NsRUx3T28KRHZ1d0JlbzVJa0NUVzBJU0NXZlhZZ2thcEwzQ0pVODdMWm4vcUdNQllsdWxPK1dwTTY4QwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1865"
+      - "1871"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:41 GMT
+      - Thu, 02 Nov 2023 18:57:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd84680b-250f-44c3-b050-7944bfb3eb17
+      - 39829dd5-ce30-413f-99cc-970e4a04d017
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819},"endpoints":[{"id":"3102cad1-1c0b-435e-ab40-c935a00cbcbc","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.2/22","zone":"fr-par-1"}},{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1499"
+      - "1447"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:41 GMT
+      - Thu, 02 Nov 2023 18:57:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e76c33bc-8ca2-4b83-b72a-957bb63e066a
+      - 0189b10a-32d4-489a-936f-32ccfcb01fc6
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/00224fac-6e27-4cce-b116-a57161979766
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/600f1eb9-da64-404e-bb12-feb4930dbcdb
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:02:36.282773Z","dhcp_enabled":true,"id":"00224fac-6e27-4cce-b116-a57161979766","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T16:02:36.282773Z","id":"937b0e0f-a128-4446-873c-ec3d8603c914","subnet":"172.16.8.0/22","updated_at":"2023-10-20T16:02:36.282773Z"},{"created_at":"2023-10-20T16:02:36.282773Z","id":"1ccc70b4-3179-47b2-be11-e3b5d102fd2a","subnet":"fd63:256c:45f7:36ec::/64","updated_at":"2023-10-20T16:02:36.282773Z"}],"tags":[],"updated_at":"2023-10-20T16:02:36.282773Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-02T18:54:14.471840Z","dhcp_enabled":true,"id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:54:14.471840Z","id":"b0f881ce-49c1-444e-84db-f850334ca776","subnet":"172.16.32.0/22","updated_at":"2023-11-02T18:54:14.471840Z"},{"created_at":"2023-11-02T18:54:14.471840Z","id":"75f86e7a-3bc6-4192-96aa-21738d7a98de","subnet":"fd63:256c:45f7:a79::/64","updated_at":"2023-11-02T18:54:14.471840Z"}],"tags":[],"updated_at":"2023-11-02T18:54:14.471840Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "718"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:41 GMT
+      - Thu, 02 Nov 2023 18:57:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f120ce3-0a8c-4987-8b68-f190324934ca
+      - dc023dd9-e951-4980-8b3c-7f801770318a
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819},"endpoints":[{"id":"3102cad1-1c0b-435e-ab40-c935a00cbcbc","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.2/22","zone":"fr-par-1"}},{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1499"
+      - "1447"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:41 GMT
+      - Thu, 02 Nov 2023 18:57:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2d0b3b1-72e9-4a54-855b-0ccc570ef2eb
+      - b54c4cfe-29d5-410a-85af-c48c751c961f
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURyekNDQXBlZ0F3SUJBZ0lVT2I0OVIzUmwvN3NmMkp5M3BFeHp4UUF0K2trd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RXpBUkJnTlZCQU1NQ2pFM01pNHhOaTQ0TGpJd0hoY05Nak14Ck1ESXdNVFl3TXpReldoY05Nek14TURFM01UWXdNelF6V2pCVk1Rc3dDUVlEVlFRR0V3SkdVakVPTUF3R0ExVUUKQ0F3RlVHRnlhWE14RGpBTUJnTlZCQWNNQlZCaGNtbHpNUkV3RHdZRFZRUUtEQWhUWTJGc1pYZGhlVEVUTUJFRwpBMVVFQXd3S01UY3lMakUyTGpndU1qQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCCkFLWU9YWnlnNDBZWjFNR2VQeWtZcFRjUjVIeGZZQktEdFlpU3loYTdGQStkNUdGdkU1K0huTTEza1dkWjRjY1UKNXhVQUJiL0JUZmtlZWxzMEZ0TElLR2F1VnVhUHR6NHYxODNtcXRoVVkvTjltQmtwcVFZRjhNSGZ1akVvS3pnKwpURmp1RXBoMFVqM0Z5WEhod0JPeWw3a2NqYkhTdTFSNDk3TW5DVXdGampiTWh0SnQwcDRZM1Y5L1lmcXhxZlVQCmRpaCtucVVTRHdTNDFrSSswZktUWkhQdEF1TVZBdS92L1loL2JhYlNvTUFQRm10L0FBdHpBdUMzUGRtRk1icjgKMU5BUDN0cytncmoycXpnbGdJRUJWYTN5NmQyRXdaSUprTTF0OVdXOTBCUEZleVVrY09tOC9HWk5RSmM5V255eQpyeTlLSEdQQWZsb1duckdYWDJacW9VOENBd0VBQWFOM01IVXdjd1lEVlIwUkJHd3dhb0lLTVRjeUxqRTJMamd1Ck1vSU1OVEV1TVRVNExqVTVMakUwZ2p4eWR5MDVOMkZqWVRWbE5TMDNNemsyTFRRek0yWXRZalZpTWkwM01XRTEKT0RjME5tSTJNREl1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTSEJLT3NqbWlIQkt3UUNBS0hCRE9lT3c0dwpEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBSXV2OGtMSDdJZmhYby9GVGtWZGxQN21KUWFhKzA3eHNGVzhiSUFaCnZ4STR3U1VEdUFuMmpjdzFwc200ZlYzOFlWMXBzTjZZc0Jpb3poVGZjb0tJbk4wTEM4VEh4bTBmaURTYTYzY0IKN203ZkhwY0RDUTlXdThCazhiajF3bUwzei9EYlRIQ3BXM094U2ZFK1RWaGpEQVRpWUNXTjRUQ3ZNZWZTQTE1TgpNT25EUnJGTStqUlMzQXE2NStvcHBLanhqWUZiRkJMS05sVGxyc3Y5SXZBS1lkUUpqaFZiS25nZVNXVk5tZGVPCldUTHorOFNtSWQrVXJ0VDlKdVFabjJCRVlOeHZmRi9UekdTY05CRlQ3WklBcDFlWXRtSitWZWF2WC9FZEpvUHMKNTBCc0tZbkFiK3E0QTFDVUQ0OUtuRWxrNkwyTGVHdFZDMlBNR3hvWTFXaURoL3c9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURzekNDQXB1Z0F3SUJBZ0lVUUswK3dOR2w4UEtTeGpxYU1jV1ZiNzRUTzdvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1URXdNakU0TlRVeU9Wb1hEVE16TVRBek1ERTROVFV5T1Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF3VDF4OHNKaVk5TVBtaGZBUklISnlsK2xRTVV1SnJhTVJ1eTRJVmMzYnlSdFVtbGRNUHlTeUlBaW51ZlYKdDRIZFFMWHNHNkkvYkZ3Y084SGJTclBMN01nRS8vbnVFSXBTRlZsSCttZWtuMXdyS0ZiVEtmU01RN0NJbkJDYQpKVVJveXh4SjhqYXJnYlhzZFM4VEhOVm13amdIQlZyRVlROFFjdGFzajFidWVlVXBSSWVoVHR1NXFLRVk0V1c4CnI4aGJHNVphcm04OXRPbWZyN3hZckxUR2NTekQ4TXY1RGkxKzNPbmtMSFZZQWRQOHd0QmVtaFFTS2ZrRXZ5SUgKaS9VT0NQVTNwQjdtUHowQ1hlK1h6eHBybUVHakpzZHIxUllVOWpyeEJuc3pweGhqVkxQS25Pdk5ROURnN0ZLcwpzUGhuZ1hkV0t3ZDRjbkNaSDZoV3JpQWVpd0lEQVFBQm8za3dkekIxQmdOVkhSRUViakJzZ2dzeE56SXVNVFl1Ck16SXVNb0lOTlRFdU1UVTVMakV3TGpJeE00SThjbmN0TWpJeVpXSTBaRE10TXprd05DMDBZbVpoTFRneE56Z3QKWkRBMk5UQTBNekkzTWpaaExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpocWh3U3NFQ0FDaHdRegpud3JWTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBTldldDliMlB4emFEaStyNm8xQTBLb21pUWVkWSt3OGNpCndEaGJKWkoxL0xGRTJQSnpSVjdWT0tFYklWbmE2eHdXaXNhRE9sNnlsQmZVR3BXdmVSWkF2VWhXTUdlTEd0UXoKNHR1cFJUckE0Z2Joem5YSkgzY01RUlkyb3JuL2orU2Raa1pDRS9nN2NmNko4QlJUalVvV0thWmprVEY5d1BlUApIYU1NZ25BMUJ4L2JCcVhSTGVoZHJtRW8rY01DN1hDcjVxODNTTThvM2hObG5vNERvdmRqSkw4bktTT2YvaWlzCjNaL1hTTHA0L2pna2FhL0VuZXlOWWlFR3E1eFN3OG5YUEcvNmpwZlpLdktYSjU3Z0prRk5qZlZYQ2NsRUx3T28KRHZ1d0JlbzVJa0NUVzBJU0NXZlhZZ2thcEwzQ0pVODdMWm4vcUdNQllsdWxPK1dwTTY4QwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1865"
+      - "1871"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:42 GMT
+      - Thu, 02 Nov 2023 18:57:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3973709-5e3d-44ca-89cd-50880cf87e9c
+      - 872f8444-4487-42a9-b8f1-7dbcdffa7c3e
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/00224fac-6e27-4cce-b116-a57161979766
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/600f1eb9-da64-404e-bb12-feb4930dbcdb
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:02:36.282773Z","dhcp_enabled":true,"id":"00224fac-6e27-4cce-b116-a57161979766","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T16:02:36.282773Z","id":"937b0e0f-a128-4446-873c-ec3d8603c914","subnet":"172.16.8.0/22","updated_at":"2023-10-20T16:02:36.282773Z"},{"created_at":"2023-10-20T16:02:36.282773Z","id":"1ccc70b4-3179-47b2-be11-e3b5d102fd2a","subnet":"fd63:256c:45f7:36ec::/64","updated_at":"2023-10-20T16:02:36.282773Z"}],"tags":[],"updated_at":"2023-10-20T16:02:36.282773Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-02T18:54:14.471840Z","dhcp_enabled":true,"id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:54:14.471840Z","id":"b0f881ce-49c1-444e-84db-f850334ca776","subnet":"172.16.32.0/22","updated_at":"2023-11-02T18:54:14.471840Z"},{"created_at":"2023-11-02T18:54:14.471840Z","id":"75f86e7a-3bc6-4192-96aa-21738d7a98de","subnet":"fd63:256c:45f7:a79::/64","updated_at":"2023-11-02T18:54:14.471840Z"}],"tags":[],"updated_at":"2023-11-02T18:54:14.471840Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "718"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:42 GMT
+      - Thu, 02 Nov 2023 18:57:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0eafbea-35d3-4dce-8332-f4a654b8089c
+      - 76640433-afac-4fd5-bc1f-4ba574abdf62
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819},"endpoints":[{"id":"3102cad1-1c0b-435e-ab40-c935a00cbcbc","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.2/22","zone":"fr-par-1"}},{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1499"
+      - "1447"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:42 GMT
+      - Thu, 02 Nov 2023 18:57:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a579f234-30ee-4d24-961b-645efed12d67
+      - ab21c78d-0ccc-400b-beda-eeb4430583ac
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURyekNDQXBlZ0F3SUJBZ0lVT2I0OVIzUmwvN3NmMkp5M3BFeHp4UUF0K2trd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RXpBUkJnTlZCQU1NQ2pFM01pNHhOaTQ0TGpJd0hoY05Nak14Ck1ESXdNVFl3TXpReldoY05Nek14TURFM01UWXdNelF6V2pCVk1Rc3dDUVlEVlFRR0V3SkdVakVPTUF3R0ExVUUKQ0F3RlVHRnlhWE14RGpBTUJnTlZCQWNNQlZCaGNtbHpNUkV3RHdZRFZRUUtEQWhUWTJGc1pYZGhlVEVUTUJFRwpBMVVFQXd3S01UY3lMakUyTGpndU1qQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCCkFLWU9YWnlnNDBZWjFNR2VQeWtZcFRjUjVIeGZZQktEdFlpU3loYTdGQStkNUdGdkU1K0huTTEza1dkWjRjY1UKNXhVQUJiL0JUZmtlZWxzMEZ0TElLR2F1VnVhUHR6NHYxODNtcXRoVVkvTjltQmtwcVFZRjhNSGZ1akVvS3pnKwpURmp1RXBoMFVqM0Z5WEhod0JPeWw3a2NqYkhTdTFSNDk3TW5DVXdGampiTWh0SnQwcDRZM1Y5L1lmcXhxZlVQCmRpaCtucVVTRHdTNDFrSSswZktUWkhQdEF1TVZBdS92L1loL2JhYlNvTUFQRm10L0FBdHpBdUMzUGRtRk1icjgKMU5BUDN0cytncmoycXpnbGdJRUJWYTN5NmQyRXdaSUprTTF0OVdXOTBCUEZleVVrY09tOC9HWk5RSmM5V255eQpyeTlLSEdQQWZsb1duckdYWDJacW9VOENBd0VBQWFOM01IVXdjd1lEVlIwUkJHd3dhb0lLTVRjeUxqRTJMamd1Ck1vSU1OVEV1TVRVNExqVTVMakUwZ2p4eWR5MDVOMkZqWVRWbE5TMDNNemsyTFRRek0yWXRZalZpTWkwM01XRTEKT0RjME5tSTJNREl1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTSEJLT3NqbWlIQkt3UUNBS0hCRE9lT3c0dwpEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBSXV2OGtMSDdJZmhYby9GVGtWZGxQN21KUWFhKzA3eHNGVzhiSUFaCnZ4STR3U1VEdUFuMmpjdzFwc200ZlYzOFlWMXBzTjZZc0Jpb3poVGZjb0tJbk4wTEM4VEh4bTBmaURTYTYzY0IKN203ZkhwY0RDUTlXdThCazhiajF3bUwzei9EYlRIQ3BXM094U2ZFK1RWaGpEQVRpWUNXTjRUQ3ZNZWZTQTE1TgpNT25EUnJGTStqUlMzQXE2NStvcHBLanhqWUZiRkJMS05sVGxyc3Y5SXZBS1lkUUpqaFZiS25nZVNXVk5tZGVPCldUTHorOFNtSWQrVXJ0VDlKdVFabjJCRVlOeHZmRi9UekdTY05CRlQ3WklBcDFlWXRtSitWZWF2WC9FZEpvUHMKNTBCc0tZbkFiK3E0QTFDVUQ0OUtuRWxrNkwyTGVHdFZDMlBNR3hvWTFXaURoL3c9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURzekNDQXB1Z0F3SUJBZ0lVUUswK3dOR2w4UEtTeGpxYU1jV1ZiNzRUTzdvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1URXdNakU0TlRVeU9Wb1hEVE16TVRBek1ERTROVFV5T1Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF3VDF4OHNKaVk5TVBtaGZBUklISnlsK2xRTVV1SnJhTVJ1eTRJVmMzYnlSdFVtbGRNUHlTeUlBaW51ZlYKdDRIZFFMWHNHNkkvYkZ3Y084SGJTclBMN01nRS8vbnVFSXBTRlZsSCttZWtuMXdyS0ZiVEtmU01RN0NJbkJDYQpKVVJveXh4SjhqYXJnYlhzZFM4VEhOVm13amdIQlZyRVlROFFjdGFzajFidWVlVXBSSWVoVHR1NXFLRVk0V1c4CnI4aGJHNVphcm04OXRPbWZyN3hZckxUR2NTekQ4TXY1RGkxKzNPbmtMSFZZQWRQOHd0QmVtaFFTS2ZrRXZ5SUgKaS9VT0NQVTNwQjdtUHowQ1hlK1h6eHBybUVHakpzZHIxUllVOWpyeEJuc3pweGhqVkxQS25Pdk5ROURnN0ZLcwpzUGhuZ1hkV0t3ZDRjbkNaSDZoV3JpQWVpd0lEQVFBQm8za3dkekIxQmdOVkhSRUViakJzZ2dzeE56SXVNVFl1Ck16SXVNb0lOTlRFdU1UVTVMakV3TGpJeE00SThjbmN0TWpJeVpXSTBaRE10TXprd05DMDBZbVpoTFRneE56Z3QKWkRBMk5UQTBNekkzTWpaaExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpocWh3U3NFQ0FDaHdRegpud3JWTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBTldldDliMlB4emFEaStyNm8xQTBLb21pUWVkWSt3OGNpCndEaGJKWkoxL0xGRTJQSnpSVjdWT0tFYklWbmE2eHdXaXNhRE9sNnlsQmZVR3BXdmVSWkF2VWhXTUdlTEd0UXoKNHR1cFJUckE0Z2Joem5YSkgzY01RUlkyb3JuL2orU2Raa1pDRS9nN2NmNko4QlJUalVvV0thWmprVEY5d1BlUApIYU1NZ25BMUJ4L2JCcVhSTGVoZHJtRW8rY01DN1hDcjVxODNTTThvM2hObG5vNERvdmRqSkw4bktTT2YvaWlzCjNaL1hTTHA0L2pna2FhL0VuZXlOWWlFR3E1eFN3OG5YUEcvNmpwZlpLdktYSjU3Z0prRk5qZlZYQ2NsRUx3T28KRHZ1d0JlbzVJa0NUVzBJU0NXZlhZZ2thcEwzQ0pVODdMWm4vcUdNQllsdWxPK1dwTTY4QwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1865"
+      - "1871"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:42 GMT
+      - Thu, 02 Nov 2023 18:57:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f358695e-1204-42bd-864d-1b04808d8314
+      - 3f0ccb1f-4a43-462a-b92d-cdcb447fc59b
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,19 +1003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819},"endpoints":[{"id":"3102cad1-1c0b-435e-ab40-c935a00cbcbc","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.2/22","zone":"fr-par-1"}},{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1499"
+      - "1447"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:43 GMT
+      - Thu, 02 Nov 2023 18:57:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,12 +1025,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da10dba5-a5b3-499d-a2ca-ccba14f98c2d
+      - 63ed1acb-2a6b-4533-8be6-6739d3e5b77b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"backup_schedule_frequency":null,"backup_schedule_retention":null,"is_backup_schedule_disabled":null,"name":null,"tags":null,"logs_policy":null,"backup_same_region":null,"backup_schedule_start_hour":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1447"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:57:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2728d2a0-66ff-47e1-aaa3-9f11ea1eb72a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{}'
     form: {}
     headers:
       Content-Type:
@@ -1038,19 +1071,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819},"endpoints":[{"id":"3102cad1-1c0b-435e-ab40-c935a00cbcbc","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.2/22","zone":"fr-par-1"}},{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1499"
+      - "1447"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:44 GMT
+      - Thu, 02 Nov 2023 18:57:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df88edaf-24b4-49de-ac97-7fe6754987f3
+      - b8f9eb3c-ea7f-46dc-82de-3c011425eaf2
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +1104,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819},"endpoints":[{"id":"3102cad1-1c0b-435e-ab40-c935a00cbcbc","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.2/22","zone":"fr-par-1"}},{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1499"
+      - "1447"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:44 GMT
+      - Thu, 02 Nov 2023 18:57:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3272f01-7f13-4a13-95e2-60298a63661e
+      - ecb4979e-3871-433b-923e-e8b8dcd18e6c
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,7 +1137,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/3102cad1-1c0b-435e-ab40-c935a00cbcbc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/a454cf1a-54cf-498c-ab55-f132e5371367
     method: DELETE
   response:
     body: ""
@@ -1114,7 +1147,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:44 GMT
+      - Thu, 02 Nov 2023 18:57:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1124,7 +1157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7aa70c1c-0769-4f0c-b99c-77d745050d71
+      - 3920cbeb-b766-4e63-b80a-5e7c49994847
     status: 204 No Content
     code: 204
     duration: ""
@@ -1135,19 +1168,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819},"endpoints":[{"id":"3102cad1-1c0b-435e-ab40-c935a00cbcbc","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.2/22","zone":"fr-par-1"}},{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1505"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:44 GMT
+      - Thu, 02 Nov 2023 18:57:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1157,7 +1190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 636ba68a-fc11-4ec3-997e-3f8e91f99dd6
+      - 1dfa5569-5a4e-4c86-baac-d19346ca33d6
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,19 +1201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819},"endpoints":[{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1277"
+      - "1230"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:14 GMT
+      - Thu, 02 Nov 2023 18:57:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,12 +1223,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0536dbf7-ed08-471a-9e2c-2dfd52bff6df
+      - befa3484-e2bd-449a-830a-6daf366e7afb
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"endpoint_spec":{"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.4/22"}}}'
+    body: '{"endpoint_spec":{"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.4/22"}}}'
     form: {}
     headers:
       Content-Type:
@@ -1203,19 +1236,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602/endpoints
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a/endpoints
     method: POST
   response:
-    body: '{"id":"97f15dca-b6ea-45f5-af91-8928e11d7ac3","ip":"172.16.8.4","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.4/22","zone":"fr-par-1"}}'
+    body: '{"id":"7dae7479-b9a4-459c-91c4-b2412b26e4a4","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "220"
+      - "216"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:15 GMT
+      - Thu, 02 Nov 2023 18:57:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f911a87c-365b-4e37-a773-245558b2ff36
+      - 9f78fb4d-2b85-456d-a3aa-ba28f75767e8
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,19 +1269,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819},"endpoints":[{"id":"97f15dca-b6ea-45f5-af91-8928e11d7ac3","ip":"172.16.8.4","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.4/22","zone":"fr-par-1"}},{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"7dae7479-b9a4-459c-91c4-b2412b26e4a4","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.4/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1506"
+      - "1454"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:15 GMT
+      - Thu, 02 Nov 2023 18:57:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5811196c-d173-4de6-8b69-47f97eb680db
+      - 70ebe574-31ab-4d3d-9be4-c13091503e8e
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,19 +1302,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819},"endpoints":[{"id":"97f15dca-b6ea-45f5-af91-8928e11d7ac3","ip":"172.16.8.4","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.4/22","zone":"fr-par-1"}},{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"7dae7479-b9a4-459c-91c4-b2412b26e4a4","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.4/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1499"
+      - "1447"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:45 GMT
+      - Thu, 02 Nov 2023 18:58:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8051fa48-14d3-4bc1-83d5-d4e2166fd412
+      - 40d271b1-5ae0-4d65-a676-6e0cefb2aa9f
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,19 +1335,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURyekNDQXBlZ0F3SUJBZ0lVT2I0OVIzUmwvN3NmMkp5M3BFeHp4UUF0K2trd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RXpBUkJnTlZCQU1NQ2pFM01pNHhOaTQ0TGpJd0hoY05Nak14Ck1ESXdNVFl3TXpReldoY05Nek14TURFM01UWXdNelF6V2pCVk1Rc3dDUVlEVlFRR0V3SkdVakVPTUF3R0ExVUUKQ0F3RlVHRnlhWE14RGpBTUJnTlZCQWNNQlZCaGNtbHpNUkV3RHdZRFZRUUtEQWhUWTJGc1pYZGhlVEVUTUJFRwpBMVVFQXd3S01UY3lMakUyTGpndU1qQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCCkFLWU9YWnlnNDBZWjFNR2VQeWtZcFRjUjVIeGZZQktEdFlpU3loYTdGQStkNUdGdkU1K0huTTEza1dkWjRjY1UKNXhVQUJiL0JUZmtlZWxzMEZ0TElLR2F1VnVhUHR6NHYxODNtcXRoVVkvTjltQmtwcVFZRjhNSGZ1akVvS3pnKwpURmp1RXBoMFVqM0Z5WEhod0JPeWw3a2NqYkhTdTFSNDk3TW5DVXdGampiTWh0SnQwcDRZM1Y5L1lmcXhxZlVQCmRpaCtucVVTRHdTNDFrSSswZktUWkhQdEF1TVZBdS92L1loL2JhYlNvTUFQRm10L0FBdHpBdUMzUGRtRk1icjgKMU5BUDN0cytncmoycXpnbGdJRUJWYTN5NmQyRXdaSUprTTF0OVdXOTBCUEZleVVrY09tOC9HWk5RSmM5V255eQpyeTlLSEdQQWZsb1duckdYWDJacW9VOENBd0VBQWFOM01IVXdjd1lEVlIwUkJHd3dhb0lLTVRjeUxqRTJMamd1Ck1vSU1OVEV1TVRVNExqVTVMakUwZ2p4eWR5MDVOMkZqWVRWbE5TMDNNemsyTFRRek0yWXRZalZpTWkwM01XRTEKT0RjME5tSTJNREl1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTSEJLT3NqbWlIQkt3UUNBS0hCRE9lT3c0dwpEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBSXV2OGtMSDdJZmhYby9GVGtWZGxQN21KUWFhKzA3eHNGVzhiSUFaCnZ4STR3U1VEdUFuMmpjdzFwc200ZlYzOFlWMXBzTjZZc0Jpb3poVGZjb0tJbk4wTEM4VEh4bTBmaURTYTYzY0IKN203ZkhwY0RDUTlXdThCazhiajF3bUwzei9EYlRIQ3BXM094U2ZFK1RWaGpEQVRpWUNXTjRUQ3ZNZWZTQTE1TgpNT25EUnJGTStqUlMzQXE2NStvcHBLanhqWUZiRkJMS05sVGxyc3Y5SXZBS1lkUUpqaFZiS25nZVNXVk5tZGVPCldUTHorOFNtSWQrVXJ0VDlKdVFabjJCRVlOeHZmRi9UekdTY05CRlQ3WklBcDFlWXRtSitWZWF2WC9FZEpvUHMKNTBCc0tZbkFiK3E0QTFDVUQ0OUtuRWxrNkwyTGVHdFZDMlBNR3hvWTFXaURoL3c9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURzekNDQXB1Z0F3SUJBZ0lVUUswK3dOR2w4UEtTeGpxYU1jV1ZiNzRUTzdvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1URXdNakU0TlRVeU9Wb1hEVE16TVRBek1ERTROVFV5T1Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF3VDF4OHNKaVk5TVBtaGZBUklISnlsK2xRTVV1SnJhTVJ1eTRJVmMzYnlSdFVtbGRNUHlTeUlBaW51ZlYKdDRIZFFMWHNHNkkvYkZ3Y084SGJTclBMN01nRS8vbnVFSXBTRlZsSCttZWtuMXdyS0ZiVEtmU01RN0NJbkJDYQpKVVJveXh4SjhqYXJnYlhzZFM4VEhOVm13amdIQlZyRVlROFFjdGFzajFidWVlVXBSSWVoVHR1NXFLRVk0V1c4CnI4aGJHNVphcm04OXRPbWZyN3hZckxUR2NTekQ4TXY1RGkxKzNPbmtMSFZZQWRQOHd0QmVtaFFTS2ZrRXZ5SUgKaS9VT0NQVTNwQjdtUHowQ1hlK1h6eHBybUVHakpzZHIxUllVOWpyeEJuc3pweGhqVkxQS25Pdk5ROURnN0ZLcwpzUGhuZ1hkV0t3ZDRjbkNaSDZoV3JpQWVpd0lEQVFBQm8za3dkekIxQmdOVkhSRUViakJzZ2dzeE56SXVNVFl1Ck16SXVNb0lOTlRFdU1UVTVMakV3TGpJeE00SThjbmN0TWpJeVpXSTBaRE10TXprd05DMDBZbVpoTFRneE56Z3QKWkRBMk5UQTBNekkzTWpaaExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpocWh3U3NFQ0FDaHdRegpud3JWTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBTldldDliMlB4emFEaStyNm8xQTBLb21pUWVkWSt3OGNpCndEaGJKWkoxL0xGRTJQSnpSVjdWT0tFYklWbmE2eHdXaXNhRE9sNnlsQmZVR3BXdmVSWkF2VWhXTUdlTEd0UXoKNHR1cFJUckE0Z2Joem5YSkgzY01RUlkyb3JuL2orU2Raa1pDRS9nN2NmNko4QlJUalVvV0thWmprVEY5d1BlUApIYU1NZ25BMUJ4L2JCcVhSTGVoZHJtRW8rY01DN1hDcjVxODNTTThvM2hObG5vNERvdmRqSkw4bktTT2YvaWlzCjNaL1hTTHA0L2pna2FhL0VuZXlOWWlFR3E1eFN3OG5YUEcvNmpwZlpLdktYSjU3Z0prRk5qZlZYQ2NsRUx3T28KRHZ1d0JlbzVJa0NUVzBJU0NXZlhZZ2thcEwzQ0pVODdMWm4vcUdNQllsdWxPK1dwTTY4QwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1865"
+      - "1871"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:49 GMT
+      - Thu, 02 Nov 2023 18:58:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8bc19628-1173-4b01-80c0-78bdcb3e6775
+      - 5fe54075-00b4-4033-bcea-03c3c84f1b43
     status: 200 OK
     code: 200
     duration: ""
@@ -1335,19 +1368,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819},"endpoints":[{"id":"97f15dca-b6ea-45f5-af91-8928e11d7ac3","ip":"172.16.8.4","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.4/22","zone":"fr-par-1"}},{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"7dae7479-b9a4-459c-91c4-b2412b26e4a4","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.4/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1499"
+      - "1447"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:50 GMT
+      - Thu, 02 Nov 2023 18:58:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8356ece-b840-45b2-969c-0bd9be99854d
+      - edac09c5-edc2-4d71-89cd-729ebda92da6
     status: 200 OK
     code: 200
     duration: ""
@@ -1368,19 +1401,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/00224fac-6e27-4cce-b116-a57161979766
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/600f1eb9-da64-404e-bb12-feb4930dbcdb
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:02:36.282773Z","dhcp_enabled":true,"id":"00224fac-6e27-4cce-b116-a57161979766","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T16:02:36.282773Z","id":"937b0e0f-a128-4446-873c-ec3d8603c914","subnet":"172.16.8.0/22","updated_at":"2023-10-20T16:02:36.282773Z"},{"created_at":"2023-10-20T16:02:36.282773Z","id":"1ccc70b4-3179-47b2-be11-e3b5d102fd2a","subnet":"fd63:256c:45f7:36ec::/64","updated_at":"2023-10-20T16:02:36.282773Z"}],"tags":[],"updated_at":"2023-10-20T16:02:36.282773Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-02T18:54:14.471840Z","dhcp_enabled":true,"id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:54:14.471840Z","id":"b0f881ce-49c1-444e-84db-f850334ca776","subnet":"172.16.32.0/22","updated_at":"2023-11-02T18:54:14.471840Z"},{"created_at":"2023-11-02T18:54:14.471840Z","id":"75f86e7a-3bc6-4192-96aa-21738d7a98de","subnet":"fd63:256c:45f7:a79::/64","updated_at":"2023-11-02T18:54:14.471840Z"}],"tags":[],"updated_at":"2023-11-02T18:54:14.471840Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "718"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:50 GMT
+      - Thu, 02 Nov 2023 18:58:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1423,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e893b9e-05b1-4c6b-9dc3-e56b31f1a42b
+      - 09208ec3-d838-4daf-a63e-1217f0dc391c
     status: 200 OK
     code: 200
     duration: ""
@@ -1401,19 +1434,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819},"endpoints":[{"id":"97f15dca-b6ea-45f5-af91-8928e11d7ac3","ip":"172.16.8.4","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.4/22","zone":"fr-par-1"}},{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"7dae7479-b9a4-459c-91c4-b2412b26e4a4","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.4/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1499"
+      - "1447"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:50 GMT
+      - Thu, 02 Nov 2023 18:58:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1582879-f8c3-4471-9f47-79fe1447c329
+      - 0f8453ab-8987-4b85-80e5-5738008add8d
     status: 200 OK
     code: 200
     duration: ""
@@ -1434,19 +1467,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURyekNDQXBlZ0F3SUJBZ0lVT2I0OVIzUmwvN3NmMkp5M3BFeHp4UUF0K2trd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RXpBUkJnTlZCQU1NQ2pFM01pNHhOaTQ0TGpJd0hoY05Nak14Ck1ESXdNVFl3TXpReldoY05Nek14TURFM01UWXdNelF6V2pCVk1Rc3dDUVlEVlFRR0V3SkdVakVPTUF3R0ExVUUKQ0F3RlVHRnlhWE14RGpBTUJnTlZCQWNNQlZCaGNtbHpNUkV3RHdZRFZRUUtEQWhUWTJGc1pYZGhlVEVUTUJFRwpBMVVFQXd3S01UY3lMakUyTGpndU1qQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCCkFLWU9YWnlnNDBZWjFNR2VQeWtZcFRjUjVIeGZZQktEdFlpU3loYTdGQStkNUdGdkU1K0huTTEza1dkWjRjY1UKNXhVQUJiL0JUZmtlZWxzMEZ0TElLR2F1VnVhUHR6NHYxODNtcXRoVVkvTjltQmtwcVFZRjhNSGZ1akVvS3pnKwpURmp1RXBoMFVqM0Z5WEhod0JPeWw3a2NqYkhTdTFSNDk3TW5DVXdGampiTWh0SnQwcDRZM1Y5L1lmcXhxZlVQCmRpaCtucVVTRHdTNDFrSSswZktUWkhQdEF1TVZBdS92L1loL2JhYlNvTUFQRm10L0FBdHpBdUMzUGRtRk1icjgKMU5BUDN0cytncmoycXpnbGdJRUJWYTN5NmQyRXdaSUprTTF0OVdXOTBCUEZleVVrY09tOC9HWk5RSmM5V255eQpyeTlLSEdQQWZsb1duckdYWDJacW9VOENBd0VBQWFOM01IVXdjd1lEVlIwUkJHd3dhb0lLTVRjeUxqRTJMamd1Ck1vSU1OVEV1TVRVNExqVTVMakUwZ2p4eWR5MDVOMkZqWVRWbE5TMDNNemsyTFRRek0yWXRZalZpTWkwM01XRTEKT0RjME5tSTJNREl1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTSEJLT3NqbWlIQkt3UUNBS0hCRE9lT3c0dwpEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBSXV2OGtMSDdJZmhYby9GVGtWZGxQN21KUWFhKzA3eHNGVzhiSUFaCnZ4STR3U1VEdUFuMmpjdzFwc200ZlYzOFlWMXBzTjZZc0Jpb3poVGZjb0tJbk4wTEM4VEh4bTBmaURTYTYzY0IKN203ZkhwY0RDUTlXdThCazhiajF3bUwzei9EYlRIQ3BXM094U2ZFK1RWaGpEQVRpWUNXTjRUQ3ZNZWZTQTE1TgpNT25EUnJGTStqUlMzQXE2NStvcHBLanhqWUZiRkJMS05sVGxyc3Y5SXZBS1lkUUpqaFZiS25nZVNXVk5tZGVPCldUTHorOFNtSWQrVXJ0VDlKdVFabjJCRVlOeHZmRi9UekdTY05CRlQ3WklBcDFlWXRtSitWZWF2WC9FZEpvUHMKNTBCc0tZbkFiK3E0QTFDVUQ0OUtuRWxrNkwyTGVHdFZDMlBNR3hvWTFXaURoL3c9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURzekNDQXB1Z0F3SUJBZ0lVUUswK3dOR2w4UEtTeGpxYU1jV1ZiNzRUTzdvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1URXdNakU0TlRVeU9Wb1hEVE16TVRBek1ERTROVFV5T1Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF3VDF4OHNKaVk5TVBtaGZBUklISnlsK2xRTVV1SnJhTVJ1eTRJVmMzYnlSdFVtbGRNUHlTeUlBaW51ZlYKdDRIZFFMWHNHNkkvYkZ3Y084SGJTclBMN01nRS8vbnVFSXBTRlZsSCttZWtuMXdyS0ZiVEtmU01RN0NJbkJDYQpKVVJveXh4SjhqYXJnYlhzZFM4VEhOVm13amdIQlZyRVlROFFjdGFzajFidWVlVXBSSWVoVHR1NXFLRVk0V1c4CnI4aGJHNVphcm04OXRPbWZyN3hZckxUR2NTekQ4TXY1RGkxKzNPbmtMSFZZQWRQOHd0QmVtaFFTS2ZrRXZ5SUgKaS9VT0NQVTNwQjdtUHowQ1hlK1h6eHBybUVHakpzZHIxUllVOWpyeEJuc3pweGhqVkxQS25Pdk5ROURnN0ZLcwpzUGhuZ1hkV0t3ZDRjbkNaSDZoV3JpQWVpd0lEQVFBQm8za3dkekIxQmdOVkhSRUViakJzZ2dzeE56SXVNVFl1Ck16SXVNb0lOTlRFdU1UVTVMakV3TGpJeE00SThjbmN0TWpJeVpXSTBaRE10TXprd05DMDBZbVpoTFRneE56Z3QKWkRBMk5UQTBNekkzTWpaaExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpocWh3U3NFQ0FDaHdRegpud3JWTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBTldldDliMlB4emFEaStyNm8xQTBLb21pUWVkWSt3OGNpCndEaGJKWkoxL0xGRTJQSnpSVjdWT0tFYklWbmE2eHdXaXNhRE9sNnlsQmZVR3BXdmVSWkF2VWhXTUdlTEd0UXoKNHR1cFJUckE0Z2Joem5YSkgzY01RUlkyb3JuL2orU2Raa1pDRS9nN2NmNko4QlJUalVvV0thWmprVEY5d1BlUApIYU1NZ25BMUJ4L2JCcVhSTGVoZHJtRW8rY01DN1hDcjVxODNTTThvM2hObG5vNERvdmRqSkw4bktTT2YvaWlzCjNaL1hTTHA0L2pna2FhL0VuZXlOWWlFR3E1eFN3OG5YUEcvNmpwZlpLdktYSjU3Z0prRk5qZlZYQ2NsRUx3T28KRHZ1d0JlbzVJa0NUVzBJU0NXZlhZZ2thcEwzQ0pVODdMWm4vcUdNQllsdWxPK1dwTTY4QwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1865"
+      - "1871"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:50 GMT
+      - Thu, 02 Nov 2023 18:58:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2e4da48-d9a4-4059-b72b-e801cb1817a5
+      - 3410f77d-3bf3-43d6-8dc5-73eacdf3c5f0
     status: 200 OK
     code: 200
     duration: ""
@@ -1467,19 +1500,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819},"endpoints":[{"id":"97f15dca-b6ea-45f5-af91-8928e11d7ac3","ip":"172.16.8.4","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.4/22","zone":"fr-par-1"}},{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"7dae7479-b9a4-459c-91c4-b2412b26e4a4","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.4/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1499"
+      - "1447"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:51 GMT
+      - Thu, 02 Nov 2023 18:58:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f549954-41ed-455f-98bf-99286039360e
+      - e7734eeb-fc15-4f84-b89d-55079085af01
     status: 200 OK
     code: 200
     duration: ""
@@ -1500,19 +1533,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819},"endpoints":[{"id":"97f15dca-b6ea-45f5-af91-8928e11d7ac3","ip":"172.16.8.4","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.4/22","zone":"fr-par-1"}},{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"7dae7479-b9a4-459c-91c4-b2412b26e4a4","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.4/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1502"
+      - "1450"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:51 GMT
+      - Thu, 02 Nov 2023 18:58:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1555,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 572384f3-bad9-429a-a13a-192aa41b11be
+      - 8df2d77e-7d48-460a-8bb6-eb57c6761ae1
     status: 200 OK
     code: 200
     duration: ""
@@ -1533,19 +1566,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:39.160629Z","endpoint":{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819},"endpoints":[{"id":"97f15dca-b6ea-45f5-af91-8928e11d7ac3","ip":"172.16.8.4","name":null,"port":5432,"private_network":{"private_network_id":"00224fac-6e27-4cce-b116-a57161979766","service_ip":"172.16.8.4/22","zone":"fr-par-1"}},{"id":"219f27a0-a7aa-440e-8c1f-c441e948c1ef","ip":"51.158.59.14","load_balancer":{},"name":null,"port":23819}],"engine":"PostgreSQL-15","id":"97aca5e5-7396-433f-b5b2-71a58746b602","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"7dae7479-b9a4-459c-91c4-b2412b26e4a4","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.4/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1502"
+      - "1450"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:52 GMT
+      - Thu, 02 Nov 2023 18:58:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a5ed669-e0af-45af-b799-4fac18c9f58d
+      - 07fc19fc-dc69-49dd-afe5-ecbf31bd65e0
     status: 200 OK
     code: 200
     duration: ""
@@ -1566,10 +1599,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"97aca5e5-7396-433f-b5b2-71a58746b602","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"222eb4d3-3904-4bfa-8178-d0650432726a","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1578,7 +1611,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:22 GMT
+      - Thu, 02 Nov 2023 18:58:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1621,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25d143ba-a553-4358-97d7-48e19483e016
+      - 5c7b40ec-dff0-4aad-b8b1-d5004dac6910
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1599,7 +1632,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/00224fac-6e27-4cce-b116-a57161979766
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/600f1eb9-da64-404e-bb12-feb4930dbcdb
     method: DELETE
   response:
     body: ""
@@ -1609,7 +1642,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:22 GMT
+      - Thu, 02 Nov 2023 18:58:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1619,7 +1652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5e62c58-0733-4d56-8e57-cab1c3c0d7ad
+      - 9892405a-5b13-4fcc-85f1-c9398af7bb64
     status: 204 No Content
     code: 204
     duration: ""
@@ -1630,10 +1663,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/97aca5e5-7396-433f-b5b2-71a58746b602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"97aca5e5-7396-433f-b5b2-71a58746b602","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"222eb4d3-3904-4bfa-8178-d0650432726a","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1642,7 +1675,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:23 GMT
+      - Thu, 02 Nov 2023 18:58:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1652,7 +1685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75980f60-7fd6-4f6b-9828-331aa3b412a2
+      - 4a8cc330-df2d-4ca0-9a05-782836e2dde4
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-private-network.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-private-network.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:06 GMT
+      - Thu, 02 Nov 2023 18:46:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43b1e8bd-7f95-4164-abfe-7cf01f074cbc
+      - dc84f4a9-3dab-4f0f-a22b-28f839778f4d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"my_private_network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"my_private_network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-20T16:03:03.894550Z","dhcp_enabled":true,"id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:03:03.894550Z","id":"e6309088-be92-445e-aff3-ed23f02d2264","subnet":"172.16.16.0/22","updated_at":"2023-10-20T16:03:03.894550Z"},{"created_at":"2023-10-20T16:03:03.894550Z","id":"8b341bcc-0ed0-4913-b457-8761651c74d0","subnet":"fd68:d440:21c4:3a82::/64","updated_at":"2023-10-20T16:03:03.894550Z"}],"tags":[],"updated_at":"2023-10-20T16:03:03.894550Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:00:09.985180Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "719"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:04 GMT
+      - Thu, 02 Nov 2023 19:00:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 192aa05b-00d9-4404-b95e-af2cd360f94f
+      - 4fc8a27f-7cef-4fd4-b4b9-f83ac7f86e0c
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3caf3e3f-59f3-4a02-9db0-30fab6472e83
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:03:03.894550Z","dhcp_enabled":true,"id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:03:03.894550Z","id":"e6309088-be92-445e-aff3-ed23f02d2264","subnet":"172.16.16.0/22","updated_at":"2023-10-20T16:03:03.894550Z"},{"created_at":"2023-10-20T16:03:03.894550Z","id":"8b341bcc-0ed0-4913-b457-8761651c74d0","subnet":"fd68:d440:21c4:3a82::/64","updated_at":"2023-10-20T16:03:03.894550Z"}],"tags":[],"updated_at":"2023-10-20T16:03:03.894550Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:00:09.985180Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "719"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:04 GMT
+      - Thu, 02 Nov 2023 19:00:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2ba14f7-1183-4905-a2b6-663a71c6f814
+      - 093f1c48-b25f-4c65-8fe1-54cb5b8352c3
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3caf3e3f-59f3-4a02-9db0-30fab6472e83
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:03:03.894550Z","dhcp_enabled":true,"id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:03:03.894550Z","id":"e6309088-be92-445e-aff3-ed23f02d2264","subnet":"172.16.16.0/22","updated_at":"2023-10-20T16:03:03.894550Z"},{"created_at":"2023-10-20T16:03:03.894550Z","id":"8b341bcc-0ed0-4913-b457-8761651c74d0","subnet":"fd68:d440:21c4:3a82::/64","updated_at":"2023-10-20T16:03:03.894550Z"}],"tags":[],"updated_at":"2023-10-20T16:03:03.894550Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:00:09.985180Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "719"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:05 GMT
+      - Thu, 02 Nov 2023 19:00:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 023b8d02-2dc9-4142-9ab1-8a90e7d0ffb1
+      - ad36840a-e87c-48d8-88d5-ffccaf0f5d65
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3caf3e3f-59f3-4a02-9db0-30fab6472e83
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:03:03.894550Z","dhcp_enabled":true,"id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:03:03.894550Z","id":"e6309088-be92-445e-aff3-ed23f02d2264","subnet":"172.16.16.0/22","updated_at":"2023-10-20T16:03:03.894550Z"},{"created_at":"2023-10-20T16:03:03.894550Z","id":"8b341bcc-0ed0-4913-b457-8761651c74d0","subnet":"fd68:d440:21c4:3a82::/64","updated_at":"2023-10-20T16:03:03.894550Z"}],"tags":[],"updated_at":"2023-10-20T16:03:03.894550Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:00:09.985180Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "719"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:05 GMT
+      - Thu, 02 Nov 2023 19:00:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,12 +462,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1b855ba-d9f1-47a8-9e2f-d7ee4fad712f
+      - 9fe50a81-bfe4-4640-9a48-88155e3dd438
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","service_ip":"192.168.1.42/24"}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24"}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -478,16 +478,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":null,"endpoints":[{"id":"049e4ab0-44ca-422b-9ebb-5b30be9744f3","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":null,"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1011"
+      - "975"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:06 GMT
+      - Thu, 02 Nov 2023 19:00:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -497,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae7ca11e-1c11-47d9-96c7-6561aab93277
+      - 475c3ffa-8ca5-423b-8b49-6fd954d23f2e
     status: 200 OK
     code: 200
     duration: ""
@@ -508,19 +508,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":null,"endpoints":[{"id":"049e4ab0-44ca-422b-9ebb-5b30be9744f3","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":null,"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1011"
+      - "975"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:07 GMT
+      - Thu, 02 Nov 2023 19:00:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -530,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ba9eea3-f0b5-47a4-9bea-6c89bc6502f4
+      - 02676ba6-4730-4e8c-a130-0f090204ae8f
     status: 200 OK
     code: 200
     duration: ""
@@ -541,19 +541,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":null,"endpoints":[{"id":"049e4ab0-44ca-422b-9ebb-5b30be9744f3","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":null,"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1011"
+      - "975"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:37 GMT
+      - Thu, 02 Nov 2023 19:00:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -563,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b69dcd5-03ae-4c34-8465-86bea16c7598
+      - 6a549c27-bc9a-443b-bf48-92458dc31b7b
     status: 200 OK
     code: 200
     duration: ""
@@ -574,19 +574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":null,"endpoints":[{"id":"049e4ab0-44ca-422b-9ebb-5b30be9744f3","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":null,"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1011"
+      - "975"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:04:07 GMT
+      - Thu, 02 Nov 2023 19:01:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13e9c0f9-ffa4-44c3-ad0a-a5ebf3817f52
+      - 1f6d2a26-a7e4-444d-a636-cb76745da74c
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":null,"endpoints":[{"id":"049e4ab0-44ca-422b-9ebb-5b30be9744f3","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":null,"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1011"
+      - "975"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:04:37 GMT
+      - Thu, 02 Nov 2023 19:01:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eeae8db4-7272-4edb-98ac-79019d72030e
+      - 29bfd35b-e653-4ff3-9f99-2a59e20440bc
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":null,"endpoints":[{"id":"049e4ab0-44ca-422b-9ebb-5b30be9744f3","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":null,"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1011"
+      - "975"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:08 GMT
+      - Thu, 02 Nov 2023 19:02:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ded39e36-e8ed-4ed7-bc31-c875eab765da
+      - 307d307d-2920-499c-998a-f627c3c855c3
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":null,"endpoints":[{"id":"049e4ab0-44ca-422b-9ebb-5b30be9744f3","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":null,"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1011"
+      - "975"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:38 GMT
+      - Thu, 02 Nov 2023 19:02:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a29c606-da9d-4704-8a26-f40f1baabb8c
+      - c4776ccd-412f-4081-8d34-df9b983751c0
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"049e4ab0-44ca-422b-9ebb-5b30be9744f3","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1505"
+      - "1451"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:08 GMT
+      - Thu, 02 Nov 2023 19:03:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bce61e7e-d9e5-4fd9-ba42-0db98a2782a8
+      - d361efe6-5238-4a57-807e-b848e25864a3
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0akNDQXA2Z0F3SUJBZ0lVYVMxN3JIbWJUMk9JWVkvbHQ3d0Y4d2dEaGVFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXdNakF4TmpBME1UTmFGdzB6TXpFd01UY3hOakEwTVROYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURBa2tuQ3JwZEVyamtySDl2UlZIUC91bmRwYSttVVNEZmRqS0R3VWZXNTB2QmZaQmFRdTdnSnE5Nk8KcjcvVGRLcTNsTEFRL0tkSi9VUldPaFkzV0tMR0VDUkwwcTZ6M1p2YjVtSHhUZEdKNEV3Wk55cGpBdCs2ZGpORAp4OGJDN0FMTWpmVDdkeHRmeVM4ZXMvZk1xaURjRTJtcy9sc2x4MG9RS1FrV2YvTGxUWGRCaGNpejE5cGVWT1hiCk0xanRncmR1b0V4cFBMOGNuZ1pPZ2VmRXFER21rU2gxOHJOWjdyMXI0c0d2MUVvKzNVRTNhMkdNTE1mVXFvc24KYWpWN2VPaFpEaUNMdFUwSWozQitpbVVVYlVqWU0wYUVNRHJCcnd1eFBieUNEVTY0MWE3UWlUZHVjZXFXajlCMgpQQklnRVE2djFSTjM1VmlYK2tJcnFkcWZyMHZOQWdNQkFBR2plakI0TUhZR0ExVWRFUVJ2TUcyQ0RERTVNaTR4Ck5qZ3VNUzQwTW9JTk5URXVNVFU0TGpFeU9TNHlOb0k4Y25jdE1HRTVaR1UwWW1RdFlXUTFOeTAwTW1ReExUazAKTVRjdFlXVXpOVFJrTmpNeU5tRmlMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekR5TU9od1RBcUFFcQpod1F6bm9FYU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQkxKS21SeXloME1oZkh5WG5BR051cnNHMjB0c29VCkxBNzJVY2dRRVJwb3BVdElEa1ZLZE4vcVFmMkVmcnZzQmhUSVU3NEcrZDNDem95YzBZN29Wa0VGOW5tcWFmZ0IKM0crM0NtN0t0MVJpaTVHRktaMTFnUHFqT2ZNK0VqQUlYb0hPVk9xayszVW5rZm14MkpLNnFKMldhUUhwMjlRNQp0bGtndmFoejduUEw0R3p0TERURFRtWlpuUXNKS3pkSUQyK0huZEJBaWtCcHVLdE5Od3hJS1VmVXdDc0p3RHFJCk9kL1J3Q1pYRjBlYnNEazNaYzlPaXhGNEx2SG1NaDZRQjZmUzdaZ0pLRXNnRU1GdGlpVXZJUmVIRGJ4RlRUMVgKdFRQbjBFT21XUTVzMi9aZ0ZrNnZCQnU5RmkraUhwMk9ad2hCd1JXTWFTSDdrR3A1Y1dlK0QzTXYKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVTjJad2xMZWlGQ25MT1VXejJDNEZVYXFmazlvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNREl4T1RBeE1qRmFGdzB6TXpFd016QXhPVEF4TWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ3RVBzS3RSOElEMFJWbXJYSjNoVWh6S0kva0JpajJIWnRIZGFya2dWclJ2SytEei9vTkVrK25DV1gKdUhwK3ZwdGtQY25LWTlPekpnaXBIc0xZQ21mdmFZellOeFJnZWZ6Y3lwSDZzaVZPM3BZSklpWWtCcFRGZ3Z0OQpOeWQ4YlJvSXgxR0tBdUtiOVFvcUJ5eGZTZmNEdzBUZUFCUFZMR1JRMnB0OVJaV0lJSEtJdVFUdHJwVWhaczB3CkZBclFYZnQ5TnVmMDVwdFpGWEJ1TVpNb0s5NzlJQktJdkRyejgvZHJabVJZSC9ZemF6NVQxZUhxUGhMZjJIRkoKN3VVZ0VVc2NxMStCdjVMV2JBMlR6ZERCQXppaVk4VktwUXVNamZCeHlJOWxSZ2lnQ213T2tTbnNDOW1Dazk0aQo5UkVBS0pReFV5bllKUjRRNks5QWMwaWZBaDl4QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1DNHlNREtDUEhKM0xURmlNelpsWldRMExUQmlPV1l0TkRSbE1TMDUKT1RRM0xUaGtZelF4TldFNFpqTmpNeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OVdqSWNFd0tnQgpLb2NFTTU2Q3lqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF5M29OOENveWJGWXRFdHcwOW9ZZXIxMzFMU2ZYCnkvQ1MzaEV2MFZEZWVZaDZBMUgzcFAxSXJoRzR4bVdjcDV0VE41d0o1bGdJODRzR3M1REJURG9USHE3bXFJU3AKb2lXM3N5bEp1T1NGVHAwekJBVFM1aEJaZ3FWTS9PalN0eHZQK1hpVkxSdVkxa0kzNDUvbGZuMmxoUVZ0TUxROApoNlVsczc4bHljMGdxalBVSklJWElFN2Y1RklJT0MwYm1ubjZPSk1qV0QzMTBoMURYWFpLaExEd3d5a3ZrdHN1CmJwbEZTWm96TzBIN1ZJa3ZxSmFxUHdRM1JielFzQitBaC90OGNkbmwzdGtqNzJmVWszbVRnZVovRDRybm1vT04KZUhDNCtHd0dBSzhQbDROV1huVUV4bmhYYTEveXdMeU9FV3YvekdBMzZJZXd6MzJQSnJwRklFWEYwZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1877"
+      - "1879"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:08 GMT
+      - Thu, 02 Nov 2023 19:03:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f90a216b-4f4e-4575-85ec-7219bf15f9a8
+      - 8dc0744e-f1a1-441d-9c7f-9339e1f23544
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"049e4ab0-44ca-422b-9ebb-5b30be9744f3","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1505"
+      - "1451"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:08 GMT
+      - Thu, 02 Nov 2023 19:03:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fade152f-07e2-4fb3-92c2-15aec48ab878
+      - 6e8bfae5-69b4-4b11-b881-2835373a7aea
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3caf3e3f-59f3-4a02-9db0-30fab6472e83
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:03:03.894550Z","dhcp_enabled":true,"id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:03:03.894550Z","id":"e6309088-be92-445e-aff3-ed23f02d2264","subnet":"172.16.16.0/22","updated_at":"2023-10-20T16:03:03.894550Z"},{"created_at":"2023-10-20T16:03:03.894550Z","id":"8b341bcc-0ed0-4913-b457-8761651c74d0","subnet":"fd68:d440:21c4:3a82::/64","updated_at":"2023-10-20T16:03:03.894550Z"}],"tags":[],"updated_at":"2023-10-20T16:03:03.894550Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:00:09.985180Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "719"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:09 GMT
+      - Thu, 02 Nov 2023 19:03:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afa5c974-ec75-4359-8e30-edc592208d86
+      - 019adcf1-7095-4638-92f3-8000a71d7ef2
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"049e4ab0-44ca-422b-9ebb-5b30be9744f3","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1505"
+      - "1451"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:09 GMT
+      - Thu, 02 Nov 2023 19:03:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 720e6421-16f2-4109-be10-767ea0216b55
+      - fd9e8206-776a-4adc-9690-b7e0e72c3ace
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0akNDQXA2Z0F3SUJBZ0lVYVMxN3JIbWJUMk9JWVkvbHQ3d0Y4d2dEaGVFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXdNakF4TmpBME1UTmFGdzB6TXpFd01UY3hOakEwTVROYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURBa2tuQ3JwZEVyamtySDl2UlZIUC91bmRwYSttVVNEZmRqS0R3VWZXNTB2QmZaQmFRdTdnSnE5Nk8KcjcvVGRLcTNsTEFRL0tkSi9VUldPaFkzV0tMR0VDUkwwcTZ6M1p2YjVtSHhUZEdKNEV3Wk55cGpBdCs2ZGpORAp4OGJDN0FMTWpmVDdkeHRmeVM4ZXMvZk1xaURjRTJtcy9sc2x4MG9RS1FrV2YvTGxUWGRCaGNpejE5cGVWT1hiCk0xanRncmR1b0V4cFBMOGNuZ1pPZ2VmRXFER21rU2gxOHJOWjdyMXI0c0d2MUVvKzNVRTNhMkdNTE1mVXFvc24KYWpWN2VPaFpEaUNMdFUwSWozQitpbVVVYlVqWU0wYUVNRHJCcnd1eFBieUNEVTY0MWE3UWlUZHVjZXFXajlCMgpQQklnRVE2djFSTjM1VmlYK2tJcnFkcWZyMHZOQWdNQkFBR2plakI0TUhZR0ExVWRFUVJ2TUcyQ0RERTVNaTR4Ck5qZ3VNUzQwTW9JTk5URXVNVFU0TGpFeU9TNHlOb0k4Y25jdE1HRTVaR1UwWW1RdFlXUTFOeTAwTW1ReExUazAKTVRjdFlXVXpOVFJrTmpNeU5tRmlMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekR5TU9od1RBcUFFcQpod1F6bm9FYU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQkxKS21SeXloME1oZkh5WG5BR051cnNHMjB0c29VCkxBNzJVY2dRRVJwb3BVdElEa1ZLZE4vcVFmMkVmcnZzQmhUSVU3NEcrZDNDem95YzBZN29Wa0VGOW5tcWFmZ0IKM0crM0NtN0t0MVJpaTVHRktaMTFnUHFqT2ZNK0VqQUlYb0hPVk9xayszVW5rZm14MkpLNnFKMldhUUhwMjlRNQp0bGtndmFoejduUEw0R3p0TERURFRtWlpuUXNKS3pkSUQyK0huZEJBaWtCcHVLdE5Od3hJS1VmVXdDc0p3RHFJCk9kL1J3Q1pYRjBlYnNEazNaYzlPaXhGNEx2SG1NaDZRQjZmUzdaZ0pLRXNnRU1GdGlpVXZJUmVIRGJ4RlRUMVgKdFRQbjBFT21XUTVzMi9aZ0ZrNnZCQnU5RmkraUhwMk9ad2hCd1JXTWFTSDdrR3A1Y1dlK0QzTXYKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVTjJad2xMZWlGQ25MT1VXejJDNEZVYXFmazlvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNREl4T1RBeE1qRmFGdzB6TXpFd016QXhPVEF4TWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ3RVBzS3RSOElEMFJWbXJYSjNoVWh6S0kva0JpajJIWnRIZGFya2dWclJ2SytEei9vTkVrK25DV1gKdUhwK3ZwdGtQY25LWTlPekpnaXBIc0xZQ21mdmFZellOeFJnZWZ6Y3lwSDZzaVZPM3BZSklpWWtCcFRGZ3Z0OQpOeWQ4YlJvSXgxR0tBdUtiOVFvcUJ5eGZTZmNEdzBUZUFCUFZMR1JRMnB0OVJaV0lJSEtJdVFUdHJwVWhaczB3CkZBclFYZnQ5TnVmMDVwdFpGWEJ1TVpNb0s5NzlJQktJdkRyejgvZHJabVJZSC9ZemF6NVQxZUhxUGhMZjJIRkoKN3VVZ0VVc2NxMStCdjVMV2JBMlR6ZERCQXppaVk4VktwUXVNamZCeHlJOWxSZ2lnQ213T2tTbnNDOW1Dazk0aQo5UkVBS0pReFV5bllKUjRRNks5QWMwaWZBaDl4QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1DNHlNREtDUEhKM0xURmlNelpsWldRMExUQmlPV1l0TkRSbE1TMDUKT1RRM0xUaGtZelF4TldFNFpqTmpNeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OVdqSWNFd0tnQgpLb2NFTTU2Q3lqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF5M29OOENveWJGWXRFdHcwOW9ZZXIxMzFMU2ZYCnkvQ1MzaEV2MFZEZWVZaDZBMUgzcFAxSXJoRzR4bVdjcDV0VE41d0o1bGdJODRzR3M1REJURG9USHE3bXFJU3AKb2lXM3N5bEp1T1NGVHAwekJBVFM1aEJaZ3FWTS9PalN0eHZQK1hpVkxSdVkxa0kzNDUvbGZuMmxoUVZ0TUxROApoNlVsczc4bHljMGdxalBVSklJWElFN2Y1RklJT0MwYm1ubjZPSk1qV0QzMTBoMURYWFpLaExEd3d5a3ZrdHN1CmJwbEZTWm96TzBIN1ZJa3ZxSmFxUHdRM1JielFzQitBaC90OGNkbmwzdGtqNzJmVWszbVRnZVovRDRybm1vT04KZUhDNCtHd0dBSzhQbDROV1huVUV4bmhYYTEveXdMeU9FV3YvekdBMzZJZXd6MzJQSnJwRklFWEYwZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1877"
+      - "1879"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:09 GMT
+      - Thu, 02 Nov 2023 19:03:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 810386af-7fe9-465d-81ef-272eec9889b4
+      - cb3fe9e3-3ad7-478e-a8df-8793bdc93f93
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3caf3e3f-59f3-4a02-9db0-30fab6472e83
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:03:03.894550Z","dhcp_enabled":true,"id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:03:03.894550Z","id":"e6309088-be92-445e-aff3-ed23f02d2264","subnet":"172.16.16.0/22","updated_at":"2023-10-20T16:03:03.894550Z"},{"created_at":"2023-10-20T16:03:03.894550Z","id":"8b341bcc-0ed0-4913-b457-8761651c74d0","subnet":"fd68:d440:21c4:3a82::/64","updated_at":"2023-10-20T16:03:03.894550Z"}],"tags":[],"updated_at":"2023-10-20T16:03:03.894550Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:00:09.985180Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "719"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:10 GMT
+      - Thu, 02 Nov 2023 19:03:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af430021-ab61-4a31-8cfc-8ff83e72fa26
+      - 9262c74a-7a63-469a-86d3-817ca7da6e96
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"049e4ab0-44ca-422b-9ebb-5b30be9744f3","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1505"
+      - "1451"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:10 GMT
+      - Thu, 02 Nov 2023 19:03:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d24ccbf8-93c2-4e85-8c42-7e611362a567
+      - 03a60499-b5f7-4463-ac06-6f9aa68dfca5
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0akNDQXA2Z0F3SUJBZ0lVYVMxN3JIbWJUMk9JWVkvbHQ3d0Y4d2dEaGVFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXdNakF4TmpBME1UTmFGdzB6TXpFd01UY3hOakEwTVROYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURBa2tuQ3JwZEVyamtySDl2UlZIUC91bmRwYSttVVNEZmRqS0R3VWZXNTB2QmZaQmFRdTdnSnE5Nk8KcjcvVGRLcTNsTEFRL0tkSi9VUldPaFkzV0tMR0VDUkwwcTZ6M1p2YjVtSHhUZEdKNEV3Wk55cGpBdCs2ZGpORAp4OGJDN0FMTWpmVDdkeHRmeVM4ZXMvZk1xaURjRTJtcy9sc2x4MG9RS1FrV2YvTGxUWGRCaGNpejE5cGVWT1hiCk0xanRncmR1b0V4cFBMOGNuZ1pPZ2VmRXFER21rU2gxOHJOWjdyMXI0c0d2MUVvKzNVRTNhMkdNTE1mVXFvc24KYWpWN2VPaFpEaUNMdFUwSWozQitpbVVVYlVqWU0wYUVNRHJCcnd1eFBieUNEVTY0MWE3UWlUZHVjZXFXajlCMgpQQklnRVE2djFSTjM1VmlYK2tJcnFkcWZyMHZOQWdNQkFBR2plakI0TUhZR0ExVWRFUVJ2TUcyQ0RERTVNaTR4Ck5qZ3VNUzQwTW9JTk5URXVNVFU0TGpFeU9TNHlOb0k4Y25jdE1HRTVaR1UwWW1RdFlXUTFOeTAwTW1ReExUazAKTVRjdFlXVXpOVFJrTmpNeU5tRmlMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekR5TU9od1RBcUFFcQpod1F6bm9FYU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQkxKS21SeXloME1oZkh5WG5BR051cnNHMjB0c29VCkxBNzJVY2dRRVJwb3BVdElEa1ZLZE4vcVFmMkVmcnZzQmhUSVU3NEcrZDNDem95YzBZN29Wa0VGOW5tcWFmZ0IKM0crM0NtN0t0MVJpaTVHRktaMTFnUHFqT2ZNK0VqQUlYb0hPVk9xayszVW5rZm14MkpLNnFKMldhUUhwMjlRNQp0bGtndmFoejduUEw0R3p0TERURFRtWlpuUXNKS3pkSUQyK0huZEJBaWtCcHVLdE5Od3hJS1VmVXdDc0p3RHFJCk9kL1J3Q1pYRjBlYnNEazNaYzlPaXhGNEx2SG1NaDZRQjZmUzdaZ0pLRXNnRU1GdGlpVXZJUmVIRGJ4RlRUMVgKdFRQbjBFT21XUTVzMi9aZ0ZrNnZCQnU5RmkraUhwMk9ad2hCd1JXTWFTSDdrR3A1Y1dlK0QzTXYKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVTjJad2xMZWlGQ25MT1VXejJDNEZVYXFmazlvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNREl4T1RBeE1qRmFGdzB6TXpFd016QXhPVEF4TWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ3RVBzS3RSOElEMFJWbXJYSjNoVWh6S0kva0JpajJIWnRIZGFya2dWclJ2SytEei9vTkVrK25DV1gKdUhwK3ZwdGtQY25LWTlPekpnaXBIc0xZQ21mdmFZellOeFJnZWZ6Y3lwSDZzaVZPM3BZSklpWWtCcFRGZ3Z0OQpOeWQ4YlJvSXgxR0tBdUtiOVFvcUJ5eGZTZmNEdzBUZUFCUFZMR1JRMnB0OVJaV0lJSEtJdVFUdHJwVWhaczB3CkZBclFYZnQ5TnVmMDVwdFpGWEJ1TVpNb0s5NzlJQktJdkRyejgvZHJabVJZSC9ZemF6NVQxZUhxUGhMZjJIRkoKN3VVZ0VVc2NxMStCdjVMV2JBMlR6ZERCQXppaVk4VktwUXVNamZCeHlJOWxSZ2lnQ213T2tTbnNDOW1Dazk0aQo5UkVBS0pReFV5bllKUjRRNks5QWMwaWZBaDl4QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1DNHlNREtDUEhKM0xURmlNelpsWldRMExUQmlPV1l0TkRSbE1TMDUKT1RRM0xUaGtZelF4TldFNFpqTmpNeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OVdqSWNFd0tnQgpLb2NFTTU2Q3lqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF5M29OOENveWJGWXRFdHcwOW9ZZXIxMzFMU2ZYCnkvQ1MzaEV2MFZEZWVZaDZBMUgzcFAxSXJoRzR4bVdjcDV0VE41d0o1bGdJODRzR3M1REJURG9USHE3bXFJU3AKb2lXM3N5bEp1T1NGVHAwekJBVFM1aEJaZ3FWTS9PalN0eHZQK1hpVkxSdVkxa0kzNDUvbGZuMmxoUVZ0TUxROApoNlVsczc4bHljMGdxalBVSklJWElFN2Y1RklJT0MwYm1ubjZPSk1qV0QzMTBoMURYWFpLaExEd3d5a3ZrdHN1CmJwbEZTWm96TzBIN1ZJa3ZxSmFxUHdRM1JielFzQitBaC90OGNkbmwzdGtqNzJmVWszbVRnZVovRDRybm1vT04KZUhDNCtHd0dBSzhQbDROV1huVUV4bmhYYTEveXdMeU9FV3YvekdBMzZJZXd6MzJQSnJwRklFWEYwZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1877"
+      - "1879"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:10 GMT
+      - Thu, 02 Nov 2023 19:03:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6467e9e-4491-4b23-a96a-aeec6aa4c6f5
+      - 738433db-62d4-4fa8-8e28-d5b0ba48c228
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,19 +1005,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3caf3e3f-59f3-4a02-9db0-30fab6472e83
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
     method: PATCH
   response:
-    body: '{"created_at":"2023-10-20T16:03:03.894550Z","dhcp_enabled":true,"id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:03:03.894550Z","id":"e6309088-be92-445e-aff3-ed23f02d2264","subnet":"172.16.16.0/22","updated_at":"2023-10-20T16:03:03.894550Z"},{"created_at":"2023-10-20T16:03:03.894550Z","id":"8b341bcc-0ed0-4913-b457-8761651c74d0","subnet":"fd68:d440:21c4:3a82::/64","updated_at":"2023-10-20T16:03:03.894550Z"}],"tags":[],"updated_at":"2023-10-20T16:06:10.869138Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:03:17.581461Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "734"
+      - "716"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:10 GMT
+      - Thu, 02 Nov 2023 19:03:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f91f47c1-aeeb-4156-876f-27bee43907f8
+      - 07c8c750-6736-43a3-93cb-ce302c19bac0
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +1038,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3caf3e3f-59f3-4a02-9db0-30fab6472e83
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:03:03.894550Z","dhcp_enabled":true,"id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:03:03.894550Z","id":"e6309088-be92-445e-aff3-ed23f02d2264","subnet":"172.16.16.0/22","updated_at":"2023-10-20T16:03:03.894550Z"},{"created_at":"2023-10-20T16:03:03.894550Z","id":"8b341bcc-0ed0-4913-b457-8761651c74d0","subnet":"fd68:d440:21c4:3a82::/64","updated_at":"2023-10-20T16:03:03.894550Z"}],"tags":[],"updated_at":"2023-10-20T16:06:10.869138Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:03:17.581461Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "734"
+      - "716"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:10 GMT
+      - Thu, 02 Nov 2023 19:03:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,12 +1060,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0be645a-5e61-4866-9b2f-33ef252978e4
+      - d9c1d018-59f3-4545-b222-b4990c73f64f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"my_private_network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"my_private_network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -1076,16 +1076,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-20T16:06:10.887036Z","dhcp_enabled":true,"id":"be16cb41-05ed-4e74-9325-436457439dad","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:06:10.887036Z","id":"9f60edb6-d33d-43c6-aa30-cf77ef9c8968","subnet":"172.16.12.0/22","updated_at":"2023-10-20T16:06:10.887036Z"},{"created_at":"2023-10-20T16:06:10.887036Z","id":"bf153124-eb1a-4b08-83d3-c2fa08120f0a","subnet":"fd68:d440:21c4:e4d4::/64","updated_at":"2023-10-20T16:06:10.887036Z"}],"tags":[],"updated_at":"2023-10-20T16:06:10.887036Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-02T19:03:17.580618Z","dhcp_enabled":true,"id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:03:17.580618Z","id":"5fac6309-5b9e-410a-99b1-d941ca004f0c","subnet":"172.16.8.0/22","updated_at":"2023-11-02T19:03:17.580618Z"},{"created_at":"2023-11-02T19:03:17.580618Z","id":"bc28f882-eca4-4c8f-abe0-df520e71f3a7","subnet":"fd68:d440:21c4:65b5::/64","updated_at":"2023-11-02T19:03:17.580618Z"}],"tags":[],"updated_at":"2023-11-02T19:03:17.580618Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "719"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:11 GMT
+      - Thu, 02 Nov 2023 19:03:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1095,7 +1095,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c33868c2-5146-4217-ba29-190eea6d9b62
+      - 0252d964-c5a0-4211-89dc-446c8cf839c0
     status: 200 OK
     code: 200
     duration: ""
@@ -1106,19 +1106,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/be16cb41-05ed-4e74-9325-436457439dad
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8c96124f-20c2-42fa-a66f-60a0387ec4c9
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:06:10.887036Z","dhcp_enabled":true,"id":"be16cb41-05ed-4e74-9325-436457439dad","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:06:10.887036Z","id":"9f60edb6-d33d-43c6-aa30-cf77ef9c8968","subnet":"172.16.12.0/22","updated_at":"2023-10-20T16:06:10.887036Z"},{"created_at":"2023-10-20T16:06:10.887036Z","id":"bf153124-eb1a-4b08-83d3-c2fa08120f0a","subnet":"fd68:d440:21c4:e4d4::/64","updated_at":"2023-10-20T16:06:10.887036Z"}],"tags":[],"updated_at":"2023-10-20T16:06:10.887036Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-02T19:03:17.580618Z","dhcp_enabled":true,"id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:03:17.580618Z","id":"5fac6309-5b9e-410a-99b1-d941ca004f0c","subnet":"172.16.8.0/22","updated_at":"2023-11-02T19:03:17.580618Z"},{"created_at":"2023-11-02T19:03:17.580618Z","id":"bc28f882-eca4-4c8f-abe0-df520e71f3a7","subnet":"fd68:d440:21c4:65b5::/64","updated_at":"2023-11-02T19:03:17.580618Z"}],"tags":[],"updated_at":"2023-11-02T19:03:17.580618Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "719"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:11 GMT
+      - Thu, 02 Nov 2023 19:03:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1128,7 +1128,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 119589f6-9400-4585-96f6-271d733209f7
+      - 896c5911-8daf-4779-8b23-bc0ff2b62467
     status: 200 OK
     code: 200
     duration: ""
@@ -1139,19 +1139,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"049e4ab0-44ca-422b-9ebb-5b30be9744f3","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1505"
+      - "1451"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:12 GMT
+      - Thu, 02 Nov 2023 19:03:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1161,12 +1161,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 894686c4-a402-4948-98a7-3ae1c0268538
+      - 9aec3db7-72b5-4c93-92e4-d65bd4ff407c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"backup_schedule_frequency":null,"backup_schedule_retention":null,"is_backup_schedule_disabled":null,"name":null,"tags":null,"logs_policy":null,"backup_same_region":null,"backup_schedule_start_hour":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1451"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 19:03:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0c1168e5-bfff-4c9b-86c3-60cc3397b6a3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{}'
     form: {}
     headers:
       Content-Type:
@@ -1174,19 +1207,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"049e4ab0-44ca-422b-9ebb-5b30be9744f3","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1505"
+      - "1451"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:12 GMT
+      - Thu, 02 Nov 2023 19:03:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1196,7 +1229,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59d37f4b-6539-404e-b6ff-cf779a73579b
+      - 83ad6fde-2ef9-4f10-9c67-37d0305fd290
     status: 200 OK
     code: 200
     duration: ""
@@ -1207,19 +1240,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"049e4ab0-44ca-422b-9ebb-5b30be9744f3","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1505"
+      - "1451"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:12 GMT
+      - Thu, 02 Nov 2023 19:03:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1229,7 +1262,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2693f036-542e-4921-8c99-4aceac1a4e7a
+      - 63461722-bd41-4da6-8f9f-da02b694af58
     status: 200 OK
     code: 200
     duration: ""
@@ -1240,7 +1273,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/049e4ab0-44ca-422b-9ebb-5b30be9744f3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/d2f13d77-2ae7-4ae8-be59-e0617730bfdb
     method: DELETE
   response:
     body: ""
@@ -1250,7 +1283,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:12 GMT
+      - Thu, 02 Nov 2023 19:03:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1260,7 +1293,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be13f78e-b4f2-474e-a0b5-3d4a834be0ee
+      - 5977552f-9d74-4f7b-b12b-7a077bd9cb47
     status: 204 No Content
     code: 204
     duration: ""
@@ -1271,19 +1304,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"049e4ab0-44ca-422b-9ebb-5b30be9744f3","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1511"
+      - "1457"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:12 GMT
+      - Thu, 02 Nov 2023 19:03:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1293,7 +1326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee34338c-8937-45ed-a7c8-6250653beb26
+      - a1f92114-6572-4f68-89b3-fa96114a5f6f
     status: 200 OK
     code: 200
     duration: ""
@@ -1304,19 +1337,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1279"
+      - "1232"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:43 GMT
+      - Thu, 02 Nov 2023 19:03:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1326,12 +1359,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46f33b00-ec53-4cc0-879a-4710437967f2
+      - 86a5e859-9e0d-44aa-b9e1-59f7258c8719
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"endpoint_spec":{"private_network":{"private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","service_ip":"192.168.1.254/24"}}}'
+    body: '{"endpoint_spec":{"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24"}}}'
     form: {}
     headers:
       Content-Type:
@@ -1339,19 +1372,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab/endpoints
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/endpoints
     method: POST
   response:
-    body: '{"id":"af46dbda-ba7e-416b-913e-474671c2b4cb","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}'
+    body: '{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}'
     headers:
       Content-Length:
-      - "226"
+      - "220"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:43 GMT
+      - Thu, 02 Nov 2023 19:03:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1361,7 +1394,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3763a2c9-9f89-4ee7-9c9a-addcaa216c7a
+      - 23dbb035-00b1-4c8e-afc8-7f8d7aa2cba1
     status: 200 OK
     code: 200
     duration: ""
@@ -1372,19 +1405,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"af46dbda-ba7e-416b-913e-474671c2b4cb","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1514"
+      - "1460"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:43 GMT
+      - Thu, 02 Nov 2023 19:03:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1394,7 +1427,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5f839e9-8e09-4793-9487-b28149fe9bf0
+      - 83a2bd9d-8d2d-4f2f-b7c8-f3966f3670a6
     status: 200 OK
     code: 200
     duration: ""
@@ -1405,19 +1438,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"af46dbda-ba7e-416b-913e-474671c2b4cb","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1507"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:14 GMT
+      - Thu, 02 Nov 2023 19:04:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1427,7 +1460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5bfdc43-7f53-4520-8b47-72ae2cc51ea6
+      - 800dae7d-2ade-4c30-a78c-4796dd1d659f
     status: 200 OK
     code: 200
     duration: ""
@@ -1438,19 +1471,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0akNDQXA2Z0F3SUJBZ0lVYVMxN3JIbWJUMk9JWVkvbHQ3d0Y4d2dEaGVFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXdNakF4TmpBME1UTmFGdzB6TXpFd01UY3hOakEwTVROYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURBa2tuQ3JwZEVyamtySDl2UlZIUC91bmRwYSttVVNEZmRqS0R3VWZXNTB2QmZaQmFRdTdnSnE5Nk8KcjcvVGRLcTNsTEFRL0tkSi9VUldPaFkzV0tMR0VDUkwwcTZ6M1p2YjVtSHhUZEdKNEV3Wk55cGpBdCs2ZGpORAp4OGJDN0FMTWpmVDdkeHRmeVM4ZXMvZk1xaURjRTJtcy9sc2x4MG9RS1FrV2YvTGxUWGRCaGNpejE5cGVWT1hiCk0xanRncmR1b0V4cFBMOGNuZ1pPZ2VmRXFER21rU2gxOHJOWjdyMXI0c0d2MUVvKzNVRTNhMkdNTE1mVXFvc24KYWpWN2VPaFpEaUNMdFUwSWozQitpbVVVYlVqWU0wYUVNRHJCcnd1eFBieUNEVTY0MWE3UWlUZHVjZXFXajlCMgpQQklnRVE2djFSTjM1VmlYK2tJcnFkcWZyMHZOQWdNQkFBR2plakI0TUhZR0ExVWRFUVJ2TUcyQ0RERTVNaTR4Ck5qZ3VNUzQwTW9JTk5URXVNVFU0TGpFeU9TNHlOb0k4Y25jdE1HRTVaR1UwWW1RdFlXUTFOeTAwTW1ReExUazAKTVRjdFlXVXpOVFJrTmpNeU5tRmlMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekR5TU9od1RBcUFFcQpod1F6bm9FYU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQkxKS21SeXloME1oZkh5WG5BR051cnNHMjB0c29VCkxBNzJVY2dRRVJwb3BVdElEa1ZLZE4vcVFmMkVmcnZzQmhUSVU3NEcrZDNDem95YzBZN29Wa0VGOW5tcWFmZ0IKM0crM0NtN0t0MVJpaTVHRktaMTFnUHFqT2ZNK0VqQUlYb0hPVk9xayszVW5rZm14MkpLNnFKMldhUUhwMjlRNQp0bGtndmFoejduUEw0R3p0TERURFRtWlpuUXNKS3pkSUQyK0huZEJBaWtCcHVLdE5Od3hJS1VmVXdDc0p3RHFJCk9kL1J3Q1pYRjBlYnNEazNaYzlPaXhGNEx2SG1NaDZRQjZmUzdaZ0pLRXNnRU1GdGlpVXZJUmVIRGJ4RlRUMVgKdFRQbjBFT21XUTVzMi9aZ0ZrNnZCQnU5RmkraUhwMk9ad2hCd1JXTWFTSDdrR3A1Y1dlK0QzTXYKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVTjJad2xMZWlGQ25MT1VXejJDNEZVYXFmazlvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNREl4T1RBeE1qRmFGdzB6TXpFd016QXhPVEF4TWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ3RVBzS3RSOElEMFJWbXJYSjNoVWh6S0kva0JpajJIWnRIZGFya2dWclJ2SytEei9vTkVrK25DV1gKdUhwK3ZwdGtQY25LWTlPekpnaXBIc0xZQ21mdmFZellOeFJnZWZ6Y3lwSDZzaVZPM3BZSklpWWtCcFRGZ3Z0OQpOeWQ4YlJvSXgxR0tBdUtiOVFvcUJ5eGZTZmNEdzBUZUFCUFZMR1JRMnB0OVJaV0lJSEtJdVFUdHJwVWhaczB3CkZBclFYZnQ5TnVmMDVwdFpGWEJ1TVpNb0s5NzlJQktJdkRyejgvZHJabVJZSC9ZemF6NVQxZUhxUGhMZjJIRkoKN3VVZ0VVc2NxMStCdjVMV2JBMlR6ZERCQXppaVk4VktwUXVNamZCeHlJOWxSZ2lnQ213T2tTbnNDOW1Dazk0aQo5UkVBS0pReFV5bllKUjRRNks5QWMwaWZBaDl4QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1DNHlNREtDUEhKM0xURmlNelpsWldRMExUQmlPV1l0TkRSbE1TMDUKT1RRM0xUaGtZelF4TldFNFpqTmpNeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OVdqSWNFd0tnQgpLb2NFTTU2Q3lqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF5M29OOENveWJGWXRFdHcwOW9ZZXIxMzFMU2ZYCnkvQ1MzaEV2MFZEZWVZaDZBMUgzcFAxSXJoRzR4bVdjcDV0VE41d0o1bGdJODRzR3M1REJURG9USHE3bXFJU3AKb2lXM3N5bEp1T1NGVHAwekJBVFM1aEJaZ3FWTS9PalN0eHZQK1hpVkxSdVkxa0kzNDUvbGZuMmxoUVZ0TUxROApoNlVsczc4bHljMGdxalBVSklJWElFN2Y1RklJT0MwYm1ubjZPSk1qV0QzMTBoMURYWFpLaExEd3d5a3ZrdHN1CmJwbEZTWm96TzBIN1ZJa3ZxSmFxUHdRM1JielFzQitBaC90OGNkbmwzdGtqNzJmVWszbVRnZVovRDRybm1vT04KZUhDNCtHd0dBSzhQbDROV1huVUV4bmhYYTEveXdMeU9FV3YvekdBMzZJZXd6MzJQSnJwRklFWEYwZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1877"
+      - "1879"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:14 GMT
+      - Thu, 02 Nov 2023 19:04:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1460,7 +1493,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70e9688b-dd48-433f-b22c-c3f3ecabfce0
+      - fc41b402-40cd-4f96-ace8-20871e2f2d4c
     status: 200 OK
     code: 200
     duration: ""
@@ -1471,19 +1504,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"af46dbda-ba7e-416b-913e-474671c2b4cb","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1507"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:14 GMT
+      - Thu, 02 Nov 2023 19:04:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1493,7 +1526,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3e0c675-0a47-4a0a-887e-511eb9d79740
+      - d36ad7bb-de0b-4cf8-b171-34862f897131
     status: 200 OK
     code: 200
     duration: ""
@@ -1504,19 +1537,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3caf3e3f-59f3-4a02-9db0-30fab6472e83
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8c96124f-20c2-42fa-a66f-60a0387ec4c9
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:03:03.894550Z","dhcp_enabled":true,"id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:03:03.894550Z","id":"e6309088-be92-445e-aff3-ed23f02d2264","subnet":"172.16.16.0/22","updated_at":"2023-10-20T16:03:03.894550Z"},{"created_at":"2023-10-20T16:03:03.894550Z","id":"8b341bcc-0ed0-4913-b457-8761651c74d0","subnet":"fd68:d440:21c4:3a82::/64","updated_at":"2023-10-20T16:03:03.894550Z"}],"tags":[],"updated_at":"2023-10-20T16:06:10.869138Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-02T19:03:17.580618Z","dhcp_enabled":true,"id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:03:17.580618Z","id":"5fac6309-5b9e-410a-99b1-d941ca004f0c","subnet":"172.16.8.0/22","updated_at":"2023-11-02T19:03:17.580618Z"},{"created_at":"2023-11-02T19:03:17.580618Z","id":"bc28f882-eca4-4c8f-abe0-df520e71f3a7","subnet":"fd68:d440:21c4:65b5::/64","updated_at":"2023-11-02T19:03:17.580618Z"}],"tags":[],"updated_at":"2023-11-02T19:03:17.580618Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "734"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:14 GMT
+      - Thu, 02 Nov 2023 19:04:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1526,7 +1559,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f5ef16b-7519-4d45-a02a-3dcf78b2a43d
+      - 28a3a615-e75e-4fc8-ab40-2b9bc0cbe8f2
     status: 200 OK
     code: 200
     duration: ""
@@ -1537,19 +1570,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/be16cb41-05ed-4e74-9325-436457439dad
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:06:10.887036Z","dhcp_enabled":true,"id":"be16cb41-05ed-4e74-9325-436457439dad","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:06:10.887036Z","id":"9f60edb6-d33d-43c6-aa30-cf77ef9c8968","subnet":"172.16.12.0/22","updated_at":"2023-10-20T16:06:10.887036Z"},{"created_at":"2023-10-20T16:06:10.887036Z","id":"bf153124-eb1a-4b08-83d3-c2fa08120f0a","subnet":"fd68:d440:21c4:e4d4::/64","updated_at":"2023-10-20T16:06:10.887036Z"}],"tags":[],"updated_at":"2023-10-20T16:06:10.887036Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:03:17.581461Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "719"
+      - "716"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:14 GMT
+      - Thu, 02 Nov 2023 19:04:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1559,7 +1592,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ace7e0f-ec78-4352-9685-a7c8491f6203
+      - 16f9f1fa-c4d7-4dd9-a317-4a38e95f81b9
     status: 200 OK
     code: 200
     duration: ""
@@ -1570,19 +1603,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"af46dbda-ba7e-416b-913e-474671c2b4cb","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1507"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:15 GMT
+      - Thu, 02 Nov 2023 19:04:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1592,7 +1625,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be9c7fc9-3d38-47ed-ae2a-7829a5b57536
+      - d14e1e5c-4342-4ac8-baaa-51621550d977
     status: 200 OK
     code: 200
     duration: ""
@@ -1603,19 +1636,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0akNDQXA2Z0F3SUJBZ0lVYVMxN3JIbWJUMk9JWVkvbHQ3d0Y4d2dEaGVFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXdNakF4TmpBME1UTmFGdzB6TXpFd01UY3hOakEwTVROYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURBa2tuQ3JwZEVyamtySDl2UlZIUC91bmRwYSttVVNEZmRqS0R3VWZXNTB2QmZaQmFRdTdnSnE5Nk8KcjcvVGRLcTNsTEFRL0tkSi9VUldPaFkzV0tMR0VDUkwwcTZ6M1p2YjVtSHhUZEdKNEV3Wk55cGpBdCs2ZGpORAp4OGJDN0FMTWpmVDdkeHRmeVM4ZXMvZk1xaURjRTJtcy9sc2x4MG9RS1FrV2YvTGxUWGRCaGNpejE5cGVWT1hiCk0xanRncmR1b0V4cFBMOGNuZ1pPZ2VmRXFER21rU2gxOHJOWjdyMXI0c0d2MUVvKzNVRTNhMkdNTE1mVXFvc24KYWpWN2VPaFpEaUNMdFUwSWozQitpbVVVYlVqWU0wYUVNRHJCcnd1eFBieUNEVTY0MWE3UWlUZHVjZXFXajlCMgpQQklnRVE2djFSTjM1VmlYK2tJcnFkcWZyMHZOQWdNQkFBR2plakI0TUhZR0ExVWRFUVJ2TUcyQ0RERTVNaTR4Ck5qZ3VNUzQwTW9JTk5URXVNVFU0TGpFeU9TNHlOb0k4Y25jdE1HRTVaR1UwWW1RdFlXUTFOeTAwTW1ReExUazAKTVRjdFlXVXpOVFJrTmpNeU5tRmlMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekR5TU9od1RBcUFFcQpod1F6bm9FYU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQkxKS21SeXloME1oZkh5WG5BR051cnNHMjB0c29VCkxBNzJVY2dRRVJwb3BVdElEa1ZLZE4vcVFmMkVmcnZzQmhUSVU3NEcrZDNDem95YzBZN29Wa0VGOW5tcWFmZ0IKM0crM0NtN0t0MVJpaTVHRktaMTFnUHFqT2ZNK0VqQUlYb0hPVk9xayszVW5rZm14MkpLNnFKMldhUUhwMjlRNQp0bGtndmFoejduUEw0R3p0TERURFRtWlpuUXNKS3pkSUQyK0huZEJBaWtCcHVLdE5Od3hJS1VmVXdDc0p3RHFJCk9kL1J3Q1pYRjBlYnNEazNaYzlPaXhGNEx2SG1NaDZRQjZmUzdaZ0pLRXNnRU1GdGlpVXZJUmVIRGJ4RlRUMVgKdFRQbjBFT21XUTVzMi9aZ0ZrNnZCQnU5RmkraUhwMk9ad2hCd1JXTWFTSDdrR3A1Y1dlK0QzTXYKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVTjJad2xMZWlGQ25MT1VXejJDNEZVYXFmazlvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNREl4T1RBeE1qRmFGdzB6TXpFd016QXhPVEF4TWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ3RVBzS3RSOElEMFJWbXJYSjNoVWh6S0kva0JpajJIWnRIZGFya2dWclJ2SytEei9vTkVrK25DV1gKdUhwK3ZwdGtQY25LWTlPekpnaXBIc0xZQ21mdmFZellOeFJnZWZ6Y3lwSDZzaVZPM3BZSklpWWtCcFRGZ3Z0OQpOeWQ4YlJvSXgxR0tBdUtiOVFvcUJ5eGZTZmNEdzBUZUFCUFZMR1JRMnB0OVJaV0lJSEtJdVFUdHJwVWhaczB3CkZBclFYZnQ5TnVmMDVwdFpGWEJ1TVpNb0s5NzlJQktJdkRyejgvZHJabVJZSC9ZemF6NVQxZUhxUGhMZjJIRkoKN3VVZ0VVc2NxMStCdjVMV2JBMlR6ZERCQXppaVk4VktwUXVNamZCeHlJOWxSZ2lnQ213T2tTbnNDOW1Dazk0aQo5UkVBS0pReFV5bllKUjRRNks5QWMwaWZBaDl4QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1DNHlNREtDUEhKM0xURmlNelpsWldRMExUQmlPV1l0TkRSbE1TMDUKT1RRM0xUaGtZelF4TldFNFpqTmpNeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OVdqSWNFd0tnQgpLb2NFTTU2Q3lqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF5M29OOENveWJGWXRFdHcwOW9ZZXIxMzFMU2ZYCnkvQ1MzaEV2MFZEZWVZaDZBMUgzcFAxSXJoRzR4bVdjcDV0VE41d0o1bGdJODRzR3M1REJURG9USHE3bXFJU3AKb2lXM3N5bEp1T1NGVHAwekJBVFM1aEJaZ3FWTS9PalN0eHZQK1hpVkxSdVkxa0kzNDUvbGZuMmxoUVZ0TUxROApoNlVsczc4bHljMGdxalBVSklJWElFN2Y1RklJT0MwYm1ubjZPSk1qV0QzMTBoMURYWFpLaExEd3d5a3ZrdHN1CmJwbEZTWm96TzBIN1ZJa3ZxSmFxUHdRM1JielFzQitBaC90OGNkbmwzdGtqNzJmVWszbVRnZVovRDRybm1vT04KZUhDNCtHd0dBSzhQbDROV1huVUV4bmhYYTEveXdMeU9FV3YvekdBMzZJZXd6MzJQSnJwRklFWEYwZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1877"
+      - "1879"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:15 GMT
+      - Thu, 02 Nov 2023 19:04:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1625,7 +1658,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c554b69d-f0ea-4029-9460-434c968b08e2
+      - cec31fb6-9366-413b-8a8e-d5814603bcb6
     status: 200 OK
     code: 200
     duration: ""
@@ -1636,19 +1669,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3caf3e3f-59f3-4a02-9db0-30fab6472e83
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8c96124f-20c2-42fa-a66f-60a0387ec4c9
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:03:03.894550Z","dhcp_enabled":true,"id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:03:03.894550Z","id":"e6309088-be92-445e-aff3-ed23f02d2264","subnet":"172.16.16.0/22","updated_at":"2023-10-20T16:03:03.894550Z"},{"created_at":"2023-10-20T16:03:03.894550Z","id":"8b341bcc-0ed0-4913-b457-8761651c74d0","subnet":"fd68:d440:21c4:3a82::/64","updated_at":"2023-10-20T16:03:03.894550Z"}],"tags":[],"updated_at":"2023-10-20T16:06:10.869138Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-02T19:03:17.580618Z","dhcp_enabled":true,"id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:03:17.580618Z","id":"5fac6309-5b9e-410a-99b1-d941ca004f0c","subnet":"172.16.8.0/22","updated_at":"2023-11-02T19:03:17.580618Z"},{"created_at":"2023-11-02T19:03:17.580618Z","id":"bc28f882-eca4-4c8f-abe0-df520e71f3a7","subnet":"fd68:d440:21c4:65b5::/64","updated_at":"2023-11-02T19:03:17.580618Z"}],"tags":[],"updated_at":"2023-11-02T19:03:17.580618Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "734"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:15 GMT
+      - Thu, 02 Nov 2023 19:04:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1658,7 +1691,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b206799-ca0e-40e6-8542-b28801f73561
+      - 99e4aa36-4692-4eb2-9f9c-0ec201e2bcf3
     status: 200 OK
     code: 200
     duration: ""
@@ -1669,19 +1702,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/be16cb41-05ed-4e74-9325-436457439dad
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:06:10.887036Z","dhcp_enabled":true,"id":"be16cb41-05ed-4e74-9325-436457439dad","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:06:10.887036Z","id":"9f60edb6-d33d-43c6-aa30-cf77ef9c8968","subnet":"172.16.12.0/22","updated_at":"2023-10-20T16:06:10.887036Z"},{"created_at":"2023-10-20T16:06:10.887036Z","id":"bf153124-eb1a-4b08-83d3-c2fa08120f0a","subnet":"fd68:d440:21c4:e4d4::/64","updated_at":"2023-10-20T16:06:10.887036Z"}],"tags":[],"updated_at":"2023-10-20T16:06:10.887036Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:03:17.581461Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "719"
+      - "716"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:15 GMT
+      - Thu, 02 Nov 2023 19:04:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1691,7 +1724,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c468f02-623f-4c26-b678-9a9a129aa35a
+      - aa65f4cc-3f5f-4a05-810b-c1cca397cf1d
     status: 200 OK
     code: 200
     duration: ""
@@ -1702,19 +1735,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"af46dbda-ba7e-416b-913e-474671c2b4cb","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1507"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:16 GMT
+      - Thu, 02 Nov 2023 19:04:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1724,7 +1757,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0b72ee4-99df-4355-a9ec-66aee924b753
+      - f119dcba-3d94-4ea2-a35c-f53533d63385
     status: 200 OK
     code: 200
     duration: ""
@@ -1735,19 +1768,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0akNDQXA2Z0F3SUJBZ0lVYVMxN3JIbWJUMk9JWVkvbHQ3d0Y4d2dEaGVFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXdNakF4TmpBME1UTmFGdzB6TXpFd01UY3hOakEwTVROYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURBa2tuQ3JwZEVyamtySDl2UlZIUC91bmRwYSttVVNEZmRqS0R3VWZXNTB2QmZaQmFRdTdnSnE5Nk8KcjcvVGRLcTNsTEFRL0tkSi9VUldPaFkzV0tMR0VDUkwwcTZ6M1p2YjVtSHhUZEdKNEV3Wk55cGpBdCs2ZGpORAp4OGJDN0FMTWpmVDdkeHRmeVM4ZXMvZk1xaURjRTJtcy9sc2x4MG9RS1FrV2YvTGxUWGRCaGNpejE5cGVWT1hiCk0xanRncmR1b0V4cFBMOGNuZ1pPZ2VmRXFER21rU2gxOHJOWjdyMXI0c0d2MUVvKzNVRTNhMkdNTE1mVXFvc24KYWpWN2VPaFpEaUNMdFUwSWozQitpbVVVYlVqWU0wYUVNRHJCcnd1eFBieUNEVTY0MWE3UWlUZHVjZXFXajlCMgpQQklnRVE2djFSTjM1VmlYK2tJcnFkcWZyMHZOQWdNQkFBR2plakI0TUhZR0ExVWRFUVJ2TUcyQ0RERTVNaTR4Ck5qZ3VNUzQwTW9JTk5URXVNVFU0TGpFeU9TNHlOb0k4Y25jdE1HRTVaR1UwWW1RdFlXUTFOeTAwTW1ReExUazAKTVRjdFlXVXpOVFJrTmpNeU5tRmlMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekR5TU9od1RBcUFFcQpod1F6bm9FYU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQkxKS21SeXloME1oZkh5WG5BR051cnNHMjB0c29VCkxBNzJVY2dRRVJwb3BVdElEa1ZLZE4vcVFmMkVmcnZzQmhUSVU3NEcrZDNDem95YzBZN29Wa0VGOW5tcWFmZ0IKM0crM0NtN0t0MVJpaTVHRktaMTFnUHFqT2ZNK0VqQUlYb0hPVk9xayszVW5rZm14MkpLNnFKMldhUUhwMjlRNQp0bGtndmFoejduUEw0R3p0TERURFRtWlpuUXNKS3pkSUQyK0huZEJBaWtCcHVLdE5Od3hJS1VmVXdDc0p3RHFJCk9kL1J3Q1pYRjBlYnNEazNaYzlPaXhGNEx2SG1NaDZRQjZmUzdaZ0pLRXNnRU1GdGlpVXZJUmVIRGJ4RlRUMVgKdFRQbjBFT21XUTVzMi9aZ0ZrNnZCQnU5RmkraUhwMk9ad2hCd1JXTWFTSDdrR3A1Y1dlK0QzTXYKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVTjJad2xMZWlGQ25MT1VXejJDNEZVYXFmazlvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNREl4T1RBeE1qRmFGdzB6TXpFd016QXhPVEF4TWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ3RVBzS3RSOElEMFJWbXJYSjNoVWh6S0kva0JpajJIWnRIZGFya2dWclJ2SytEei9vTkVrK25DV1gKdUhwK3ZwdGtQY25LWTlPekpnaXBIc0xZQ21mdmFZellOeFJnZWZ6Y3lwSDZzaVZPM3BZSklpWWtCcFRGZ3Z0OQpOeWQ4YlJvSXgxR0tBdUtiOVFvcUJ5eGZTZmNEdzBUZUFCUFZMR1JRMnB0OVJaV0lJSEtJdVFUdHJwVWhaczB3CkZBclFYZnQ5TnVmMDVwdFpGWEJ1TVpNb0s5NzlJQktJdkRyejgvZHJabVJZSC9ZemF6NVQxZUhxUGhMZjJIRkoKN3VVZ0VVc2NxMStCdjVMV2JBMlR6ZERCQXppaVk4VktwUXVNamZCeHlJOWxSZ2lnQ213T2tTbnNDOW1Dazk0aQo5UkVBS0pReFV5bllKUjRRNks5QWMwaWZBaDl4QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1DNHlNREtDUEhKM0xURmlNelpsWldRMExUQmlPV1l0TkRSbE1TMDUKT1RRM0xUaGtZelF4TldFNFpqTmpNeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OVdqSWNFd0tnQgpLb2NFTTU2Q3lqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF5M29OOENveWJGWXRFdHcwOW9ZZXIxMzFMU2ZYCnkvQ1MzaEV2MFZEZWVZaDZBMUgzcFAxSXJoRzR4bVdjcDV0VE41d0o1bGdJODRzR3M1REJURG9USHE3bXFJU3AKb2lXM3N5bEp1T1NGVHAwekJBVFM1aEJaZ3FWTS9PalN0eHZQK1hpVkxSdVkxa0kzNDUvbGZuMmxoUVZ0TUxROApoNlVsczc4bHljMGdxalBVSklJWElFN2Y1RklJT0MwYm1ubjZPSk1qV0QzMTBoMURYWFpLaExEd3d5a3ZrdHN1CmJwbEZTWm96TzBIN1ZJa3ZxSmFxUHdRM1JielFzQitBaC90OGNkbmwzdGtqNzJmVWszbVRnZVovRDRybm1vT04KZUhDNCtHd0dBSzhQbDROV1huVUV4bmhYYTEveXdMeU9FV3YvekdBMzZJZXd6MzJQSnJwRklFWEYwZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1877"
+      - "1879"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:16 GMT
+      - Thu, 02 Nov 2023 19:04:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1757,12 +1790,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47f085e8-5898-4689-8935-43d0238d60aa
+      - 06abfcf0-5b22-406b-975c-0c37533b6b1e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"192.168.1.0/24","address":null,"pool_low":null,"pool_high":null,"enable_dynamic":null,"valid_lifetime":null,"renew_timer":null,"rebind_timer":null,"push_default_route":null,"push_dns_server":null,"dns_servers_override":null,"dns_search":null,"dns_local_name":null}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"192.168.1.0/24"}'
     form: {}
     headers:
       Content-Type:
@@ -1773,16 +1806,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps
     method: POST
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "586"
+      - "568"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:17 GMT
+      - Thu, 02 Nov 2023 19:04:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1792,7 +1825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1268f66f-3888-4f40-be48-4768daa4152f
+      - 7501cfd3-b9ce-4d78-a012-b07ddc6834bd
     status: 200 OK
     code: 200
     duration: ""
@@ -1803,19 +1836,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/a70a910f-43d5-433d-9fba-c7b9a3d30779
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/9a82af0b-34a4-4749-ab14-189473b39511
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "586"
+      - "568"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:17 GMT
+      - Thu, 02 Nov 2023 19:04:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1825,7 +1858,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b36565d-fa19-41aa-846d-0bb81cd14f16
+      - 9bb65c58-65a8-43f9-80cc-489f7eeca57d
     status: 200 OK
     code: 200
     duration: ""
@@ -1841,16 +1874,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips
     method: POST
   response:
-    body: '{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":null,"id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"}'
+    body: '{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":null,"id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "365"
+      - "356"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:17 GMT
+      - Thu, 02 Nov 2023 19:04:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1860,7 +1893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15a7219c-1c3c-4354-b34f-57eb533ebab9
+      - 931998d3-ac6a-4fb5-ab31-ba673d4b406f
     status: 200 OK
     code: 200
     duration: ""
@@ -1871,19 +1904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/5f70de3c-f79a-48cb-9039-fff8e870b535
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/a85bcd79-4ee5-4871-b63e-1abd0fae407c
     method: GET
   response:
-    body: '{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":null,"id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"}'
+    body: '{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":null,"id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "365"
+      - "356"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:18 GMT
+      - Thu, 02 Nov 2023 19:04:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1893,12 +1926,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc3c2098-3046-4772-9474-752439ee5038
+      - 4c8f4dc0-0679-4882-a81e-15308561407a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"5f70de3c-f79a-48cb-9039-fff8e870b535","enable_smtp":false,"enable_bastion":false,"bastion_port":null}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","enable_smtp":false,"enable_bastion":false}'
     form: {}
     headers:
       Content-Type:
@@ -1909,16 +1942,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways
     method: POST
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:07:18.218885Z","gateway_networks":[],"id":"8910856f-3503-4ea3-9748-545163679069","ip":{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:07:18.218885Z","upstream_dns_servers":[],"version":null,"zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:24.389160Z","upstream_dns_servers":[],"version":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "967"
+      - "938"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:18 GMT
+      - Thu, 02 Nov 2023 19:04:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1928,7 +1961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c5fb353-5570-4aa2-b69a-59540441d151
+      - 2d3ec1cb-4cfb-43d8-b194-546383564cf9
     status: 200 OK
     code: 200
     duration: ""
@@ -1939,19 +1972,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8910856f-3503-4ea3-9748-545163679069
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:07:18.218885Z","gateway_networks":[],"id":"8910856f-3503-4ea3-9748-545163679069","ip":{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:07:18.286969Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:24.460270Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "970"
+      - "941"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:18 GMT
+      - Thu, 02 Nov 2023 19:04:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1961,7 +1994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69fa5484-3ad0-4ff8-a671-f3afa77ad2d8
+      - 1f20612d-5d83-4a5d-abc1-25ddafa5a94f
     status: 200 OK
     code: 200
     duration: ""
@@ -1972,19 +2005,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8910856f-3503-4ea3-9748-545163679069
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:07:18.218885Z","gateway_networks":[],"id":"8910856f-3503-4ea3-9748-545163679069","ip":{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:07:19.050613Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:25.143008Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "967"
+      - "938"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:23 GMT
+      - Thu, 02 Nov 2023 19:04:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1994,7 +2027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94026d43-a013-4690-b127-190f39d54e97
+      - 50f3f045-dd62-4890-974a-f593e9f4a193
     status: 200 OK
     code: 200
     duration: ""
@@ -2005,19 +2038,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8910856f-3503-4ea3-9748-545163679069
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:07:18.218885Z","gateway_networks":[],"id":"8910856f-3503-4ea3-9748-545163679069","ip":{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:07:19.050613Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:25.143008Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "967"
+      - "938"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:23 GMT
+      - Thu, 02 Nov 2023 19:04:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2027,7 +2060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84f3b783-9eea-43f9-924e-68a40f9f622c
+      - 305e4372-f5ec-49df-9643-c37a725a7575
     status: 200 OK
     code: 200
     duration: ""
@@ -2038,19 +2071,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8910856f-3503-4ea3-9748-545163679069
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:07:18.218885Z","gateway_networks":[],"id":"8910856f-3503-4ea3-9748-545163679069","ip":{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:07:19.050613Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:25.143008Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "967"
+      - "938"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:23 GMT
+      - Thu, 02 Nov 2023 19:04:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2060,12 +2093,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f07cd61-0c48-4632-809e-8faa70d8859f
+      - db33b62d-2ca4-425a-93c9-0c20d49db128
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"8910856f-3503-4ea3-9748-545163679069","private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"a70a910f-43d5-433d-9fba-c7b9a3d30779"}'
+    body: '{"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"9a82af0b-34a4-4749-ab14-189473b39511"}'
     form: {}
     headers:
       Content-Type:
@@ -2076,16 +2109,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":null,"private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"created","updated_at":"2023-10-20T16:07:24.976704Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":null,"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"created","updated_at":"2023-11-02T19:04:31.839577Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "983"
+      - "953"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:25 GMT
+      - Thu, 02 Nov 2023 19:04:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2095,7 +2128,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e8af2b2-a06f-4af1-86dd-f84f85befcb3
+      - 61856ad0-35dc-4bce-8f71-ef7e080ea104
     status: 200 OK
     code: 200
     duration: ""
@@ -2106,19 +2139,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8910856f-3503-4ea3-9748-545163679069
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:07:18.218885Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":null,"private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"created","updated_at":"2023-10-20T16:07:24.976704Z","zone":"nl-ams-1"}],"id":"8910856f-3503-4ea3-9748-545163679069","ip":{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:07:25.163800Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":null,"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"created","updated_at":"2023-11-02T19:04:31.839577Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:32.023648Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1953"
+      - "1894"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:25 GMT
+      - Thu, 02 Nov 2023 19:04:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2128,7 +2161,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f16b06dc-3d4c-4020-86c3-a75384bc81ef
+      - ca3ddeac-0b87-47fc-b9fd-2db9f010d573
     status: 200 OK
     code: 200
     duration: ""
@@ -2139,19 +2172,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8910856f-3503-4ea3-9748-545163679069
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:07:18.218885Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":"02:00:00:11:D8:08","private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"ready","updated_at":"2023-10-20T16:07:27.095115Z","zone":"nl-ams-1"}],"id":"8910856f-3503-4ea3-9748-545163679069","ip":{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:07:27.226169Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":null,"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"created","updated_at":"2023-11-02T19:04:31.839577Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:32.023648Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1962"
+      - "1894"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:30 GMT
+      - Thu, 02 Nov 2023 19:04:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2161,7 +2194,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb858384-21dc-4ac7-851f-0226b5784951
+      - fd8d024a-d091-4a07-beb8-688fdc960187
     status: 200 OK
     code: 200
     duration: ""
@@ -2172,19 +2205,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/4feba31d-fdb0-4541-afb8-69e7a4223e5e
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":"02:00:00:11:D8:08","private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"ready","updated_at":"2023-10-20T16:07:27.095115Z","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "996"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:30 GMT
+      - Thu, 02 Nov 2023 19:04:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2194,7 +2227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ea4eff2-5e65-4a1d-8f43-0487bcf220b6
+      - 2ba8ac74-c0e0-4de3-96eb-5a136c8c1b33
     status: 200 OK
     code: 200
     duration: ""
@@ -2205,19 +2238,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/4feba31d-fdb0-4541-afb8-69e7a4223e5e
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":"02:00:00:11:D8:08","private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"ready","updated_at":"2023-10-20T16:07:27.095115Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "996"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:30 GMT
+      - Thu, 02 Nov 2023 19:04:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2227,7 +2260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b48573a9-f93f-43d1-b70f-b502d66b8e40
+      - 96cdd6c2-a8a9-4d36-874b-5c2d7304ef1e
     status: 200 OK
     code: 200
     duration: ""
@@ -2238,19 +2271,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8910856f-3503-4ea3-9748-545163679069
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:07:18.218885Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":"02:00:00:11:D8:08","private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"ready","updated_at":"2023-10-20T16:07:27.095115Z","zone":"nl-ams-1"}],"id":"8910856f-3503-4ea3-9748-545163679069","ip":{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:07:27.226169Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1962"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:30 GMT
+      - Thu, 02 Nov 2023 19:04:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2260,7 +2293,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 443cd196-bbc6-4de0-ae57-aa1698181678
+      - 26e7b735-0c07-44b3-a11d-7dba3230a727
     status: 200 OK
     code: 200
     duration: ""
@@ -2271,19 +2304,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/4feba31d-fdb0-4541-afb8-69e7a4223e5e
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":"02:00:00:11:D8:08","private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"ready","updated_at":"2023-10-20T16:07:27.095115Z","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "996"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:30 GMT
+      - Thu, 02 Nov 2023 19:04:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2293,7 +2326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1988f54f-41cf-40d0-80b3-f3c27445d715
+      - 8ffffb14-fef3-4c25-8a0e-d689e2210e27
     status: 200 OK
     code: 200
     duration: ""
@@ -2304,19 +2337,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8910856f-3503-4ea3-9748-545163679069
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:07:18.218885Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":"02:00:00:11:D8:08","private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"ready","updated_at":"2023-10-20T16:07:27.095115Z","zone":"nl-ams-1"}],"id":"8910856f-3503-4ea3-9748-545163679069","ip":{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:07:27.226169Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1962"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:30 GMT
+      - Thu, 02 Nov 2023 19:04:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2326,7 +2359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6923e96f-f172-45df-9c17-73201c34a062
+      - 0eea8b7b-ba41-4748-a366-6e55fcf982e5
     status: 200 OK
     code: 200
     duration: ""
@@ -2337,19 +2370,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8910856f-3503-4ea3-9748-545163679069
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:07:18.218885Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":"02:00:00:11:D8:08","private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"ready","updated_at":"2023-10-20T16:07:27.095115Z","zone":"nl-ams-1"}],"id":"8910856f-3503-4ea3-9748-545163679069","ip":{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:07:27.226169Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1962"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:30 GMT
+      - Thu, 02 Nov 2023 19:04:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2359,12 +2392,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3416dd4-5cdc-4e88-8475-efe421e6d551
+      - 49a76c0a-53f4-4955-908f-cab9b53ab4ed
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"8910856f-3503-4ea3-9748-545163679069","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both"}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1903"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 19:04:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - eba47e98-bc1f-4211-9d80-0a64e2bb1eb5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both"}'
     form: {}
     headers:
       Content-Type:
@@ -2375,16 +2441,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules
     method: POST
   response:
-    body: '{"created_at":"2023-10-20T16:07:30.826419Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"dcd8003d-d6a9-4e9b-913b-bc7dea46e6a6","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-10-20T16:07:30.826419Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-02T19:04:42.717872Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"030551cf-3765-4015-8cdd-5387f1c19d34","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-02T19:04:42.717872Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "291"
+      - "283"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:30 GMT
+      - Thu, 02 Nov 2023 19:04:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2394,7 +2460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f13c1ca-4e33-43c1-9b49-d7d36d319ee7
+      - 167606c9-e986-41d6-b19c-6b2fb90496a2
     status: 200 OK
     code: 200
     duration: ""
@@ -2405,19 +2471,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8910856f-3503-4ea3-9748-545163679069
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:07:18.218885Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":"02:00:00:11:D8:08","private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"ready","updated_at":"2023-10-20T16:07:27.095115Z","zone":"nl-ams-1"}],"id":"8910856f-3503-4ea3-9748-545163679069","ip":{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:07:27.226169Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1962"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:30 GMT
+      - Thu, 02 Nov 2023 19:04:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2427,7 +2493,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 060c9622-9b3f-41da-bf41-2b3a55f505e3
+      - b8a33d2b-ea38-405c-a7f6-8598c0c8464a
     status: 200 OK
     code: 200
     duration: ""
@@ -2438,19 +2504,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/dcd8003d-d6a9-4e9b-913b-bc7dea46e6a6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/030551cf-3765-4015-8cdd-5387f1c19d34
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:07:30.826419Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"dcd8003d-d6a9-4e9b-913b-bc7dea46e6a6","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-10-20T16:07:30.826419Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-02T19:04:42.717872Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"030551cf-3765-4015-8cdd-5387f1c19d34","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-02T19:04:42.717872Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "291"
+      - "283"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:30 GMT
+      - Thu, 02 Nov 2023 19:04:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2460,7 +2526,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4d0bb4c-2e47-444f-a7b3-9ff50aa91377
+      - 2e5243e4-4351-4861-835a-235c79e53f19
     status: 200 OK
     code: 200
     duration: ""
@@ -2471,19 +2537,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"af46dbda-ba7e-416b-913e-474671c2b4cb","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1507"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:31 GMT
+      - Thu, 02 Nov 2023 19:04:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2493,7 +2559,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46957bb7-4967-4998-a46b-0e888b6cf49a
+      - 475218fb-4aa9-4a3b-805b-946270372649
     status: 200 OK
     code: 200
     duration: ""
@@ -2504,19 +2570,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/a70a910f-43d5-433d-9fba-c7b9a3d30779
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/a85bcd79-4ee5-4871-b63e-1abd0fae407c
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "586"
+      - "390"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:32 GMT
+      - Thu, 02 Nov 2023 19:04:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2526,7 +2592,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5805a696-0b18-42d3-9dee-1310b4ee27a5
+      - 1f04f954-8c38-4058-8ecb-241c01bd5ff0
     status: 200 OK
     code: 200
     duration: ""
@@ -2537,19 +2603,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/5f70de3c-f79a-48cb-9039-fff8e870b535
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/9a82af0b-34a4-4749-ab14-189473b39511
     method: GET
   response:
-    body: '{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "399"
+      - "568"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:32 GMT
+      - Thu, 02 Nov 2023 19:04:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2559,7 +2625,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38cb4788-d042-4ed1-ad1e-fecfd64ddf39
+      - e2060c6d-159c-4362-bcb1-fe5ec91985dd
     status: 200 OK
     code: 200
     duration: ""
@@ -2570,19 +2636,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/be16cb41-05ed-4e74-9325-436457439dad
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8c96124f-20c2-42fa-a66f-60a0387ec4c9
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:06:10.887036Z","dhcp_enabled":true,"id":"be16cb41-05ed-4e74-9325-436457439dad","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:06:10.887036Z","id":"9f60edb6-d33d-43c6-aa30-cf77ef9c8968","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:24.061078Z"},{"created_at":"2023-10-20T16:06:10.887036Z","id":"bf153124-eb1a-4b08-83d3-c2fa08120f0a","subnet":"fd68:d440:21c4:e4d4::/64","updated_at":"2023-10-20T16:07:24.066188Z"}],"tags":[],"updated_at":"2023-10-20T16:07:26.752494Z","vpc_id":"8cd44b5b-c882-4098-93ac-0261cc6d1548"}'
+    body: '{"created_at":"2023-11-02T19:03:17.580618Z","dhcp_enabled":true,"id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:03:17.580618Z","id":"5fac6309-5b9e-410a-99b1-d941ca004f0c","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:30.346920Z"},{"created_at":"2023-11-02T19:03:17.580618Z","id":"bc28f882-eca4-4c8f-abe0-df520e71f3a7","subnet":"fd68:d440:21c4:65b5::/64","updated_at":"2023-11-02T19:04:30.349838Z"}],"tags":[],"updated_at":"2023-11-02T19:04:38.949487Z","vpc_id":"f24e24ff-e35b-4e4c-8e20-22beb977d3ef"}'
     headers:
       Content-Length:
-      - "719"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:32 GMT
+      - Thu, 02 Nov 2023 19:04:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2592,7 +2658,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4122f678-8479-4c5a-807d-1e0c128f4ec8
+      - cbd676e4-ba74-4798-aad8-148d9ff386f4
     status: 200 OK
     code: 200
     duration: ""
@@ -2603,19 +2669,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3caf3e3f-59f3-4a02-9db0-30fab6472e83
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:03:03.894550Z","dhcp_enabled":true,"id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:03:03.894550Z","id":"e6309088-be92-445e-aff3-ed23f02d2264","subnet":"172.16.16.0/22","updated_at":"2023-10-20T16:03:03.894550Z"},{"created_at":"2023-10-20T16:03:03.894550Z","id":"8b341bcc-0ed0-4913-b457-8761651c74d0","subnet":"fd68:d440:21c4:3a82::/64","updated_at":"2023-10-20T16:03:03.894550Z"}],"tags":[],"updated_at":"2023-10-20T16:06:10.869138Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "734"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:32 GMT
+      - Thu, 02 Nov 2023 19:04:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2625,7 +2691,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8e3f5ce-faf8-41a9-8f30-eccff5188234
+      - c90645fc-0f1f-4b06-ab65-e1b7c510580b
     status: 200 OK
     code: 200
     duration: ""
@@ -2636,19 +2702,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8910856f-3503-4ea3-9748-545163679069
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:07:18.218885Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":"02:00:00:11:D8:08","private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"ready","updated_at":"2023-10-20T16:07:27.095115Z","zone":"nl-ams-1"}],"id":"8910856f-3503-4ea3-9748-545163679069","ip":{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:07:27.226169Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:03:17.581461Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "1962"
+      - "716"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:32 GMT
+      - Thu, 02 Nov 2023 19:04:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2658,7 +2724,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f565901-bb9b-4a24-883e-2ffb47479655
+      - 7d61298a-fde9-4fb0-917f-26285f5241d9
     status: 200 OK
     code: 200
     duration: ""
@@ -2669,19 +2735,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/4feba31d-fdb0-4541-afb8-69e7a4223e5e
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":"02:00:00:11:D8:08","private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"ready","updated_at":"2023-10-20T16:07:27.095115Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "996"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:32 GMT
+      - Thu, 02 Nov 2023 19:04:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2691,7 +2757,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76f360e4-1287-46f6-8fbf-04f104df1898
+      - 4c8c9af8-0095-4d62-8373-5cd25064e4f0
     status: 200 OK
     code: 200
     duration: ""
@@ -2702,19 +2768,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"af46dbda-ba7e-416b-913e-474671c2b4cb","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1507"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:32 GMT
+      - Thu, 02 Nov 2023 19:04:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2724,7 +2790,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4732782-7666-42b2-b1b0-1770f1aaf760
+      - a7939fe8-b92e-48ab-b09f-29f62eceae9c
     status: 200 OK
     code: 200
     duration: ""
@@ -2735,19 +2801,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8910856f-3503-4ea3-9748-545163679069
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:07:18.218885Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":"02:00:00:11:D8:08","private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"ready","updated_at":"2023-10-20T16:07:27.095115Z","zone":"nl-ams-1"}],"id":"8910856f-3503-4ea3-9748-545163679069","ip":{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:07:27.226169Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1962"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:32 GMT
+      - Thu, 02 Nov 2023 19:04:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2757,7 +2823,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70353408-7197-48e2-9546-d90e638cef9e
+      - a5551f3c-9699-4354-85b9-0eb56f22f462
     status: 200 OK
     code: 200
     duration: ""
@@ -2768,19 +2834,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab/certificate
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0akNDQXA2Z0F3SUJBZ0lVYVMxN3JIbWJUMk9JWVkvbHQ3d0Y4d2dEaGVFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXdNakF4TmpBME1UTmFGdzB6TXpFd01UY3hOakEwTVROYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURBa2tuQ3JwZEVyamtySDl2UlZIUC91bmRwYSttVVNEZmRqS0R3VWZXNTB2QmZaQmFRdTdnSnE5Nk8KcjcvVGRLcTNsTEFRL0tkSi9VUldPaFkzV0tMR0VDUkwwcTZ6M1p2YjVtSHhUZEdKNEV3Wk55cGpBdCs2ZGpORAp4OGJDN0FMTWpmVDdkeHRmeVM4ZXMvZk1xaURjRTJtcy9sc2x4MG9RS1FrV2YvTGxUWGRCaGNpejE5cGVWT1hiCk0xanRncmR1b0V4cFBMOGNuZ1pPZ2VmRXFER21rU2gxOHJOWjdyMXI0c0d2MUVvKzNVRTNhMkdNTE1mVXFvc24KYWpWN2VPaFpEaUNMdFUwSWozQitpbVVVYlVqWU0wYUVNRHJCcnd1eFBieUNEVTY0MWE3UWlUZHVjZXFXajlCMgpQQklnRVE2djFSTjM1VmlYK2tJcnFkcWZyMHZOQWdNQkFBR2plakI0TUhZR0ExVWRFUVJ2TUcyQ0RERTVNaTR4Ck5qZ3VNUzQwTW9JTk5URXVNVFU0TGpFeU9TNHlOb0k4Y25jdE1HRTVaR1UwWW1RdFlXUTFOeTAwTW1ReExUazAKTVRjdFlXVXpOVFJrTmpNeU5tRmlMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekR5TU9od1RBcUFFcQpod1F6bm9FYU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQkxKS21SeXloME1oZkh5WG5BR051cnNHMjB0c29VCkxBNzJVY2dRRVJwb3BVdElEa1ZLZE4vcVFmMkVmcnZzQmhUSVU3NEcrZDNDem95YzBZN29Wa0VGOW5tcWFmZ0IKM0crM0NtN0t0MVJpaTVHRktaMTFnUHFqT2ZNK0VqQUlYb0hPVk9xayszVW5rZm14MkpLNnFKMldhUUhwMjlRNQp0bGtndmFoejduUEw0R3p0TERURFRtWlpuUXNKS3pkSUQyK0huZEJBaWtCcHVLdE5Od3hJS1VmVXdDc0p3RHFJCk9kL1J3Q1pYRjBlYnNEazNaYzlPaXhGNEx2SG1NaDZRQjZmUzdaZ0pLRXNnRU1GdGlpVXZJUmVIRGJ4RlRUMVgKdFRQbjBFT21XUTVzMi9aZ0ZrNnZCQnU5RmkraUhwMk9ad2hCd1JXTWFTSDdrR3A1Y1dlK0QzTXYKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1877"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:32 GMT
+      - Thu, 02 Nov 2023 19:04:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2790,7 +2856,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2cb71b80-ec07-46d9-8aa6-ca38039fc4d6
+      - 0f167cbc-f70e-46ab-aeaf-2039a067dfb3
     status: 200 OK
     code: 200
     duration: ""
@@ -2801,19 +2867,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/4feba31d-fdb0-4541-afb8-69e7a4223e5e
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/certificate
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":"02:00:00:11:D8:08","private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"ready","updated_at":"2023-10-20T16:07:27.095115Z","zone":"nl-ams-1"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVTjJad2xMZWlGQ25MT1VXejJDNEZVYXFmazlvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNREl4T1RBeE1qRmFGdzB6TXpFd016QXhPVEF4TWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ3RVBzS3RSOElEMFJWbXJYSjNoVWh6S0kva0JpajJIWnRIZGFya2dWclJ2SytEei9vTkVrK25DV1gKdUhwK3ZwdGtQY25LWTlPekpnaXBIc0xZQ21mdmFZellOeFJnZWZ6Y3lwSDZzaVZPM3BZSklpWWtCcFRGZ3Z0OQpOeWQ4YlJvSXgxR0tBdUtiOVFvcUJ5eGZTZmNEdzBUZUFCUFZMR1JRMnB0OVJaV0lJSEtJdVFUdHJwVWhaczB3CkZBclFYZnQ5TnVmMDVwdFpGWEJ1TVpNb0s5NzlJQktJdkRyejgvZHJabVJZSC9ZemF6NVQxZUhxUGhMZjJIRkoKN3VVZ0VVc2NxMStCdjVMV2JBMlR6ZERCQXppaVk4VktwUXVNamZCeHlJOWxSZ2lnQ213T2tTbnNDOW1Dazk0aQo5UkVBS0pReFV5bllKUjRRNks5QWMwaWZBaDl4QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1DNHlNREtDUEhKM0xURmlNelpsWldRMExUQmlPV1l0TkRSbE1TMDUKT1RRM0xUaGtZelF4TldFNFpqTmpNeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OVdqSWNFd0tnQgpLb2NFTTU2Q3lqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF5M29OOENveWJGWXRFdHcwOW9ZZXIxMzFMU2ZYCnkvQ1MzaEV2MFZEZWVZaDZBMUgzcFAxSXJoRzR4bVdjcDV0VE41d0o1bGdJODRzR3M1REJURG9USHE3bXFJU3AKb2lXM3N5bEp1T1NGVHAwekJBVFM1aEJaZ3FWTS9PalN0eHZQK1hpVkxSdVkxa0kzNDUvbGZuMmxoUVZ0TUxROApoNlVsczc4bHljMGdxalBVSklJWElFN2Y1RklJT0MwYm1ubjZPSk1qV0QzMTBoMURYWFpLaExEd3d5a3ZrdHN1CmJwbEZTWm96TzBIN1ZJa3ZxSmFxUHdRM1JielFzQitBaC90OGNkbmwzdGtqNzJmVWszbVRnZVovRDRybm1vT04KZUhDNCtHd0dBSzhQbDROV1huVUV4bmhYYTEveXdMeU9FV3YvekdBMzZJZXd6MzJQSnJwRklFWEYwZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "996"
+      - "1879"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:32 GMT
+      - Thu, 02 Nov 2023 19:04:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2823,7 +2889,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8df1bfa8-d4ba-4089-99af-7de13c27f55f
+      - f3358d9d-2e9f-47a3-8775-a969250660cc
     status: 200 OK
     code: 200
     duration: ""
@@ -2834,19 +2900,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/dcd8003d-d6a9-4e9b-913b-bc7dea46e6a6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/030551cf-3765-4015-8cdd-5387f1c19d34
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:07:30.826419Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"dcd8003d-d6a9-4e9b-913b-bc7dea46e6a6","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-10-20T16:07:30.826419Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-02T19:04:42.717872Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"030551cf-3765-4015-8cdd-5387f1c19d34","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-02T19:04:42.717872Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "291"
+      - "283"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:32 GMT
+      - Thu, 02 Nov 2023 19:04:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2856,7 +2922,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c281a6a-4545-4e40-8a44-63e630c5e4da
+      - d047633c-bad9-48fe-9787-635e8590893e
     status: 200 OK
     code: 200
     duration: ""
@@ -2867,19 +2933,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/dcd8003d-d6a9-4e9b-913b-bc7dea46e6a6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/030551cf-3765-4015-8cdd-5387f1c19d34
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:07:30.826419Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"dcd8003d-d6a9-4e9b-913b-bc7dea46e6a6","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-10-20T16:07:30.826419Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-02T19:04:42.717872Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"030551cf-3765-4015-8cdd-5387f1c19d34","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-02T19:04:42.717872Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "291"
+      - "283"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:33 GMT
+      - Thu, 02 Nov 2023 19:04:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2889,7 +2955,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 775f144c-80a6-4863-88f6-aeeff33e6f3f
+      - 9253227f-6e8e-4b3e-84c9-133471cab5e1
     status: 200 OK
     code: 200
     duration: ""
@@ -2900,19 +2966,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3caf3e3f-59f3-4a02-9db0-30fab6472e83
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/a85bcd79-4ee5-4871-b63e-1abd0fae407c
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:03:03.894550Z","dhcp_enabled":true,"id":"3caf3e3f-59f3-4a02-9db0-30fab6472e83","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:03:03.894550Z","id":"e6309088-be92-445e-aff3-ed23f02d2264","subnet":"172.16.16.0/22","updated_at":"2023-10-20T16:03:03.894550Z"},{"created_at":"2023-10-20T16:03:03.894550Z","id":"8b341bcc-0ed0-4913-b457-8761651c74d0","subnet":"fd68:d440:21c4:3a82::/64","updated_at":"2023-10-20T16:03:03.894550Z"}],"tags":[],"updated_at":"2023-10-20T16:06:10.869138Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "734"
+      - "390"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:33 GMT
+      - Thu, 02 Nov 2023 19:04:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2922,7 +2988,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d56f2b1-657d-42fd-9c17-5ffa91630981
+      - 03f290d0-96e0-470a-a574-ab5394a38a9e
     status: 200 OK
     code: 200
     duration: ""
@@ -2933,19 +2999,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/a70a910f-43d5-433d-9fba-c7b9a3d30779
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/9a82af0b-34a4-4749-ab14-189473b39511
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "586"
+      - "568"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:33 GMT
+      - Thu, 02 Nov 2023 19:04:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2955,7 +3021,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd02e997-1549-4e91-af3c-a0a23ff2cb82
+      - a444d14b-8999-407e-88c6-4b2b95d84b6a
     status: 200 OK
     code: 200
     duration: ""
@@ -2966,19 +3032,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8910856f-3503-4ea3-9748-545163679069
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:07:18.218885Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":"02:00:00:11:D8:08","private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"ready","updated_at":"2023-10-20T16:07:27.095115Z","zone":"nl-ams-1"}],"id":"8910856f-3503-4ea3-9748-545163679069","ip":{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:07:27.226169Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1962"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:33 GMT
+      - Thu, 02 Nov 2023 19:04:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2988,7 +3054,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51bb37b0-2a3f-454c-a211-290c37d9debe
+      - 11a0499f-f2c3-4564-bfdd-d62d1af2d32b
     status: 200 OK
     code: 200
     duration: ""
@@ -2999,19 +3065,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/5f70de3c-f79a-48cb-9039-fff8e870b535
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
     method: GET
   response:
-    body: '{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:03:17.581461Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "399"
+      - "716"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:33 GMT
+      - Thu, 02 Nov 2023 19:04:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3021,7 +3087,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47b3d5e2-7694-41e1-b205-2445a9f3debd
+      - ee8ebee9-f325-4a3a-a9e5-3f52505020f1
     status: 200 OK
     code: 200
     duration: ""
@@ -3032,19 +3098,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/4feba31d-fdb0-4541-afb8-69e7a4223e5e
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8c96124f-20c2-42fa-a66f-60a0387ec4c9
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":"02:00:00:11:D8:08","private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"ready","updated_at":"2023-10-20T16:07:27.095115Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-02T19:03:17.580618Z","dhcp_enabled":true,"id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:03:17.580618Z","id":"5fac6309-5b9e-410a-99b1-d941ca004f0c","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:30.346920Z"},{"created_at":"2023-11-02T19:03:17.580618Z","id":"bc28f882-eca4-4c8f-abe0-df520e71f3a7","subnet":"fd68:d440:21c4:65b5::/64","updated_at":"2023-11-02T19:04:30.349838Z"}],"tags":[],"updated_at":"2023-11-02T19:04:38.949487Z","vpc_id":"f24e24ff-e35b-4e4c-8e20-22beb977d3ef"}'
     headers:
       Content-Length:
-      - "996"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:33 GMT
+      - Thu, 02 Nov 2023 19:04:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3054,7 +3120,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9df0d9f-b6d7-4425-861c-01d685ec46ce
+      - b66df8aa-732e-42d7-a62b-3acf03f41fa3
     status: 200 OK
     code: 200
     duration: ""
@@ -3065,19 +3131,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/be16cb41-05ed-4e74-9325-436457439dad
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:06:10.887036Z","dhcp_enabled":true,"id":"be16cb41-05ed-4e74-9325-436457439dad","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:06:10.887036Z","id":"9f60edb6-d33d-43c6-aa30-cf77ef9c8968","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:24.061078Z"},{"created_at":"2023-10-20T16:06:10.887036Z","id":"bf153124-eb1a-4b08-83d3-c2fa08120f0a","subnet":"fd68:d440:21c4:e4d4::/64","updated_at":"2023-10-20T16:07:24.066188Z"}],"tags":[],"updated_at":"2023-10-20T16:07:26.752494Z","vpc_id":"8cd44b5b-c882-4098-93ac-0261cc6d1548"}'
+    body: '{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "719"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:33 GMT
+      - Thu, 02 Nov 2023 19:04:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3087,7 +3153,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18c90743-dfcd-49e3-8f39-73d57a0fe38d
+      - ae08b4db-8a14-4527-9367-23e92c6f0e0e
     status: 200 OK
     code: 200
     duration: ""
@@ -3098,19 +3164,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8910856f-3503-4ea3-9748-545163679069
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:07:18.218885Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":"02:00:00:11:D8:08","private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"ready","updated_at":"2023-10-20T16:07:27.095115Z","zone":"nl-ams-1"}],"id":"8910856f-3503-4ea3-9748-545163679069","ip":{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:07:27.226169Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1962"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:33 GMT
+      - Thu, 02 Nov 2023 19:04:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3120,7 +3186,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52044a7c-7377-4ff2-8490-6e14180595f9
+      - 000bedc4-5562-40a6-b081-4769638b2606
     status: 200 OK
     code: 200
     duration: ""
@@ -3131,19 +3197,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"af46dbda-ba7e-416b-913e-474671c2b4cb","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1507"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:33 GMT
+      - Thu, 02 Nov 2023 19:04:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3153,7 +3219,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8febb26-d02c-499f-9934-3c82521b6a9e
+      - 50402085-3051-4f89-93b4-b1adb573cebd
     status: 200 OK
     code: 200
     duration: ""
@@ -3164,19 +3230,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/4feba31d-fdb0-4541-afb8-69e7a4223e5e
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":"02:00:00:11:D8:08","private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"ready","updated_at":"2023-10-20T16:07:27.095115Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "996"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:33 GMT
+      - Thu, 02 Nov 2023 19:04:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3186,7 +3252,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29ed68ba-6d09-46e9-aa78-411b6a0a5b5c
+      - f2f4b79d-f611-4ae5-b7dc-25994b4d2d29
     status: 200 OK
     code: 200
     duration: ""
@@ -3197,19 +3263,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0akNDQXA2Z0F3SUJBZ0lVYVMxN3JIbWJUMk9JWVkvbHQ3d0Y4d2dEaGVFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXdNakF4TmpBME1UTmFGdzB6TXpFd01UY3hOakEwTVROYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURBa2tuQ3JwZEVyamtySDl2UlZIUC91bmRwYSttVVNEZmRqS0R3VWZXNTB2QmZaQmFRdTdnSnE5Nk8KcjcvVGRLcTNsTEFRL0tkSi9VUldPaFkzV0tMR0VDUkwwcTZ6M1p2YjVtSHhUZEdKNEV3Wk55cGpBdCs2ZGpORAp4OGJDN0FMTWpmVDdkeHRmeVM4ZXMvZk1xaURjRTJtcy9sc2x4MG9RS1FrV2YvTGxUWGRCaGNpejE5cGVWT1hiCk0xanRncmR1b0V4cFBMOGNuZ1pPZ2VmRXFER21rU2gxOHJOWjdyMXI0c0d2MUVvKzNVRTNhMkdNTE1mVXFvc24KYWpWN2VPaFpEaUNMdFUwSWozQitpbVVVYlVqWU0wYUVNRHJCcnd1eFBieUNEVTY0MWE3UWlUZHVjZXFXajlCMgpQQklnRVE2djFSTjM1VmlYK2tJcnFkcWZyMHZOQWdNQkFBR2plakI0TUhZR0ExVWRFUVJ2TUcyQ0RERTVNaTR4Ck5qZ3VNUzQwTW9JTk5URXVNVFU0TGpFeU9TNHlOb0k4Y25jdE1HRTVaR1UwWW1RdFlXUTFOeTAwTW1ReExUazAKTVRjdFlXVXpOVFJrTmpNeU5tRmlMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekR5TU9od1RBcUFFcQpod1F6bm9FYU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQkxKS21SeXloME1oZkh5WG5BR051cnNHMjB0c29VCkxBNzJVY2dRRVJwb3BVdElEa1ZLZE4vcVFmMkVmcnZzQmhUSVU3NEcrZDNDem95YzBZN29Wa0VGOW5tcWFmZ0IKM0crM0NtN0t0MVJpaTVHRktaMTFnUHFqT2ZNK0VqQUlYb0hPVk9xayszVW5rZm14MkpLNnFKMldhUUhwMjlRNQp0bGtndmFoejduUEw0R3p0TERURFRtWlpuUXNKS3pkSUQyK0huZEJBaWtCcHVLdE5Od3hJS1VmVXdDc0p3RHFJCk9kL1J3Q1pYRjBlYnNEazNaYzlPaXhGNEx2SG1NaDZRQjZmUzdaZ0pLRXNnRU1GdGlpVXZJUmVIRGJ4RlRUMVgKdFRQbjBFT21XUTVzMi9aZ0ZrNnZCQnU5RmkraUhwMk9ad2hCd1JXTWFTSDdrR3A1Y1dlK0QzTXYKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVTjJad2xMZWlGQ25MT1VXejJDNEZVYXFmazlvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNREl4T1RBeE1qRmFGdzB6TXpFd016QXhPVEF4TWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ3RVBzS3RSOElEMFJWbXJYSjNoVWh6S0kva0JpajJIWnRIZGFya2dWclJ2SytEei9vTkVrK25DV1gKdUhwK3ZwdGtQY25LWTlPekpnaXBIc0xZQ21mdmFZellOeFJnZWZ6Y3lwSDZzaVZPM3BZSklpWWtCcFRGZ3Z0OQpOeWQ4YlJvSXgxR0tBdUtiOVFvcUJ5eGZTZmNEdzBUZUFCUFZMR1JRMnB0OVJaV0lJSEtJdVFUdHJwVWhaczB3CkZBclFYZnQ5TnVmMDVwdFpGWEJ1TVpNb0s5NzlJQktJdkRyejgvZHJabVJZSC9ZemF6NVQxZUhxUGhMZjJIRkoKN3VVZ0VVc2NxMStCdjVMV2JBMlR6ZERCQXppaVk4VktwUXVNamZCeHlJOWxSZ2lnQ213T2tTbnNDOW1Dazk0aQo5UkVBS0pReFV5bllKUjRRNks5QWMwaWZBaDl4QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1DNHlNREtDUEhKM0xURmlNelpsWldRMExUQmlPV1l0TkRSbE1TMDUKT1RRM0xUaGtZelF4TldFNFpqTmpNeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OVdqSWNFd0tnQgpLb2NFTTU2Q3lqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF5M29OOENveWJGWXRFdHcwOW9ZZXIxMzFMU2ZYCnkvQ1MzaEV2MFZEZWVZaDZBMUgzcFAxSXJoRzR4bVdjcDV0VE41d0o1bGdJODRzR3M1REJURG9USHE3bXFJU3AKb2lXM3N5bEp1T1NGVHAwekJBVFM1aEJaZ3FWTS9PalN0eHZQK1hpVkxSdVkxa0kzNDUvbGZuMmxoUVZ0TUxROApoNlVsczc4bHljMGdxalBVSklJWElFN2Y1RklJT0MwYm1ubjZPSk1qV0QzMTBoMURYWFpLaExEd3d5a3ZrdHN1CmJwbEZTWm96TzBIN1ZJa3ZxSmFxUHdRM1JielFzQitBaC90OGNkbmwzdGtqNzJmVWszbVRnZVovRDRybm1vT04KZUhDNCtHd0dBSzhQbDROV1huVUV4bmhYYTEveXdMeU9FV3YvekdBMzZJZXd6MzJQSnJwRklFWEYwZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1877"
+      - "1879"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:33 GMT
+      - Thu, 02 Nov 2023 19:04:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3219,7 +3285,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d05cd68-4da3-4c71-8c12-5cd5f087ad2e
+      - fee6384e-7ac1-4ff4-9b4e-bdfb85073c13
     status: 200 OK
     code: 200
     duration: ""
@@ -3230,19 +3296,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/dcd8003d-d6a9-4e9b-913b-bc7dea46e6a6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/030551cf-3765-4015-8cdd-5387f1c19d34
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:07:30.826419Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"dcd8003d-d6a9-4e9b-913b-bc7dea46e6a6","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-10-20T16:07:30.826419Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-02T19:04:42.717872Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"030551cf-3765-4015-8cdd-5387f1c19d34","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-02T19:04:42.717872Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "291"
+      - "283"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:34 GMT
+      - Thu, 02 Nov 2023 19:04:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3252,7 +3318,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a67634be-5f04-4f9c-b834-fed9fc7998dd
+      - 3d348d86-4911-4526-bb85-24a0964ae261
     status: 200 OK
     code: 200
     duration: ""
@@ -3263,19 +3329,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8910856f-3503-4ea3-9748-545163679069
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:07:18.218885Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":"02:00:00:11:D8:08","private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"ready","updated_at":"2023-10-20T16:07:27.095115Z","zone":"nl-ams-1"}],"id":"8910856f-3503-4ea3-9748-545163679069","ip":{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:07:27.226169Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1962"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:34 GMT
+      - Thu, 02 Nov 2023 19:04:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3285,7 +3351,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbe18c3b-3103-475c-a3e2-254358298d2c
+      - 032c4ada-49d6-4a47-980b-64babb95c679
     status: 200 OK
     code: 200
     duration: ""
@@ -3296,7 +3362,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/dcd8003d-d6a9-4e9b-913b-bc7dea46e6a6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/030551cf-3765-4015-8cdd-5387f1c19d34
     method: DELETE
   response:
     body: ""
@@ -3306,7 +3372,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:34 GMT
+      - Thu, 02 Nov 2023 19:04:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3316,7 +3382,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cffb612c-7283-44df-a039-f7caf74655ff
+      - 865ff78a-e65b-4a36-8fa5-41f0a5e7f6ed
     status: 204 No Content
     code: 204
     duration: ""
@@ -3327,19 +3393,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8910856f-3503-4ea3-9748-545163679069
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:07:18.218885Z","gateway_networks":[{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":"02:00:00:11:D8:08","private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"ready","updated_at":"2023-10-20T16:07:27.095115Z","zone":"nl-ams-1"}],"id":"8910856f-3503-4ea3-9748-545163679069","ip":{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:07:27.226169Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1962"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:34 GMT
+      - Thu, 02 Nov 2023 19:04:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3349,7 +3415,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a685605-09ff-4bf4-8114-62a83bdd4424
+      - f29d6de8-0e9b-4238-936d-66ae6ffcc913
     status: 200 OK
     code: 200
     duration: ""
@@ -3360,19 +3426,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/4feba31d-fdb0-4541-afb8-69e7a4223e5e
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":"02:00:00:11:D8:08","private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"ready","updated_at":"2023-10-20T16:07:27.095115Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "996"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:34 GMT
+      - Thu, 02 Nov 2023 19:04:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3382,7 +3448,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94b1a45c-af49-4ba2-aec8-473abbc62af9
+      - e96401c7-ace4-4c86-9bc1-505fc40efe68
     status: 200 OK
     code: 200
     duration: ""
@@ -3393,19 +3459,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"af46dbda-ba7e-416b-913e-474671c2b4cb","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1507"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:34 GMT
+      - Thu, 02 Nov 2023 19:04:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3415,7 +3481,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74322be8-1a49-4a83-aa35-e5932c7be23f
+      - d4155031-ddaa-4161-8883-fab51d4e0181
     status: 200 OK
     code: 200
     duration: ""
@@ -3426,7 +3492,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/4feba31d-fdb0-4541-afb8-69e7a4223e5e?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -3436,7 +3502,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:34 GMT
+      - Thu, 02 Nov 2023 19:04:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3446,7 +3512,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a785d2d5-c69c-4dbc-8409-ec83ac059802
+      - 871f3f8b-94b3-45c5-8eda-cb613b081390
     status: 204 No Content
     code: 204
     duration: ""
@@ -3457,19 +3523,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/4feba31d-fdb0-4541-afb8-69e7a4223e5e
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-20T16:07:24.976704Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-20T16:07:17.483060Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:17.483060Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","ipam_config":null,"mac_address":"02:00:00:11:D8:08","private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","status":"detaching","updated_at":"2023-10-20T16:07:34.771838Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"detaching","updated_at":"2023-11-02T19:04:46.495890Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1000"
+      - "970"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:34 GMT
+      - Thu, 02 Nov 2023 19:04:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3479,12 +3545,76 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8875697b-6a55-4860-9000-6066530d64f3
+      - bc336bf5-43da-4731-87d8-8423fc4e3051
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"backup_schedule_frequency":null,"backup_schedule_retention":null,"is_backup_schedule_disabled":null,"name":null,"tags":null,"logs_policy":null,"backup_same_region":null,"backup_schedule_start_hour":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1453"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 19:04:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1d126815-83f4-455f-a4d5-0c0c6b3dbf1a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 19:04:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a98e57ce-8ae1-40fc-8a67-565fdc9f7a63
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{}'
     form: {}
     headers:
       Content-Type:
@@ -3492,19 +3622,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"af46dbda-ba7e-416b-913e-474671c2b4cb","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1507"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:34 GMT
+      - Thu, 02 Nov 2023 19:04:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3514,7 +3644,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 338911cc-4641-4fb7-a06c-c88014617b6a
+      - fbe17f8c-88a8-4cd4-bbff-2b3d5d8d352e
     status: 200 OK
     code: 200
     duration: ""
@@ -3525,17 +3655,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3caf3e3f-59f3-4a02-9db0-30fab6472e83
-    method: DELETE
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    method: GET
   response:
-    body: ""
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
+      Content-Length:
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:34 GMT
+      - Thu, 02 Nov 2023 19:04:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3545,7 +3677,38 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c879757-46e4-4ee9-90ec-dd463ac74dca
+      - a29d2cbd-8b48-43bb-966d-dd0778e29af5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/12092b19-c7b9-4e52-b1d4-571b56c675a6
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 19:04:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3d25eb68-41a7-43c6-b70d-b8f97291c939
     status: 204 No Content
     code: 204
     duration: ""
@@ -3556,19 +3719,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"af46dbda-ba7e-416b-913e-474671c2b4cb","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1507"
+      - "1459"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:35 GMT
+      - Thu, 02 Nov 2023 19:04:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3578,7 +3741,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36c30d31-9fa8-4305-b450-cf15ce69b291
+      - cafe6355-3d2a-449a-8d22-ad78cdbf75b8
     status: 200 OK
     code: 200
     duration: ""
@@ -3589,74 +3752,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/af46dbda-ba7e-416b-913e-474671c2b4cb
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:07:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 67f89171-1145-4230-89b9-23d074ee6083
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"af46dbda-ba7e-416b-913e-474671c2b4cb","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"be16cb41-05ed-4e74-9325-436457439dad","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1513"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:07:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9933f7db-b225-4260-8cc6-134571b6aa52
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/4feba31d-fdb0-4541-afb8-69e7a4223e5e
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"4feba31d-fdb0-4541-afb8-69e7a4223e5e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3665,7 +3764,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:39 GMT
+      - Thu, 02 Nov 2023 19:04:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3675,7 +3774,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 412b149b-4bfe-4334-b812-3989dfc66f3b
+      - 6f51bb2a-17fa-4b08-bd4e-6b6a1b77d2fc
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3686,19 +3785,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8910856f-3503-4ea3-9748-545163679069
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:07:18.218885Z","gateway_networks":[],"id":"8910856f-3503-4ea3-9748-545163679069","ip":{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:07:27.226169Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "937"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:39 GMT
+      - Thu, 02 Nov 2023 19:04:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3708,7 +3807,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d420b39-16e6-4611-8a9d-aa2abc1a6f69
+      - 23057c48-2a20-468e-85fa-614dca4b35b7
     status: 200 OK
     code: 200
     duration: ""
@@ -3719,10 +3818,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/a70a910f-43d5-433d-9fba-c7b9a3d30779
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/9a82af0b-34a4-4749-ab14-189473b39511
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"a70a910f-43d5-433d-9fba-c7b9a3d30779","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"9a82af0b-34a4-4749-ab14-189473b39511","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3731,7 +3830,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:40 GMT
+      - Thu, 02 Nov 2023 19:04:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3741,7 +3840,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71e2cfa1-3cc8-4445-bdd2-d321fb3c9f41
+      - f6d5cd25-8ce1-48de-acfa-a6104ba200a3
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3752,19 +3851,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8910856f-3503-4ea3-9748-545163679069
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-20T16:07:18.218885Z","gateway_networks":[],"id":"8910856f-3503-4ea3-9748-545163679069","ip":{"address":"51.15.95.111","created_at":"2023-10-20T16:07:17.951612Z","gateway_id":"8910856f-3503-4ea3-9748-545163679069","id":"5f70de3c-f79a-48cb-9039-fff8e870b535","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"111-95-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-20T16:07:17.951612Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-10-20T16:07:27.226169Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "937"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:40 GMT
+      - Thu, 02 Nov 2023 19:04:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3774,7 +3873,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dcdac691-7dc3-46bd-a1a1-f6a590ffcaa2
+      - 86f54794-abed-44ce-ad5e-474ef37bb6c5
     status: 200 OK
     code: 200
     duration: ""
@@ -3785,7 +3884,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8910856f-3503-4ea3-9748-545163679069?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -3795,7 +3894,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:40 GMT
+      - Thu, 02 Nov 2023 19:04:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3805,7 +3904,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08bfe939-7229-4a99-b960-bc9ddfda11fc
+      - 7a18e950-0e66-4b99-adcd-f27925157a8d
     status: 204 No Content
     code: 204
     duration: ""
@@ -3816,10 +3915,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8910856f-3503-4ea3-9748-545163679069
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"8910856f-3503-4ea3-9748-545163679069","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3828,7 +3927,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:40 GMT
+      - Thu, 02 Nov 2023 19:04:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3838,7 +3937,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a0326ce-1de1-45d9-9427-60d95915e139
+      - 3b0aebf5-b4d5-4cd7-b7ba-963f3998ac26
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3849,7 +3948,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/5f70de3c-f79a-48cb-9039-fff8e870b535
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/a85bcd79-4ee5-4871-b63e-1abd0fae407c
     method: DELETE
   response:
     body: ""
@@ -3859,7 +3958,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:40 GMT
+      - Thu, 02 Nov 2023 19:04:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3869,7 +3968,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19d780de-08c8-46fe-bf2e-37687b2caa6b
+      - da68a5b0-7b5f-4b35-9bbe-d8d69ef417ec
     status: 204 No Content
     code: 204
     duration: ""
@@ -3880,19 +3979,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1279"
+      - "1232"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:08:05 GMT
+      - Thu, 02 Nov 2023 19:05:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3902,7 +4001,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd5d0126-f810-4802-a020-a97e8067c282
+      - 8e1fd8f9-bd09-4e48-834b-5c33826f261f
     status: 200 OK
     code: 200
     duration: ""
@@ -3913,19 +4012,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1279"
+      - "1232"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:08:05 GMT
+      - Thu, 02 Nov 2023 19:05:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3935,7 +4034,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 892f7b81-f35b-4233-843c-cc218b295db7
+      - 9a123d7d-3ce9-4dda-8ea1-d4898252111e
     status: 200 OK
     code: 200
     duration: ""
@@ -3946,19 +4045,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0akNDQXA2Z0F3SUJBZ0lVYVMxN3JIbWJUMk9JWVkvbHQ3d0Y4d2dEaGVFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXdNakF4TmpBME1UTmFGdzB6TXpFd01UY3hOakEwTVROYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURBa2tuQ3JwZEVyamtySDl2UlZIUC91bmRwYSttVVNEZmRqS0R3VWZXNTB2QmZaQmFRdTdnSnE5Nk8KcjcvVGRLcTNsTEFRL0tkSi9VUldPaFkzV0tMR0VDUkwwcTZ6M1p2YjVtSHhUZEdKNEV3Wk55cGpBdCs2ZGpORAp4OGJDN0FMTWpmVDdkeHRmeVM4ZXMvZk1xaURjRTJtcy9sc2x4MG9RS1FrV2YvTGxUWGRCaGNpejE5cGVWT1hiCk0xanRncmR1b0V4cFBMOGNuZ1pPZ2VmRXFER21rU2gxOHJOWjdyMXI0c0d2MUVvKzNVRTNhMkdNTE1mVXFvc24KYWpWN2VPaFpEaUNMdFUwSWozQitpbVVVYlVqWU0wYUVNRHJCcnd1eFBieUNEVTY0MWE3UWlUZHVjZXFXajlCMgpQQklnRVE2djFSTjM1VmlYK2tJcnFkcWZyMHZOQWdNQkFBR2plakI0TUhZR0ExVWRFUVJ2TUcyQ0RERTVNaTR4Ck5qZ3VNUzQwTW9JTk5URXVNVFU0TGpFeU9TNHlOb0k4Y25jdE1HRTVaR1UwWW1RdFlXUTFOeTAwTW1ReExUazAKTVRjdFlXVXpOVFJrTmpNeU5tRmlMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekR5TU9od1RBcUFFcQpod1F6bm9FYU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQkxKS21SeXloME1oZkh5WG5BR051cnNHMjB0c29VCkxBNzJVY2dRRVJwb3BVdElEa1ZLZE4vcVFmMkVmcnZzQmhUSVU3NEcrZDNDem95YzBZN29Wa0VGOW5tcWFmZ0IKM0crM0NtN0t0MVJpaTVHRktaMTFnUHFqT2ZNK0VqQUlYb0hPVk9xayszVW5rZm14MkpLNnFKMldhUUhwMjlRNQp0bGtndmFoejduUEw0R3p0TERURFRtWlpuUXNKS3pkSUQyK0huZEJBaWtCcHVLdE5Od3hJS1VmVXdDc0p3RHFJCk9kL1J3Q1pYRjBlYnNEazNaYzlPaXhGNEx2SG1NaDZRQjZmUzdaZ0pLRXNnRU1GdGlpVXZJUmVIRGJ4RlRUMVgKdFRQbjBFT21XUTVzMi9aZ0ZrNnZCQnU5RmkraUhwMk9ad2hCd1JXTWFTSDdrR3A1Y1dlK0QzTXYKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVTjJad2xMZWlGQ25MT1VXejJDNEZVYXFmazlvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNREl4T1RBeE1qRmFGdzB6TXpFd016QXhPVEF4TWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ3RVBzS3RSOElEMFJWbXJYSjNoVWh6S0kva0JpajJIWnRIZGFya2dWclJ2SytEei9vTkVrK25DV1gKdUhwK3ZwdGtQY25LWTlPekpnaXBIc0xZQ21mdmFZellOeFJnZWZ6Y3lwSDZzaVZPM3BZSklpWWtCcFRGZ3Z0OQpOeWQ4YlJvSXgxR0tBdUtiOVFvcUJ5eGZTZmNEdzBUZUFCUFZMR1JRMnB0OVJaV0lJSEtJdVFUdHJwVWhaczB3CkZBclFYZnQ5TnVmMDVwdFpGWEJ1TVpNb0s5NzlJQktJdkRyejgvZHJabVJZSC9ZemF6NVQxZUhxUGhMZjJIRkoKN3VVZ0VVc2NxMStCdjVMV2JBMlR6ZERCQXppaVk4VktwUXVNamZCeHlJOWxSZ2lnQ213T2tTbnNDOW1Dazk0aQo5UkVBS0pReFV5bllKUjRRNks5QWMwaWZBaDl4QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1DNHlNREtDUEhKM0xURmlNelpsWldRMExUQmlPV1l0TkRSbE1TMDUKT1RRM0xUaGtZelF4TldFNFpqTmpNeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OVdqSWNFd0tnQgpLb2NFTTU2Q3lqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF5M29OOENveWJGWXRFdHcwOW9ZZXIxMzFMU2ZYCnkvQ1MzaEV2MFZEZWVZaDZBMUgzcFAxSXJoRzR4bVdjcDV0VE41d0o1bGdJODRzR3M1REJURG9USHE3bXFJU3AKb2lXM3N5bEp1T1NGVHAwekJBVFM1aEJaZ3FWTS9PalN0eHZQK1hpVkxSdVkxa0kzNDUvbGZuMmxoUVZ0TUxROApoNlVsczc4bHljMGdxalBVSklJWElFN2Y1RklJT0MwYm1ubjZPSk1qV0QzMTBoMURYWFpLaExEd3d5a3ZrdHN1CmJwbEZTWm96TzBIN1ZJa3ZxSmFxUHdRM1JielFzQitBaC90OGNkbmwzdGtqNzJmVWszbVRnZVovRDRybm1vT04KZUhDNCtHd0dBSzhQbDROV1huVUV4bmhYYTEveXdMeU9FV3YvekdBMzZJZXd6MzJQSnJwRklFWEYwZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1877"
+      - "1879"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:08:05 GMT
+      - Thu, 02 Nov 2023 19:05:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3968,7 +4067,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f010393-4cb2-46b4-9436-1ed98f80986d
+      - 4c7ee21f-19b4-4b41-b12e-fca6dee74d7a
     status: 200 OK
     code: 200
     duration: ""
@@ -3979,19 +4078,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/be16cb41-05ed-4e74-9325-436457439dad
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8c96124f-20c2-42fa-a66f-60a0387ec4c9
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:06:10.887036Z","dhcp_enabled":true,"id":"be16cb41-05ed-4e74-9325-436457439dad","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-20T16:06:10.887036Z","id":"9f60edb6-d33d-43c6-aa30-cf77ef9c8968","subnet":"192.168.1.0/24","updated_at":"2023-10-20T16:07:24.061078Z"},{"created_at":"2023-10-20T16:06:10.887036Z","id":"bf153124-eb1a-4b08-83d3-c2fa08120f0a","subnet":"fd68:d440:21c4:e4d4::/64","updated_at":"2023-10-20T16:07:24.066188Z"}],"tags":[],"updated_at":"2023-10-20T16:07:34.966069Z","vpc_id":"8cd44b5b-c882-4098-93ac-0261cc6d1548"}'
+    body: '{"created_at":"2023-11-02T19:03:17.580618Z","dhcp_enabled":true,"id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:03:17.580618Z","id":"5fac6309-5b9e-410a-99b1-d941ca004f0c","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:30.346920Z"},{"created_at":"2023-11-02T19:03:17.580618Z","id":"bc28f882-eca4-4c8f-abe0-df520e71f3a7","subnet":"fd68:d440:21c4:65b5::/64","updated_at":"2023-11-02T19:04:30.349838Z"}],"tags":[],"updated_at":"2023-11-02T19:04:46.677701Z","vpc_id":"f24e24ff-e35b-4e4c-8e20-22beb977d3ef"}'
     headers:
       Content-Length:
-      - "719"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:08:06 GMT
+      - Thu, 02 Nov 2023 19:05:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4001,7 +4100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a153328-6a74-4522-a020-6b969f8bdcf1
+      - 8c47f419-3aed-45af-8ce1-f0b0d8b3b448
     status: 200 OK
     code: 200
     duration: ""
@@ -4012,19 +4111,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1279"
+      - "1232"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:08:06 GMT
+      - Thu, 02 Nov 2023 19:05:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4034,7 +4133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b1356fa-415f-4965-a650-abd40fc81c27
+      - 2fcd03b3-30c9-4beb-bddb-a274077ef815
     status: 200 OK
     code: 200
     duration: ""
@@ -4045,19 +4144,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0akNDQXA2Z0F3SUJBZ0lVYVMxN3JIbWJUMk9JWVkvbHQ3d0Y4d2dEaGVFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXdNakF4TmpBME1UTmFGdzB6TXpFd01UY3hOakEwTVROYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURBa2tuQ3JwZEVyamtySDl2UlZIUC91bmRwYSttVVNEZmRqS0R3VWZXNTB2QmZaQmFRdTdnSnE5Nk8KcjcvVGRLcTNsTEFRL0tkSi9VUldPaFkzV0tMR0VDUkwwcTZ6M1p2YjVtSHhUZEdKNEV3Wk55cGpBdCs2ZGpORAp4OGJDN0FMTWpmVDdkeHRmeVM4ZXMvZk1xaURjRTJtcy9sc2x4MG9RS1FrV2YvTGxUWGRCaGNpejE5cGVWT1hiCk0xanRncmR1b0V4cFBMOGNuZ1pPZ2VmRXFER21rU2gxOHJOWjdyMXI0c0d2MUVvKzNVRTNhMkdNTE1mVXFvc24KYWpWN2VPaFpEaUNMdFUwSWozQitpbVVVYlVqWU0wYUVNRHJCcnd1eFBieUNEVTY0MWE3UWlUZHVjZXFXajlCMgpQQklnRVE2djFSTjM1VmlYK2tJcnFkcWZyMHZOQWdNQkFBR2plakI0TUhZR0ExVWRFUVJ2TUcyQ0RERTVNaTR4Ck5qZ3VNUzQwTW9JTk5URXVNVFU0TGpFeU9TNHlOb0k4Y25jdE1HRTVaR1UwWW1RdFlXUTFOeTAwTW1ReExUazAKTVRjdFlXVXpOVFJrTmpNeU5tRmlMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekR5TU9od1RBcUFFcQpod1F6bm9FYU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQkxKS21SeXloME1oZkh5WG5BR051cnNHMjB0c29VCkxBNzJVY2dRRVJwb3BVdElEa1ZLZE4vcVFmMkVmcnZzQmhUSVU3NEcrZDNDem95YzBZN29Wa0VGOW5tcWFmZ0IKM0crM0NtN0t0MVJpaTVHRktaMTFnUHFqT2ZNK0VqQUlYb0hPVk9xayszVW5rZm14MkpLNnFKMldhUUhwMjlRNQp0bGtndmFoejduUEw0R3p0TERURFRtWlpuUXNKS3pkSUQyK0huZEJBaWtCcHVLdE5Od3hJS1VmVXdDc0p3RHFJCk9kL1J3Q1pYRjBlYnNEazNaYzlPaXhGNEx2SG1NaDZRQjZmUzdaZ0pLRXNnRU1GdGlpVXZJUmVIRGJ4RlRUMVgKdFRQbjBFT21XUTVzMi9aZ0ZrNnZCQnU5RmkraUhwMk9ad2hCd1JXTWFTSDdrR3A1Y1dlK0QzTXYKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVTjJad2xMZWlGQ25MT1VXejJDNEZVYXFmazlvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNREl4T1RBeE1qRmFGdzB6TXpFd016QXhPVEF4TWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ3RVBzS3RSOElEMFJWbXJYSjNoVWh6S0kva0JpajJIWnRIZGFya2dWclJ2SytEei9vTkVrK25DV1gKdUhwK3ZwdGtQY25LWTlPekpnaXBIc0xZQ21mdmFZellOeFJnZWZ6Y3lwSDZzaVZPM3BZSklpWWtCcFRGZ3Z0OQpOeWQ4YlJvSXgxR0tBdUtiOVFvcUJ5eGZTZmNEdzBUZUFCUFZMR1JRMnB0OVJaV0lJSEtJdVFUdHJwVWhaczB3CkZBclFYZnQ5TnVmMDVwdFpGWEJ1TVpNb0s5NzlJQktJdkRyejgvZHJabVJZSC9ZemF6NVQxZUhxUGhMZjJIRkoKN3VVZ0VVc2NxMStCdjVMV2JBMlR6ZERCQXppaVk4VktwUXVNamZCeHlJOWxSZ2lnQ213T2tTbnNDOW1Dazk0aQo5UkVBS0pReFV5bllKUjRRNks5QWMwaWZBaDl4QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1DNHlNREtDUEhKM0xURmlNelpsWldRMExUQmlPV1l0TkRSbE1TMDUKT1RRM0xUaGtZelF4TldFNFpqTmpNeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OVdqSWNFd0tnQgpLb2NFTTU2Q3lqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF5M29OOENveWJGWXRFdHcwOW9ZZXIxMzFMU2ZYCnkvQ1MzaEV2MFZEZWVZaDZBMUgzcFAxSXJoRzR4bVdjcDV0VE41d0o1bGdJODRzR3M1REJURG9USHE3bXFJU3AKb2lXM3N5bEp1T1NGVHAwekJBVFM1aEJaZ3FWTS9PalN0eHZQK1hpVkxSdVkxa0kzNDUvbGZuMmxoUVZ0TUxROApoNlVsczc4bHljMGdxalBVSklJWElFN2Y1RklJT0MwYm1ubjZPSk1qV0QzMTBoMURYWFpLaExEd3d5a3ZrdHN1CmJwbEZTWm96TzBIN1ZJa3ZxSmFxUHdRM1JielFzQitBaC90OGNkbmwzdGtqNzJmVWszbVRnZVovRDRybm1vT04KZUhDNCtHd0dBSzhQbDROV1huVUV4bmhYYTEveXdMeU9FV3YvekdBMzZJZXd6MzJQSnJwRklFWEYwZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1877"
+      - "1879"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:08:06 GMT
+      - Thu, 02 Nov 2023 19:05:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4067,7 +4166,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10c20ed7-0dfa-492b-a980-7cf24cfacd08
+      - f8bde147-c958-4d28-a7df-b9c557307ec9
     status: 200 OK
     code: 200
     duration: ""
@@ -4078,19 +4177,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1279"
+      - "1232"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:08:06 GMT
+      - Thu, 02 Nov 2023 19:05:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4100,7 +4199,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 409ed9c3-e988-4d86-84b0-b78b0ef599df
+      - b3005a59-3c6a-49d4-b885-cdb80addc1d8
     status: 200 OK
     code: 200
     duration: ""
@@ -4111,7 +4210,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/be16cb41-05ed-4e74-9325-436457439dad
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8c96124f-20c2-42fa-a66f-60a0387ec4c9
     method: DELETE
   response:
     body: ""
@@ -4121,7 +4220,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:08:07 GMT
+      - Thu, 02 Nov 2023 19:05:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4131,7 +4230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 106fc468-3e5e-4178-8378-e78777ef457a
+      - b77b80cc-a9ba-4713-a837-ab9a400f9163
     status: 204 No Content
     code: 204
     duration: ""
@@ -4142,19 +4241,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1282"
+      - "1235"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:08:07 GMT
+      - Thu, 02 Nov 2023 19:05:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4164,7 +4263,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1ab25ab-a15d-4a2e-9e8a-d66202f1cd2c
+      - 79587adf-76df-4119-833f-3aa6f72378a2
     status: 200 OK
     code: 200
     duration: ""
@@ -4175,19 +4274,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:03:06.398762Z","endpoint":{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774},"endpoints":[{"id":"388425fa-c7b1-48a6-83ee-fa3216261069","ip":"51.158.129.26","load_balancer":{},"name":null,"port":19774}],"engine":"PostgreSQL-15","id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1282"
+      - "1235"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:08:09 GMT
+      - Thu, 02 Nov 2023 19:05:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4197,7 +4296,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18caedb9-d78f-4519-a099-b0ae01820a30
+      - 4bccb242-0577-45c6-8e68-bc31243d6531
     status: 200 OK
     code: 200
     duration: ""
@@ -4208,10 +4307,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -4220,7 +4319,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:08:39 GMT
+      - Thu, 02 Nov 2023 19:05:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4230,7 +4329,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 638b4276-8fed-4af7-a540-71610d23bb5d
+      - 15a35d07-9681-4c92-a56f-33b17d99cadb
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4241,10 +4340,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0a9de4bd-ad57-42d1-9417-ae354d6326ab
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"0a9de4bd-ad57-42d1-9417-ae354d6326ab","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -4253,7 +4352,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:08:39 GMT
+      - Thu, 02 Nov 2023 19:05:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4263,7 +4362,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3df869f-046a-4aab-8d2a-40e4c8402c53
+      - 58e2531e-efb8-45d7-9260-8f80dd03fb11
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-settings.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-settings.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:05 GMT
+      - Thu, 02 Nov 2023 18:46:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 028c2b1e-7c53-431b-ba7a-11bdf302f873
+      - f99d100a-ac02-4232-ad44-202e4f1e672f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.229742Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1f6fbc49-973f-4246-b5a3-79890df2e0a9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "725"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:10 GMT
+      - Thu, 02 Nov 2023 18:46:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9d329d2-ce99-4459-bc48-dc0d057f0c85
+      - 75e063ee-e5e5-45ed-b2d9-1f2e17de135a
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1f6fbc49-973f-4246-b5a3-79890df2e0a9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.229742Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1f6fbc49-973f-4246-b5a3-79890df2e0a9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "725"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:10 GMT
+      - Thu, 02 Nov 2023 18:46:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4c69994-e119-4711-a74a-acffe022fb78
+      - 9dbcaba0-59f3-40f8-bfbf-a489cd55fc2c
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1f6fbc49-973f-4246-b5a3-79890df2e0a9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.229742Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1f6fbc49-973f-4246-b5a3-79890df2e0a9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "725"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:40 GMT
+      - Thu, 02 Nov 2023 18:47:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87bd257c-1bf8-4be3-b644-22e779302c59
+      - 5012c664-0808-4cae-a6f9-4e43535ae2f7
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1f6fbc49-973f-4246-b5a3-79890df2e0a9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.229742Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1f6fbc49-973f-4246-b5a3-79890df2e0a9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "725"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:52:10 GMT
+      - Thu, 02 Nov 2023 18:47:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5df5243-b572-4989-8a21-171c7fc50022
+      - 26c02aa8-3b9b-4053-94dd-0659a05a7075
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1f6fbc49-973f-4246-b5a3-79890df2e0a9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.229742Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1f6fbc49-973f-4246-b5a3-79890df2e0a9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "725"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:52:41 GMT
+      - Thu, 02 Nov 2023 18:48:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44f92f5c-6b43-4130-b63a-8c2460abd26b
+      - 2ec3c935-fc90-4cb2-a944-c5890709da48
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1f6fbc49-973f-4246-b5a3-79890df2e0a9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.229742Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1f6fbc49-973f-4246-b5a3-79890df2e0a9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "725"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:53:11 GMT
+      - Thu, 02 Nov 2023 18:48:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c39c22f5-213d-4966-896b-ee77ccb53691
+      - 9188c0d0-0758-4741-8011-e636410f07b2
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1f6fbc49-973f-4246-b5a3-79890df2e0a9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.229742Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1f6fbc49-973f-4246-b5a3-79890df2e0a9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "725"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:53:41 GMT
+      - Thu, 02 Nov 2023 18:49:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7cbe4140-2c02-4fbe-828f-294110ca00fe
+      - 3c1ed8f4-c34f-4313-a383-a78864a29cdb
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1f6fbc49-973f-4246-b5a3-79890df2e0a9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.229742Z","endpoint":{"id":"ed2b0acc-b225-4a5a-9df6-56e4b53ffa89","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19429},"endpoints":[{"id":"ed2b0acc-b225-4a5a-9df6-56e4b53ffa89","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19429}],"engine":"PostgreSQL-15","id":"1f6fbc49-973f-4246-b5a3-79890df2e0a9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1213"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,12 +594,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78435f9f-0664-4cfd-a801-00f9dcd58d1a
+      - f72aa5c6-057d-461d-8472-b61430e83ddf
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"settings":[{"name":"work_mem","value":"4"},{"name":"effective_cache_size","value":"1300"},{"name":"max_connections","value":"200"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"}]}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974},"endpoints":[{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974}],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1171"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:50:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e5b22eba-5eef-4dbe-b34d-92cbeb862dd2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"settings":[{"name":"max_connections","value":"200"},{"name":"effective_cache_size","value":"1300"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"max_parallel_workers","value":"2"},{"name":"work_mem","value":"4"},{"name":"maintenance_work_mem","value":"150"}]}'
     form: {}
     headers:
       Content-Type:
@@ -607,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1f6fbc49-973f-4246-b5a3-79890df2e0a9/settings
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e/settings
     method: PUT
   response:
-    body: '{"settings":[{"name":"work_mem","value":"4"},{"name":"effective_cache_size","value":"1300"},{"name":"max_connections","value":"200"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"}]}'
+    body: '{"settings":[{"name":"max_connections","value":"200"},{"name":"effective_cache_size","value":"1300"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"max_parallel_workers","value":"2"},{"name":"work_mem","value":"4"},{"name":"maintenance_work_mem","value":"150"}]}'
     headers:
       Content-Length:
-      - "290"
+      - "279"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:50:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f194b456-b93f-432e-8d7b-fa0ece80e2e7
+      - 7a130894-a996-41bd-81c5-6b70b5b05817
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1f6fbc49-973f-4246-b5a3-79890df2e0a9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.229742Z","endpoint":{"id":"ed2b0acc-b225-4a5a-9df6-56e4b53ffa89","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19429},"endpoints":[{"id":"ed2b0acc-b225-4a5a-9df6-56e4b53ffa89","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19429}],"engine":"PostgreSQL-15","id":"1f6fbc49-973f-4246-b5a3-79890df2e0a9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974},"endpoints":[{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974}],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1219"
+      - "1177"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:50:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b89bad46-33d8-4cf1-a5dd-128301f3273f
+      - 0def05ad-f43e-4a40-892d-74b941ed41e2
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1f6fbc49-973f-4246-b5a3-79890df2e0a9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.229742Z","endpoint":{"id":"ed2b0acc-b225-4a5a-9df6-56e4b53ffa89","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19429},"endpoints":[{"id":"ed2b0acc-b225-4a5a-9df6-56e4b53ffa89","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19429}],"engine":"PostgreSQL-15","id":"1f6fbc49-973f-4246-b5a3-79890df2e0a9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974},"endpoints":[{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974}],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1219"
+      - "1177"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:42 GMT
+      - Thu, 02 Nov 2023 18:50:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a745c07-b098-4519-8ee2-2691b55a0a7b
+      - 1dd23861-0499-4aa9-808e-fe83b42e3e4d
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1f6fbc49-973f-4246-b5a3-79890df2e0a9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.229742Z","endpoint":{"id":"ed2b0acc-b225-4a5a-9df6-56e4b53ffa89","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19429},"endpoints":[{"id":"ed2b0acc-b225-4a5a-9df6-56e4b53ffa89","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19429}],"engine":"PostgreSQL-15","id":"1f6fbc49-973f-4246-b5a3-79890df2e0a9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974},"endpoints":[{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974}],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1213"
+      - "1171"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:12 GMT
+      - Thu, 02 Nov 2023 18:51:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44107b61-b866-43f1-9d2b-40ac4939aa38
+      - 23245b39-7676-4712-b82a-ef73868427df
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1f6fbc49-973f-4246-b5a3-79890df2e0a9/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVRmJFYzNUSmh3emJxbW9CQzVCMnpqTkJHdHp3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU4xb1hEVE16TVRBeE56RTFOVEUxTjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUE3c2EwclByd3N0OUhtbmZDNDdtc2pTbzI4bVVGTlp6N2hsZnkxVkJuUWUzRVRrS29MNzdaNXFZcTY5NDEKclRveE1tZ3R0WWlaUCtXNmZ0Q3hBQnFBYUNyS1pXTUJFTVcxSjhaTE10ZSs5bkFRRUtNUGQ5UngvNUUydGdDZgpKTXBjd1VpNzBMclNMbzlFNjh2SDQ1SzVoSFlraHc1RGs3ZXZwUCtObE5Nc2dmbG12WEZGeFMzL2FZaE5ZdER1CnpQZllISVhxSXJqUUhDM1ZoaGZoQjE5Z1N5UVBCLzJPQzJwNWZFbEpYM0RYNDBhRFg4ZUcvclJjeDMwU1NVc04KMElLNkpNc0U0WFZ4N3krbG9Wdy9mdjdpRjc5NUpBaDhjQ09uUjVpMlhpZVh2SlhEclFxaWRMYzZSYi9hNTQ4WQpjNFdmM0F1blh2RkdiL2Z1WC8vMnV2bjREd0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdE1XWTJabUpqTkRrdE9UY3paaTAwTWpRMkxXSTFZVE10TnprNE9UQmtaakpsTUdFNUxuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJMdXhod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUNiM2w0Q1B4SXY2VnhEajZUWW96WWxidTIyK3ZDN2FMUXY2RE5xb0xjR2JHam5oamdJTGJCMWJJWElNRi81ClNETU15MGJvaGJoazFoUGVlMm4zYUd0OGJTcUxXekVJcUpjUDk5ZEJTUkkxVTd1NHh2SEhUV1phV0JIUmFrU1oKam9uQyt1Tk91NHVrSzZLVDA5NVBRNU9nSC9Kb2FNUXhpMHErVFlZN1FiU0ZJNWliOEVnUk9yeU9TdVRSTWNMNQowNERkcTQvYUVpOVBXRGttbmt3aSszaHMyN0tGN3FuYmFQRDUwcE9BNDhBSW9zdCtVdEdCTnZ1czhlMFlwdFRWCnZqVnBNTXRjV25zYjRCMVU4TTNIOE5DMXJNaU1xNGxPMDNDWjJ5TlcvbDNhcVd6eENCRFVVazJwQkM2YldaK00Ka0t2dDF0YStwdVJCbjVQRG00Q2E5ZHhKCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVVmVDcDJabDM4Q0trWElZVGhZWW9JaFFXdHhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXdXaGNOTXpNeE1ETXdNVGcwTnpJd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtHaHhoUkRYdThYRXg2MjhDam90WFczOEs5NVFzT2VxM2pNZHZLVmxKVkl4TWNuQXZxeGhibloKd3d0cllJS1hrOXF3ZGJWK1dCQzhLbG52OWlMM0RNV0pibk1zd04wazBDaVZlaythazMrcnFiWHZHWllJTnVnWAo4NTNzWFhjNThSbU1CcTR4NzhqSWRhOHNyOE1FdE9MOUFqZ3VMUkhKRjhtLzhLQzdBQjJtYmxESFo4U0tXZ0xhCkkxRDMrKzZwaGVJUWlNaHMxYVBKbVEveXdWaWRpL0lHbGtGKzMyamlnVGZrWElScnVuZ3FXMC94ZmJUcnhWQWMKUHhTaUFJVHJTQzVsYjRzaU1GUGVHRlVvcitPcmRiQU41ZTY1S2lScUdhL2hNYXNvYW9hajdYK1M0aTY3Mi9DOAppdEdNMDF1Q2hTTEF2MlVyZndNa0FvMFJEY3l3VURjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0T1RKbE9XUmpZbVl0TlRGbU1TMDBOVGsxTFdFM01HSXRZVFl6TVRWbVkyUXgKTnpabExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDROWWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQTV6a0xXc1hsaGVGcUx4U3NxQWlqVzVaZHk3OENGNFZmVzFCalFpYTNncXppOHVTSWo2cDNkCkc0TUlkVE1jMWd2Qkhic29TZ3Nid2pjVVgzRGNHZGNOb2gxOFZyaGx5TUFrYVVDbVl3Nm1vZjVpaTU4WjNFM0sKeHgxeHdPazBaWUtzWU9DbDJyZ3ViZVVTSlVNZjV1ckMrQzJYcmhqeHJ3eERjTkdmSnZKbC9hbXVxMzJxZ3RYVgpsMkowMFA0Qjc0dzNJdFpab1dyNW1DZTJGb1JoUzZVbktxMTB6TDlRcVBQV1hjcEk5UHp5bi9Nb1gzb2dwS3RhCkxiMVpDejM0d0pCNTZKNm80TGE0cmRpZkoyaGJwWlBmWS9yMGdJcTQ2STc4UlZla3RWMXJVZFBYa1FZSDZqOTgKenhsbGdsY3RhV0JqbDEwbGNaU0pPK0NnWkRUV3ZBQXEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:13 GMT
+      - Thu, 02 Nov 2023 18:51:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c450092c-459e-4877-94cc-d81dbdb80969
+      - 0a237ebe-4e3f-41e3-8314-db9acd5fca68
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1f6fbc49-973f-4246-b5a3-79890df2e0a9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.229742Z","endpoint":{"id":"ed2b0acc-b225-4a5a-9df6-56e4b53ffa89","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19429},"endpoints":[{"id":"ed2b0acc-b225-4a5a-9df6-56e4b53ffa89","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19429}],"engine":"PostgreSQL-15","id":"1f6fbc49-973f-4246-b5a3-79890df2e0a9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974},"endpoints":[{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974}],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1213"
+      - "1171"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:13 GMT
+      - Thu, 02 Nov 2023 18:51:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7af44aa4-28bf-4766-b69a-d36b0ea799d0
+      - 6829876f-38c5-40c4-9271-5e9016235a5b
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1f6fbc49-973f-4246-b5a3-79890df2e0a9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.229742Z","endpoint":{"id":"ed2b0acc-b225-4a5a-9df6-56e4b53ffa89","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19429},"endpoints":[{"id":"ed2b0acc-b225-4a5a-9df6-56e4b53ffa89","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19429}],"engine":"PostgreSQL-15","id":"1f6fbc49-973f-4246-b5a3-79890df2e0a9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974},"endpoints":[{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974}],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1213"
+      - "1171"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:14 GMT
+      - Thu, 02 Nov 2023 18:51:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d575aa43-4ab9-45b2-be95-722562d87515
+      - c61cd52f-e31c-455b-ba05-ce12443a1f62
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1f6fbc49-973f-4246-b5a3-79890df2e0a9/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURuakNDQW9hZ0F3SUJBZ0lVRmJFYzNUSmh3emJxbW9CQzVCMnpqTkJHdHp3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEl6Ck1UQXlNREUxTlRFMU4xb1hEVE16TVRBeE56RTFOVEUxTjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUE3c2EwclByd3N0OUhtbmZDNDdtc2pTbzI4bVVGTlp6N2hsZnkxVkJuUWUzRVRrS29MNzdaNXFZcTY5NDEKclRveE1tZ3R0WWlaUCtXNmZ0Q3hBQnFBYUNyS1pXTUJFTVcxSjhaTE10ZSs5bkFRRUtNUGQ5UngvNUUydGdDZgpKTXBjd1VpNzBMclNMbzlFNjh2SDQ1SzVoSFlraHc1RGs3ZXZwUCtObE5Nc2dmbG12WEZGeFMzL2FZaE5ZdER1CnpQZllISVhxSXJqUUhDM1ZoaGZoQjE5Z1N5UVBCLzJPQzJwNWZFbEpYM0RYNDBhRFg4ZUcvclJjeDMwU1NVc04KMElLNkpNc0U0WFZ4N3krbG9Wdy9mdjdpRjc5NUpBaDhjQ09uUjVpMlhpZVh2SlhEclFxaWRMYzZSYi9hNTQ4WQpjNFdmM0F1blh2RkdiL2Z1WC8vMnV2bjREd0lEQVFBQm8yUXdZakJnQmdOVkhSRUVXVEJYZ2dzMU1TNHhOVGt1Ck9TNDRPSUk4Y25jdE1XWTJabUpqTkRrdE9UY3paaTAwTWpRMkxXSTFZVE10TnprNE9UQmtaakpsTUdFNUxuSmsKWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJMdXhod1F6bndsWU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQgpBUUNiM2w0Q1B4SXY2VnhEajZUWW96WWxidTIyK3ZDN2FMUXY2RE5xb0xjR2JHam5oamdJTGJCMWJJWElNRi81ClNETU15MGJvaGJoazFoUGVlMm4zYUd0OGJTcUxXekVJcUpjUDk5ZEJTUkkxVTd1NHh2SEhUV1phV0JIUmFrU1oKam9uQyt1Tk91NHVrSzZLVDA5NVBRNU9nSC9Kb2FNUXhpMHErVFlZN1FiU0ZJNWliOEVnUk9yeU9TdVRSTWNMNQowNERkcTQvYUVpOVBXRGttbmt3aSszaHMyN0tGN3FuYmFQRDUwcE9BNDhBSW9zdCtVdEdCTnZ1czhlMFlwdFRWCnZqVnBNTXRjV25zYjRCMVU4TTNIOE5DMXJNaU1xNGxPMDNDWjJ5TlcvbDNhcVd6eENCRFVVazJwQkM2YldaK00Ka0t2dDF0YStwdVJCbjVQRG00Q2E5ZHhKCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVVmVDcDJabDM4Q0trWElZVGhZWW9JaFFXdHhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXdXaGNOTXpNeE1ETXdNVGcwTnpJd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtHaHhoUkRYdThYRXg2MjhDam90WFczOEs5NVFzT2VxM2pNZHZLVmxKVkl4TWNuQXZxeGhibloKd3d0cllJS1hrOXF3ZGJWK1dCQzhLbG52OWlMM0RNV0pibk1zd04wazBDaVZlaythazMrcnFiWHZHWllJTnVnWAo4NTNzWFhjNThSbU1CcTR4NzhqSWRhOHNyOE1FdE9MOUFqZ3VMUkhKRjhtLzhLQzdBQjJtYmxESFo4U0tXZ0xhCkkxRDMrKzZwaGVJUWlNaHMxYVBKbVEveXdWaWRpL0lHbGtGKzMyamlnVGZrWElScnVuZ3FXMC94ZmJUcnhWQWMKUHhTaUFJVHJTQzVsYjRzaU1GUGVHRlVvcitPcmRiQU41ZTY1S2lScUdhL2hNYXNvYW9hajdYK1M0aTY3Mi9DOAppdEdNMDF1Q2hTTEF2MlVyZndNa0FvMFJEY3l3VURjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0T1RKbE9XUmpZbVl0TlRGbU1TMDBOVGsxTFdFM01HSXRZVFl6TVRWbVkyUXgKTnpabExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDROWWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQTV6a0xXc1hsaGVGcUx4U3NxQWlqVzVaZHk3OENGNFZmVzFCalFpYTNncXppOHVTSWo2cDNkCkc0TUlkVE1jMWd2Qkhic29TZ3Nid2pjVVgzRGNHZGNOb2gxOFZyaGx5TUFrYVVDbVl3Nm1vZjVpaTU4WjNFM0sKeHgxeHdPazBaWUtzWU9DbDJyZ3ViZVVTSlVNZjV1ckMrQzJYcmhqeHJ3eERjTkdmSnZKbC9hbXVxMzJxZ3RYVgpsMkowMFA0Qjc0dzNJdFpab1dyNW1DZTJGb1JoUzZVbktxMTB6TDlRcVBQV1hjcEk5UHp5bi9Nb1gzb2dwS3RhCkxiMVpDejM0d0pCNTZKNm80TGE0cmRpZkoyaGJwWlBmWS9yMGdJcTQ2STc4UlZla3RWMXJVZFBYa1FZSDZqOTgKenhsbGdsY3RhV0JqbDEwbGNaU0pPK0NnWkRUV3ZBQXEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1833"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:14 GMT
+      - Thu, 02 Nov 2023 18:51:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e09b7ebf-7fab-4802-ae78-6244fcadf32f
+      - d5442b61-64e8-4cfe-89f6-1c6aacdaca42
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1f6fbc49-973f-4246-b5a3-79890df2e0a9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.229742Z","endpoint":{"id":"ed2b0acc-b225-4a5a-9df6-56e4b53ffa89","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19429},"endpoints":[{"id":"ed2b0acc-b225-4a5a-9df6-56e4b53ffa89","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19429}],"engine":"PostgreSQL-15","id":"1f6fbc49-973f-4246-b5a3-79890df2e0a9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974},"endpoints":[{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974}],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1213"
+      - "1171"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:15 GMT
+      - Thu, 02 Nov 2023 18:51:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83f2d219-1642-4644-9615-3ace811e9a11
+      - 017e182c-bc59-4f99-af03-dc3132ca3820
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1f6fbc49-973f-4246-b5a3-79890df2e0a9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.229742Z","endpoint":{"id":"ed2b0acc-b225-4a5a-9df6-56e4b53ffa89","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19429},"endpoints":[{"id":"ed2b0acc-b225-4a5a-9df6-56e4b53ffa89","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19429}],"engine":"PostgreSQL-15","id":"1f6fbc49-973f-4246-b5a3-79890df2e0a9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974},"endpoints":[{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974}],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1216"
+      - "1174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:15 GMT
+      - Thu, 02 Nov 2023 18:51:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 645e22fe-bd60-447c-a4fb-54c3d9ce86a1
+      - 6305d825-11bb-4a0a-a240-89f9f6dfac2d
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1f6fbc49-973f-4246-b5a3-79890df2e0a9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:51:10.229742Z","endpoint":{"id":"ed2b0acc-b225-4a5a-9df6-56e4b53ffa89","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19429},"endpoints":[{"id":"ed2b0acc-b225-4a5a-9df6-56e4b53ffa89","ip":"51.159.9.88","load_balancer":{},"name":null,"port":19429}],"engine":"PostgreSQL-15","id":"1f6fbc49-973f-4246-b5a3-79890df2e0a9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974},"endpoints":[{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974}],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1216"
+      - "1174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:15 GMT
+      - Thu, 02 Nov 2023 18:51:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5cda8fdf-2b50-4293-a779-8a677f7a9391
+      - 440a6ba6-b8aa-43e5-ad58-d65b74e7dd47
     status: 200 OK
     code: 200
     duration: ""
@@ -970,10 +1003,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1f6fbc49-973f-4246-b5a3-79890df2e0a9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"1f6fbc49-973f-4246-b5a3-79890df2e0a9","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -982,7 +1015,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:49 GMT
+      - Thu, 02 Nov 2023 18:51:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0297e254-55a6-4d64-ad02-a9bd5e435d48
+      - ab4fa0e1-bb9d-4c98-8ac5-9b28a29aed5c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1003,10 +1036,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1f6fbc49-973f-4246-b5a3-79890df2e0a9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"1f6fbc49-973f-4246-b5a3-79890df2e0a9","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1015,7 +1048,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:50 GMT
+      - Thu, 02 Nov 2023 18:51:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78be4c75-9648-406f-a9a5-c7bcab8330dd
+      - 051cc551-793f-4f19-9a58-53edeb025094
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-volume.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-volume.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:07 GMT
+      - Thu, 02 Nov 2023 18:46:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f93e273f-60ed-4d97-9934-3e334fdc198b
+      - 2ebfd0c7-f206-49c2-ae42-a0d8dc738a69
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "776"
+      - "747"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:06 GMT
+      - Thu, 02 Nov 2023 18:56:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 523b4eef-71bc-4cb4-afec-de58738f7a8a
+      - cb10322c-2c1b-4aba-be24-12debcc8a7f8
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "776"
+      - "747"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:06 GMT
+      - Thu, 02 Nov 2023 18:56:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5d22fbd-d0dd-4de2-908b-1597cfdfad18
+      - 412f9733-1871-40ba-9f73-b0ebb21cb8f9
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "776"
+      - "747"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:36 GMT
+      - Thu, 02 Nov 2023 18:56:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dde59b22-2ae0-46cf-8496-3d1fb389599e
+      - bcb10774-7c6c-4da2-94d6-6341c45b935d
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "776"
+      - "747"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:06 GMT
+      - Thu, 02 Nov 2023 18:57:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5136f2c-cda7-4dee-a874-27ec6a88828d
+      - 39eca28e-9a6d-4045-9f63-ded5e65e26b4
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "776"
+      - "747"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:37 GMT
+      - Thu, 02 Nov 2023 18:57:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6a51cfa-adbf-4674-979a-8f8b9ed02fd5
+      - 06053eab-f366-4672-ac87-4da5f8d362d0
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "776"
+      - "747"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:04:07 GMT
+      - Thu, 02 Nov 2023 18:58:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4e1cc1d-a834-4bd5-9e33-c03560d2fbb7
+      - 94fa1739-ce3f-4bc7-bf2e-6be8254972aa
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "776"
+      - "747"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:04:37 GMT
+      - Thu, 02 Nov 2023 18:58:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8fd5348-c890-4ca1-99ad-bf826fc94bbd
+      - b018369c-5f40-42dc-858c-233f737f5011
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:07 GMT
+      - Thu, 02 Nov 2023 18:59:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 698613b2-5f9d-41e6-84f4-e5fe946e212b
+      - 74306923-130c-4d12-8f8e-1bddcc85774b
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUFlBaGlhSXpUUWp3VU4zcHd3Znk4YUV5UmJ3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzR5TVRBdU5EUXdIaGNOCk1qTXhNREl3TVRZd01qUXdXaGNOTXpNeE1ERTNNVFl3TWpRd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqSXhNQzQwTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxRVWtPOHR2SkdEVjkvWElWWXYrNjFsUnpLREhraXVwTCs4MU1UWkQ3K0c3QjNHRGJjZWNuMDMKTWhiWEh1c28xUlhWOE9DZldjWHZjZTlncWhOZW1tYWQ4VElSZUExRlZnTzR2ZkRxZXdQNHNLMk1IR3lhbGZsNwowS1NiUllHeHVXTmpqSVVMS01hVm91d0YreUNLekpnT1VEL201cGVmTDdHMEVKT2dxSFl1K01mS0tEWDdaQ3pWCkJmVWhCWHlQL2hJWTlpelFBa3lRZ2NidUpvdjROSGp2YXdnREVXY0E4b2xGdUpBUXh0ZnkyWDZQMkpRMlFGeEsKVlpIMzdjZHhuUjA1TUljbkExM3ZtSm9PME52b2daU2IyWXFBUlBlc1pRcXc1UnU1aDVVU2JlL2cvNHNJcWVJRAo0dVdpU1oxc1Nwb2xjajVqeUk5a2lRK2pMc1RoSHc4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMakl4TUM0ME5JSThjbmN0TUdRNU5ESTFPVGN0WVRJd055MDBOekJpTFRrNE5qTXROMll6TnprME5HUTEKTm1Ga0xuSmtZaTV1YkMxaGJYTXVjMk4zTG1Oc2IzVmtod1F6RHlkT2h3UXpudElzTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXBXMkZmRFpvcVIveFNMdTE2Q2Faa2RlRnJmVVZBVS9paEViR0Z4aEEvWGdIZzhWMmV3dmxhCnhKdVg0RUNYdWhkMlFqRTkxTTRqdFhKZXpGTWNMMStPbDBZWWIraWJycGt4S2prL01oem9NaS9IWnk0S2N2dloKSnR5QzN2OEVBcU1HN3dNbGZlUzV6QjIzOEFvY2pwUlJja2htMjdyYzJIMWpJN25EYTQ2SGRiK0NaZVR6RjlPWQpaalhXMitHWGRzeElHY3ZoeFQ1UDU2Wmo0djREUHFvK0k5SkZTUU50N1lBR1kvRVJEU3l1TThMMWlUU0pFTG1mCko5OHBhaUszVzhjdWhwZmo0Y1M4TFd4TTBxN1NYVnJ0WVVHNlVuZlRHNkxSTGlta09lRGtCYXl0YW1YNmUrVFAKbEZ5bFRJbWo0bXZwZys1cjdOZmExRTk2NUFTd1ROUFcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVWVlTbTZrcjlrSU5JQXNUUzRXQUdGNSs5VXY4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpBdU1qQXlNQjRYCkRUSXpNVEV3TWpFNE5UWTBNRm9YRFRNek1UQXpNREU0TlRZME1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekF1TWpBeU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXFzV0tPaHpITEo3ZTROMEl5SW9ycHk5WG15OHgrOFdwSU8zL0RLbmx6a000WnQ2V0RzbVgKSWczUktEU1BJNFFPQ3dkQXQ4dzQwaGNNb3RRbE1vdlRmYUlKSGM0YTFiWUIvSlpqck5ldEdSVDdkaFp2bklweQppSmcvUHNDWVg1d2tHQ3V4YmJ3QjExcjYyS2pBaU0vSjBtYktLMFVxOXdGWFZHaVRvbHA1YWxQTDQ2a25yRzlpCk5DSExzMmhxZCtyVnV6UFd0aFVDbzgxSFcvdkRVdUNrME42dGtmZzRndnp0THpPM0E3R3c3V0NPS2JUN0FwUWwKZWIvVndMcHlUS3k5UTUybFk2OVAwck5CNEN6ak5SR0tTVVp6OXorSFRvN1YxdFVZeVFlN1pYNE1Ia3FuWHdsTQpQOTdxMmN5S05TNDRIN1dPckRKRjdmQURHMDdUbVZOQnp3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNd0xqSXdNb0k4Y25jdE5UVmxOVEE0WldVdFl6Sm1PUzAwTVRGbUxXSTFabUV0Wm1RM1pUUTUKWldGa1pqWmhMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRem5xL2lod1F6bm9MS01BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE3cjJ6UWtIejc4c24xY2xxbysxUE5FRFFoRlZ0TEZ6ZVFvbXNiTm9UcHYxV3hiUzhoCmFqMUNxWkZRazNHY2IyclFFWUFaVzR6SVlQK2NhR3dJc3hKNDhpOFM4cHIyUy9tN3hFTW5BQUw5QnVEc2N1eFQKclQxcUNCZ2VSbWhaTFpUU3o4cHJqZEJFTlhaN1FZLzZrdktwUUxmU0grcGxaYXh3OWlhdzZhcmkrbDNjQVRIbQp0VjNjYUM1YzRiMG1WOW5lVW9DZGlHczlPcnVseEtRTE9GbkFKNitiVnZNZTZ5L0E1VzRxQXlHMGRyMno1RHBYCjdHU3o0Rkc5c1JWc21uZVN5bTg2S3dManF0amJDcU5henRyZ0hzTk5PZUJETHFNWnhvRy9HQno0bmo3MFVYMDEKVHRMNm5lZ2FtRUs4cXRtRmk5anplTmtETTlMNEN5VE9lOUFxCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1847"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:07 GMT
+      - Thu, 02 Nov 2023 18:59:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b34cbab-5342-4d7f-90c9-24c7e193405d
+      - a7443468-eecd-4ae8-844f-112ec690c8e1
     status: 200 OK
     code: 200
     duration: ""
@@ -638,19 +638,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:07 GMT
+      - Thu, 02 Nov 2023 18:59:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -660,7 +660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09e925be-c2fd-47b6-8ece-2ddff62940fa
+      - d38ccb68-24eb-4e69-9c3d-4b9f054b005f
     status: 200 OK
     code: 200
     duration: ""
@@ -671,19 +671,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:08 GMT
+      - Thu, 02 Nov 2023 18:59:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -693,7 +693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b389a28-47cc-4f07-ad6b-ba0fd3b190e0
+      - 9631d1d0-f9b4-4f34-8b04-9a46d6019c49
     status: 200 OK
     code: 200
     duration: ""
@@ -704,19 +704,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUFlBaGlhSXpUUWp3VU4zcHd3Znk4YUV5UmJ3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzR5TVRBdU5EUXdIaGNOCk1qTXhNREl3TVRZd01qUXdXaGNOTXpNeE1ERTNNVFl3TWpRd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqSXhNQzQwTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxRVWtPOHR2SkdEVjkvWElWWXYrNjFsUnpLREhraXVwTCs4MU1UWkQ3K0c3QjNHRGJjZWNuMDMKTWhiWEh1c28xUlhWOE9DZldjWHZjZTlncWhOZW1tYWQ4VElSZUExRlZnTzR2ZkRxZXdQNHNLMk1IR3lhbGZsNwowS1NiUllHeHVXTmpqSVVMS01hVm91d0YreUNLekpnT1VEL201cGVmTDdHMEVKT2dxSFl1K01mS0tEWDdaQ3pWCkJmVWhCWHlQL2hJWTlpelFBa3lRZ2NidUpvdjROSGp2YXdnREVXY0E4b2xGdUpBUXh0ZnkyWDZQMkpRMlFGeEsKVlpIMzdjZHhuUjA1TUljbkExM3ZtSm9PME52b2daU2IyWXFBUlBlc1pRcXc1UnU1aDVVU2JlL2cvNHNJcWVJRAo0dVdpU1oxc1Nwb2xjajVqeUk5a2lRK2pMc1RoSHc4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMakl4TUM0ME5JSThjbmN0TUdRNU5ESTFPVGN0WVRJd055MDBOekJpTFRrNE5qTXROMll6TnprME5HUTEKTm1Ga0xuSmtZaTV1YkMxaGJYTXVjMk4zTG1Oc2IzVmtod1F6RHlkT2h3UXpudElzTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXBXMkZmRFpvcVIveFNMdTE2Q2Faa2RlRnJmVVZBVS9paEViR0Z4aEEvWGdIZzhWMmV3dmxhCnhKdVg0RUNYdWhkMlFqRTkxTTRqdFhKZXpGTWNMMStPbDBZWWIraWJycGt4S2prL01oem9NaS9IWnk0S2N2dloKSnR5QzN2OEVBcU1HN3dNbGZlUzV6QjIzOEFvY2pwUlJja2htMjdyYzJIMWpJN25EYTQ2SGRiK0NaZVR6RjlPWQpaalhXMitHWGRzeElHY3ZoeFQ1UDU2Wmo0djREUHFvK0k5SkZTUU50N1lBR1kvRVJEU3l1TThMMWlUU0pFTG1mCko5OHBhaUszVzhjdWhwZmo0Y1M4TFd4TTBxN1NYVnJ0WVVHNlVuZlRHNkxSTGlta09lRGtCYXl0YW1YNmUrVFAKbEZ5bFRJbWo0bXZwZys1cjdOZmExRTk2NUFTd1ROUFcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVWVlTbTZrcjlrSU5JQXNUUzRXQUdGNSs5VXY4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpBdU1qQXlNQjRYCkRUSXpNVEV3TWpFNE5UWTBNRm9YRFRNek1UQXpNREU0TlRZME1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekF1TWpBeU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXFzV0tPaHpITEo3ZTROMEl5SW9ycHk5WG15OHgrOFdwSU8zL0RLbmx6a000WnQ2V0RzbVgKSWczUktEU1BJNFFPQ3dkQXQ4dzQwaGNNb3RRbE1vdlRmYUlKSGM0YTFiWUIvSlpqck5ldEdSVDdkaFp2bklweQppSmcvUHNDWVg1d2tHQ3V4YmJ3QjExcjYyS2pBaU0vSjBtYktLMFVxOXdGWFZHaVRvbHA1YWxQTDQ2a25yRzlpCk5DSExzMmhxZCtyVnV6UFd0aFVDbzgxSFcvdkRVdUNrME42dGtmZzRndnp0THpPM0E3R3c3V0NPS2JUN0FwUWwKZWIvVndMcHlUS3k5UTUybFk2OVAwck5CNEN6ak5SR0tTVVp6OXorSFRvN1YxdFVZeVFlN1pYNE1Ia3FuWHdsTQpQOTdxMmN5S05TNDRIN1dPckRKRjdmQURHMDdUbVZOQnp3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNd0xqSXdNb0k4Y25jdE5UVmxOVEE0WldVdFl6Sm1PUzAwTVRGbUxXSTFabUV0Wm1RM1pUUTUKWldGa1pqWmhMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRem5xL2lod1F6bm9MS01BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE3cjJ6UWtIejc4c24xY2xxbysxUE5FRFFoRlZ0TEZ6ZVFvbXNiTm9UcHYxV3hiUzhoCmFqMUNxWkZRazNHY2IyclFFWUFaVzR6SVlQK2NhR3dJc3hKNDhpOFM4cHIyUy9tN3hFTW5BQUw5QnVEc2N1eFQKclQxcUNCZ2VSbWhaTFpUU3o4cHJqZEJFTlhaN1FZLzZrdktwUUxmU0grcGxaYXh3OWlhdzZhcmkrbDNjQVRIbQp0VjNjYUM1YzRiMG1WOW5lVW9DZGlHczlPcnVseEtRTE9GbkFKNitiVnZNZTZ5L0E1VzRxQXlHMGRyMno1RHBYCjdHU3o0Rkc5c1JWc21uZVN5bTg2S3dManF0amJDcU5henRyZ0hzTk5PZUJETHFNWnhvRy9HQno0bmo3MFVYMDEKVHRMNm5lZ2FtRUs4cXRtRmk5anplTmtETTlMNEN5VE9lOUFxCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1847"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:08 GMT
+      - Thu, 02 Nov 2023 18:59:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -726,7 +726,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5a31394-6186-4358-8154-00ddd7c12f39
+      - 2c1ac239-c328-4388-aaed-19d6bbc8e291
     status: 200 OK
     code: 200
     duration: ""
@@ -737,19 +737,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:08 GMT
+      - Thu, 02 Nov 2023 18:59:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -759,7 +759,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f8aa7af-4b74-4d84-b645-001ebbbdee3c
+      - bb9870f6-bd7d-45f2-99ce-6189d0dced17
     status: 200 OK
     code: 200
     duration: ""
@@ -770,19 +770,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUFlBaGlhSXpUUWp3VU4zcHd3Znk4YUV5UmJ3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzR5TVRBdU5EUXdIaGNOCk1qTXhNREl3TVRZd01qUXdXaGNOTXpNeE1ERTNNVFl3TWpRd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqSXhNQzQwTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxRVWtPOHR2SkdEVjkvWElWWXYrNjFsUnpLREhraXVwTCs4MU1UWkQ3K0c3QjNHRGJjZWNuMDMKTWhiWEh1c28xUlhWOE9DZldjWHZjZTlncWhOZW1tYWQ4VElSZUExRlZnTzR2ZkRxZXdQNHNLMk1IR3lhbGZsNwowS1NiUllHeHVXTmpqSVVMS01hVm91d0YreUNLekpnT1VEL201cGVmTDdHMEVKT2dxSFl1K01mS0tEWDdaQ3pWCkJmVWhCWHlQL2hJWTlpelFBa3lRZ2NidUpvdjROSGp2YXdnREVXY0E4b2xGdUpBUXh0ZnkyWDZQMkpRMlFGeEsKVlpIMzdjZHhuUjA1TUljbkExM3ZtSm9PME52b2daU2IyWXFBUlBlc1pRcXc1UnU1aDVVU2JlL2cvNHNJcWVJRAo0dVdpU1oxc1Nwb2xjajVqeUk5a2lRK2pMc1RoSHc4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMakl4TUM0ME5JSThjbmN0TUdRNU5ESTFPVGN0WVRJd055MDBOekJpTFRrNE5qTXROMll6TnprME5HUTEKTm1Ga0xuSmtZaTV1YkMxaGJYTXVjMk4zTG1Oc2IzVmtod1F6RHlkT2h3UXpudElzTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXBXMkZmRFpvcVIveFNMdTE2Q2Faa2RlRnJmVVZBVS9paEViR0Z4aEEvWGdIZzhWMmV3dmxhCnhKdVg0RUNYdWhkMlFqRTkxTTRqdFhKZXpGTWNMMStPbDBZWWIraWJycGt4S2prL01oem9NaS9IWnk0S2N2dloKSnR5QzN2OEVBcU1HN3dNbGZlUzV6QjIzOEFvY2pwUlJja2htMjdyYzJIMWpJN25EYTQ2SGRiK0NaZVR6RjlPWQpaalhXMitHWGRzeElHY3ZoeFQ1UDU2Wmo0djREUHFvK0k5SkZTUU50N1lBR1kvRVJEU3l1TThMMWlUU0pFTG1mCko5OHBhaUszVzhjdWhwZmo0Y1M4TFd4TTBxN1NYVnJ0WVVHNlVuZlRHNkxSTGlta09lRGtCYXl0YW1YNmUrVFAKbEZ5bFRJbWo0bXZwZys1cjdOZmExRTk2NUFTd1ROUFcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVWVlTbTZrcjlrSU5JQXNUUzRXQUdGNSs5VXY4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpBdU1qQXlNQjRYCkRUSXpNVEV3TWpFNE5UWTBNRm9YRFRNek1UQXpNREU0TlRZME1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekF1TWpBeU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXFzV0tPaHpITEo3ZTROMEl5SW9ycHk5WG15OHgrOFdwSU8zL0RLbmx6a000WnQ2V0RzbVgKSWczUktEU1BJNFFPQ3dkQXQ4dzQwaGNNb3RRbE1vdlRmYUlKSGM0YTFiWUIvSlpqck5ldEdSVDdkaFp2bklweQppSmcvUHNDWVg1d2tHQ3V4YmJ3QjExcjYyS2pBaU0vSjBtYktLMFVxOXdGWFZHaVRvbHA1YWxQTDQ2a25yRzlpCk5DSExzMmhxZCtyVnV6UFd0aFVDbzgxSFcvdkRVdUNrME42dGtmZzRndnp0THpPM0E3R3c3V0NPS2JUN0FwUWwKZWIvVndMcHlUS3k5UTUybFk2OVAwck5CNEN6ak5SR0tTVVp6OXorSFRvN1YxdFVZeVFlN1pYNE1Ia3FuWHdsTQpQOTdxMmN5S05TNDRIN1dPckRKRjdmQURHMDdUbVZOQnp3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNd0xqSXdNb0k4Y25jdE5UVmxOVEE0WldVdFl6Sm1PUzAwTVRGbUxXSTFabUV0Wm1RM1pUUTUKWldGa1pqWmhMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRem5xL2lod1F6bm9MS01BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE3cjJ6UWtIejc4c24xY2xxbysxUE5FRFFoRlZ0TEZ6ZVFvbXNiTm9UcHYxV3hiUzhoCmFqMUNxWkZRazNHY2IyclFFWUFaVzR6SVlQK2NhR3dJc3hKNDhpOFM4cHIyUy9tN3hFTW5BQUw5QnVEc2N1eFQKclQxcUNCZ2VSbWhaTFpUU3o4cHJqZEJFTlhaN1FZLzZrdktwUUxmU0grcGxaYXh3OWlhdzZhcmkrbDNjQVRIbQp0VjNjYUM1YzRiMG1WOW5lVW9DZGlHczlPcnVseEtRTE9GbkFKNitiVnZNZTZ5L0E1VzRxQXlHMGRyMno1RHBYCjdHU3o0Rkc5c1JWc21uZVN5bTg2S3dManF0amJDcU5henRyZ0hzTk5PZUJETHFNWnhvRy9HQno0bmo3MFVYMDEKVHRMNm5lZ2FtRUs4cXRtRmk5anplTmtETTlMNEN5VE9lOUFxCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1847"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:09 GMT
+      - Thu, 02 Nov 2023 18:59:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -792,7 +792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 048e0009-0895-40bd-a290-0ff4a10c2a69
+      - f2bd7728-3a6c-4b21-977c-c47ea010bd6e
     status: 200 OK
     code: 200
     duration: ""
@@ -803,19 +803,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:10 GMT
+      - Thu, 02 Nov 2023 18:59:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -825,42 +825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ddd86909-eb1d-46f5-ab7e-66b787d9e52c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"backup_schedule_frequency":null,"backup_schedule_retention":null,"is_backup_schedule_disabled":null,"name":null,"tags":null,"logs_policy":null,"backup_same_region":null,"backup_schedule_start_hour":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
-    method: PATCH
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1268"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:05:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5dc37ad4-b134-415f-95a0-8308b35172c9
+      - 3222004a-e631-442f-8633-5c7367158f84
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +836,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:10 GMT
+      - Thu, 02 Nov 2023 18:59:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +858,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 788421c0-e5df-41ce-b1bb-e3ca40158894
+      - 20506ca1-db3d-44e0-9288-c25fedc317ee
     status: 200 OK
     code: 200
     duration: ""
@@ -906,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad/upgrade
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a/upgrade
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1275"
+      - "1229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:11 GMT
+      - Thu, 02 Nov 2023 18:59:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 413700c1-0630-4a58-8dcf-06118ddd1b2d
+      - c74fa2ea-2573-4e84-8cbb-66b80fd6803a
     status: 200 OK
     code: 200
     duration: ""
@@ -939,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1275"
+      - "1229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:11 GMT
+      - Thu, 02 Nov 2023 18:59:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8f1ef50-c543-4784-9cbc-1809d65f019b
+      - 7c0a2412-3974-4e1e-b083-d579be4ec64e
     status: 200 OK
     code: 200
     duration: ""
@@ -972,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1275"
+      - "1229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:41 GMT
+      - Thu, 02 Nov 2023 18:59:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86c42ccd-80c3-4671-a408-bff322755909
+      - f7344750-dd49-476d-85dd-aa5e426310e7
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1275"
+      - "1229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:11 GMT
+      - Thu, 02 Nov 2023 19:00:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53cfe97b-47b2-4675-bb5e-ab5280226d1a
+      - b2f5a7cf-4ee2-440d-b673-f440b0c4b500
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +1003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1275"
+      - "1229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:06:42 GMT
+      - Thu, 02 Nov 2023 19:00:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b45df7e0-e349-4aad-90ac-fdba5ea3b0d3
+      - 783dccc8-0ce9-4d5f-9508-14b7cec02964
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +1036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1275"
+      - "1229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:12 GMT
+      - Thu, 02 Nov 2023 19:01:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd01a984-1393-42cc-9b09-67455ceb169a
+      - 1b3f672f-7ef5-42e1-b7ad-c79a930e984d
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,19 +1069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1275"
+      - "1229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:07:42 GMT
+      - Thu, 02 Nov 2023 19:01:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 244f61ed-39b6-456a-ac36-b7a3eab7338c
+      - 983a6566-b75b-4e26-89c7-112dddbc6f64
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,19 +1102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1275"
+      - "1229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:08:12 GMT
+      - Thu, 02 Nov 2023 19:02:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8340abc-739d-4763-ab0a-a27aeb613aca
+      - 344773a6-e266-432c-966d-6bde7eb68059
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,19 +1135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1275"
+      - "1229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:08:42 GMT
+      - Thu, 02 Nov 2023 19:02:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 315821ea-ce52-45f8-9d3d-b1f079664076
+      - d5022f32-de3d-4936-a4ed-ce978ffe9ee7
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,19 +1168,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1275"
+      - "1229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:09:13 GMT
+      - Thu, 02 Nov 2023 19:03:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abd1d4f6-4391-4212-a278-f07d8922ef86
+      - 97b7a4b2-83d8-4090-9a4f-fcf8f5a90ce7
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,19 +1201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1275"
+      - "1229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:09:43 GMT
+      - Thu, 02 Nov 2023 19:03:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89942e34-c0e7-477c-a62a-2b132d3ab770
+      - a6a97cdd-fb9f-4ac1-982e-eb61a0952af8
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,19 +1234,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1275"
+      - "1229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:10:13 GMT
+      - Thu, 02 Nov 2023 19:04:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0d3c94d-ad94-4121-99b9-e2552b00de8b
+      - 3e58316a-8cae-4101-873c-06e107669d0f
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,19 +1267,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1275"
+      - "1229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:10:43 GMT
+      - Thu, 02 Nov 2023 19:04:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32a1aa1b-cecb-4781-b973-657f8958a847
+      - 32f9cd39-ffed-481f-b031-8ffb8771a9d2
     status: 200 OK
     code: 200
     duration: ""
@@ -1335,19 +1300,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1275"
+      - "1229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:11:13 GMT
+      - Thu, 02 Nov 2023 19:05:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd35c26e-66c8-4456-a783-3ac46073906b
+      - 7e194910-86ad-4a24-9bb3-8528e0bf125c
     status: 200 OK
     code: 200
     duration: ""
@@ -1368,19 +1333,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:11:44 GMT
+      - Thu, 02 Nov 2023 19:05:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 842a8614-df82-47da-bfcf-e12a38de7c2d
+      - b83a19e6-20e6-4ae7-aef1-98ece7c37c7c
     status: 200 OK
     code: 200
     duration: ""
@@ -1401,19 +1366,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:11:44 GMT
+      - Thu, 02 Nov 2023 19:06:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1388,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ed7abe3-5328-4db1-919f-97b4f70a7241
+      - e765ddd8-c540-4b01-bc37-d7c08675d970
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1222"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 19:06:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7f6cc53c-bb28-473d-8499-5e6a06e39bcd
     status: 200 OK
     code: 200
     duration: ""
@@ -1436,19 +1434,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad/upgrade
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a/upgrade
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1276"
+      - "1230"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:11:44 GMT
+      - Thu, 02 Nov 2023 19:06:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1458,7 +1456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4453a551-4bfa-4505-b490-d53e61cee01e
+      - 529a27bd-f27a-4cff-9cd0-a307ca014ea9
     status: 200 OK
     code: 200
     duration: ""
@@ -1469,19 +1467,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1276"
+      - "1230"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:11:44 GMT
+      - Thu, 02 Nov 2023 19:06:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1491,7 +1489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2bbbb300-88aa-4c7a-ae6c-b4c95b03f94a
+      - 0d7d822c-2e59-453b-a1e4-268a88cc458f
     status: 200 OK
     code: 200
     duration: ""
@@ -1502,19 +1500,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1269"
+      - "1223"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:12:15 GMT
+      - Thu, 02 Nov 2023 19:06:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1524,7 +1522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5d11746-f271-4959-8ebd-ac20b84c37bd
+      - 947d62d9-53af-4be6-8599-f6ccaf69598b
     status: 200 OK
     code: 200
     duration: ""
@@ -1535,19 +1533,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1269"
+      - "1223"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:12:15 GMT
+      - Thu, 02 Nov 2023 19:06:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1557,7 +1555,42 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3221a27-726a-4d2e-b92e-93d5821c9680
+      - 5d9b0060-d94e-4905-aaeb-2fc2420fe263
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    method: PATCH
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1223"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 19:06:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 46d08415-26b3-4c49-9558-ff8fe453945a
     status: 200 OK
     code: 200
     duration: ""
@@ -1568,19 +1601,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUFlBaGlhSXpUUWp3VU4zcHd3Znk4YUV5UmJ3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzR5TVRBdU5EUXdIaGNOCk1qTXhNREl3TVRZd01qUXdXaGNOTXpNeE1ERTNNVFl3TWpRd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqSXhNQzQwTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxRVWtPOHR2SkdEVjkvWElWWXYrNjFsUnpLREhraXVwTCs4MU1UWkQ3K0c3QjNHRGJjZWNuMDMKTWhiWEh1c28xUlhWOE9DZldjWHZjZTlncWhOZW1tYWQ4VElSZUExRlZnTzR2ZkRxZXdQNHNLMk1IR3lhbGZsNwowS1NiUllHeHVXTmpqSVVMS01hVm91d0YreUNLekpnT1VEL201cGVmTDdHMEVKT2dxSFl1K01mS0tEWDdaQ3pWCkJmVWhCWHlQL2hJWTlpelFBa3lRZ2NidUpvdjROSGp2YXdnREVXY0E4b2xGdUpBUXh0ZnkyWDZQMkpRMlFGeEsKVlpIMzdjZHhuUjA1TUljbkExM3ZtSm9PME52b2daU2IyWXFBUlBlc1pRcXc1UnU1aDVVU2JlL2cvNHNJcWVJRAo0dVdpU1oxc1Nwb2xjajVqeUk5a2lRK2pMc1RoSHc4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMakl4TUM0ME5JSThjbmN0TUdRNU5ESTFPVGN0WVRJd055MDBOekJpTFRrNE5qTXROMll6TnprME5HUTEKTm1Ga0xuSmtZaTV1YkMxaGJYTXVjMk4zTG1Oc2IzVmtod1F6RHlkT2h3UXpudElzTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXBXMkZmRFpvcVIveFNMdTE2Q2Faa2RlRnJmVVZBVS9paEViR0Z4aEEvWGdIZzhWMmV3dmxhCnhKdVg0RUNYdWhkMlFqRTkxTTRqdFhKZXpGTWNMMStPbDBZWWIraWJycGt4S2prL01oem9NaS9IWnk0S2N2dloKSnR5QzN2OEVBcU1HN3dNbGZlUzV6QjIzOEFvY2pwUlJja2htMjdyYzJIMWpJN25EYTQ2SGRiK0NaZVR6RjlPWQpaalhXMitHWGRzeElHY3ZoeFQ1UDU2Wmo0djREUHFvK0k5SkZTUU50N1lBR1kvRVJEU3l1TThMMWlUU0pFTG1mCko5OHBhaUszVzhjdWhwZmo0Y1M4TFd4TTBxN1NYVnJ0WVVHNlVuZlRHNkxSTGlta09lRGtCYXl0YW1YNmUrVFAKbEZ5bFRJbWo0bXZwZys1cjdOZmExRTk2NUFTd1ROUFcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1845"
+      - "1223"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:12:15 GMT
+      - Thu, 02 Nov 2023 19:06:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1590,7 +1623,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 729741e7-a130-4307-8652-239920b4a43b
+      - c04846e5-5617-4005-97aa-792fe8d0d623
     status: 200 OK
     code: 200
     duration: ""
@@ -1601,19 +1634,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVWVlTbTZrcjlrSU5JQXNUUzRXQUdGNSs5VXY4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpBdU1qQXlNQjRYCkRUSXpNVEV3TWpFNE5UWTBNRm9YRFRNek1UQXpNREU0TlRZME1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekF1TWpBeU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXFzV0tPaHpITEo3ZTROMEl5SW9ycHk5WG15OHgrOFdwSU8zL0RLbmx6a000WnQ2V0RzbVgKSWczUktEU1BJNFFPQ3dkQXQ4dzQwaGNNb3RRbE1vdlRmYUlKSGM0YTFiWUIvSlpqck5ldEdSVDdkaFp2bklweQppSmcvUHNDWVg1d2tHQ3V4YmJ3QjExcjYyS2pBaU0vSjBtYktLMFVxOXdGWFZHaVRvbHA1YWxQTDQ2a25yRzlpCk5DSExzMmhxZCtyVnV6UFd0aFVDbzgxSFcvdkRVdUNrME42dGtmZzRndnp0THpPM0E3R3c3V0NPS2JUN0FwUWwKZWIvVndMcHlUS3k5UTUybFk2OVAwck5CNEN6ak5SR0tTVVp6OXorSFRvN1YxdFVZeVFlN1pYNE1Ia3FuWHdsTQpQOTdxMmN5S05TNDRIN1dPckRKRjdmQURHMDdUbVZOQnp3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNd0xqSXdNb0k4Y25jdE5UVmxOVEE0WldVdFl6Sm1PUzAwTVRGbUxXSTFabUV0Wm1RM1pUUTUKWldGa1pqWmhMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRem5xL2lod1F6bm9MS01BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE3cjJ6UWtIejc4c24xY2xxbysxUE5FRFFoRlZ0TEZ6ZVFvbXNiTm9UcHYxV3hiUzhoCmFqMUNxWkZRazNHY2IyclFFWUFaVzR6SVlQK2NhR3dJc3hKNDhpOFM4cHIyUy9tN3hFTW5BQUw5QnVEc2N1eFQKclQxcUNCZ2VSbWhaTFpUU3o4cHJqZEJFTlhaN1FZLzZrdktwUUxmU0grcGxaYXh3OWlhdzZhcmkrbDNjQVRIbQp0VjNjYUM1YzRiMG1WOW5lVW9DZGlHczlPcnVseEtRTE9GbkFKNitiVnZNZTZ5L0E1VzRxQXlHMGRyMno1RHBYCjdHU3o0Rkc5c1JWc21uZVN5bTg2S3dManF0amJDcU5henRyZ0hzTk5PZUJETHFNWnhvRy9HQno0bmo3MFVYMDEKVHRMNm5lZ2FtRUs4cXRtRmk5anplTmtETTlMNEN5VE9lOUFxCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1269"
+      - "1847"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:12:15 GMT
+      - Thu, 02 Nov 2023 19:06:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1623,7 +1656,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e76a440a-8324-4350-b467-1742ca6b3874
+      - 70c47894-470f-4c44-a839-ec3b5b180626
     status: 200 OK
     code: 200
     duration: ""
@@ -1634,19 +1667,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1269"
+      - "1223"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:12:16 GMT
+      - Thu, 02 Nov 2023 19:06:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1656,7 +1689,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1841f23f-0dad-44aa-8a1e-824925f93bf3
+      - d75956b7-9ec2-4d8e-aae4-e95063f6c27b
     status: 200 OK
     code: 200
     duration: ""
@@ -1667,19 +1700,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUFlBaGlhSXpUUWp3VU4zcHd3Znk4YUV5UmJ3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzR5TVRBdU5EUXdIaGNOCk1qTXhNREl3TVRZd01qUXdXaGNOTXpNeE1ERTNNVFl3TWpRd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqSXhNQzQwTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxRVWtPOHR2SkdEVjkvWElWWXYrNjFsUnpLREhraXVwTCs4MU1UWkQ3K0c3QjNHRGJjZWNuMDMKTWhiWEh1c28xUlhWOE9DZldjWHZjZTlncWhOZW1tYWQ4VElSZUExRlZnTzR2ZkRxZXdQNHNLMk1IR3lhbGZsNwowS1NiUllHeHVXTmpqSVVMS01hVm91d0YreUNLekpnT1VEL201cGVmTDdHMEVKT2dxSFl1K01mS0tEWDdaQ3pWCkJmVWhCWHlQL2hJWTlpelFBa3lRZ2NidUpvdjROSGp2YXdnREVXY0E4b2xGdUpBUXh0ZnkyWDZQMkpRMlFGeEsKVlpIMzdjZHhuUjA1TUljbkExM3ZtSm9PME52b2daU2IyWXFBUlBlc1pRcXc1UnU1aDVVU2JlL2cvNHNJcWVJRAo0dVdpU1oxc1Nwb2xjajVqeUk5a2lRK2pMc1RoSHc4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMakl4TUM0ME5JSThjbmN0TUdRNU5ESTFPVGN0WVRJd055MDBOekJpTFRrNE5qTXROMll6TnprME5HUTEKTm1Ga0xuSmtZaTV1YkMxaGJYTXVjMk4zTG1Oc2IzVmtod1F6RHlkT2h3UXpudElzTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXBXMkZmRFpvcVIveFNMdTE2Q2Faa2RlRnJmVVZBVS9paEViR0Z4aEEvWGdIZzhWMmV3dmxhCnhKdVg0RUNYdWhkMlFqRTkxTTRqdFhKZXpGTWNMMStPbDBZWWIraWJycGt4S2prL01oem9NaS9IWnk0S2N2dloKSnR5QzN2OEVBcU1HN3dNbGZlUzV6QjIzOEFvY2pwUlJja2htMjdyYzJIMWpJN25EYTQ2SGRiK0NaZVR6RjlPWQpaalhXMitHWGRzeElHY3ZoeFQ1UDU2Wmo0djREUHFvK0k5SkZTUU50N1lBR1kvRVJEU3l1TThMMWlUU0pFTG1mCko5OHBhaUszVzhjdWhwZmo0Y1M4TFd4TTBxN1NYVnJ0WVVHNlVuZlRHNkxSTGlta09lRGtCYXl0YW1YNmUrVFAKbEZ5bFRJbWo0bXZwZys1cjdOZmExRTk2NUFTd1ROUFcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1845"
+      - "1223"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:12:16 GMT
+      - Thu, 02 Nov 2023 19:06:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1689,7 +1722,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33397866-528f-48e8-8009-0ff36ca943e7
+      - 3ebdf4de-1ff4-4055-924b-3f9b3fcfb2f8
     status: 200 OK
     code: 200
     duration: ""
@@ -1700,19 +1733,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVWVlTbTZrcjlrSU5JQXNUUzRXQUdGNSs5VXY4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpBdU1qQXlNQjRYCkRUSXpNVEV3TWpFNE5UWTBNRm9YRFRNek1UQXpNREU0TlRZME1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekF1TWpBeU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXFzV0tPaHpITEo3ZTROMEl5SW9ycHk5WG15OHgrOFdwSU8zL0RLbmx6a000WnQ2V0RzbVgKSWczUktEU1BJNFFPQ3dkQXQ4dzQwaGNNb3RRbE1vdlRmYUlKSGM0YTFiWUIvSlpqck5ldEdSVDdkaFp2bklweQppSmcvUHNDWVg1d2tHQ3V4YmJ3QjExcjYyS2pBaU0vSjBtYktLMFVxOXdGWFZHaVRvbHA1YWxQTDQ2a25yRzlpCk5DSExzMmhxZCtyVnV6UFd0aFVDbzgxSFcvdkRVdUNrME42dGtmZzRndnp0THpPM0E3R3c3V0NPS2JUN0FwUWwKZWIvVndMcHlUS3k5UTUybFk2OVAwck5CNEN6ak5SR0tTVVp6OXorSFRvN1YxdFVZeVFlN1pYNE1Ia3FuWHdsTQpQOTdxMmN5S05TNDRIN1dPckRKRjdmQURHMDdUbVZOQnp3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNd0xqSXdNb0k4Y25jdE5UVmxOVEE0WldVdFl6Sm1PUzAwTVRGbUxXSTFabUV0Wm1RM1pUUTUKWldGa1pqWmhMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRem5xL2lod1F6bm9MS01BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE3cjJ6UWtIejc4c24xY2xxbysxUE5FRFFoRlZ0TEZ6ZVFvbXNiTm9UcHYxV3hiUzhoCmFqMUNxWkZRazNHY2IyclFFWUFaVzR6SVlQK2NhR3dJc3hKNDhpOFM4cHIyUy9tN3hFTW5BQUw5QnVEc2N1eFQKclQxcUNCZ2VSbWhaTFpUU3o4cHJqZEJFTlhaN1FZLzZrdktwUUxmU0grcGxaYXh3OWlhdzZhcmkrbDNjQVRIbQp0VjNjYUM1YzRiMG1WOW5lVW9DZGlHczlPcnVseEtRTE9GbkFKNitiVnZNZTZ5L0E1VzRxQXlHMGRyMno1RHBYCjdHU3o0Rkc5c1JWc21uZVN5bTg2S3dManF0amJDcU5henRyZ0hzTk5PZUJETHFNWnhvRy9HQno0bmo3MFVYMDEKVHRMNm5lZ2FtRUs4cXRtRmk5anplTmtETTlMNEN5VE9lOUFxCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1269"
+      - "1847"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:12:17 GMT
+      - Thu, 02 Nov 2023 19:06:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1722,7 +1755,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6ad53c3-1cac-43de-96e9-7019ca211b9f
+      - 53c9d3cc-753e-486c-a6f7-cd550054498e
     status: 200 OK
     code: 200
     duration: ""
@@ -1733,19 +1766,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1223"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 19:06:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c1668828-e5e5-48d9-ace1-ef846fa9507b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1272"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:12:17 GMT
+      - Thu, 02 Nov 2023 19:06:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1755,7 +1821,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 436f5af5-09c6-4a4e-8ecc-c0a9c045917d
+      - 2201fff6-8b4d-407c-94dc-a3f64b9621ea
     status: 200 OK
     code: 200
     duration: ""
@@ -1766,19 +1832,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:02:06.076653Z","endpoint":{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895},"endpoints":[{"id":"07e6178f-adf8-4d5a-accc-346d5d299881","ip":"51.158.210.44","load_balancer":{},"name":null,"port":11895}],"engine":"PostgreSQL-15","id":"0d942597-a207-470b-9863-7f37944d56ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1272"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:12:17 GMT
+      - Thu, 02 Nov 2023 19:06:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1788,7 +1854,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 024ca30f-4f3e-45ac-a58e-1b1a7b558372
+      - c056a914-d0a4-4185-af2a-ca65ff859096
     status: 200 OK
     code: 200
     duration: ""
@@ -1799,10 +1865,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"0d942597-a207-470b-9863-7f37944d56ad","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1811,7 +1877,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:12:47 GMT
+      - Thu, 02 Nov 2023 19:07:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1821,7 +1887,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d8906b3-fb63-45f0-b3c7-d7465913bd9e
+      - c8a3f847-ac04-4df9-9c68-b8a673f3e415
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1832,10 +1898,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/0d942597-a207-470b-9863-7f37944d56ad
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"0d942597-a207-470b-9863-7f37944d56ad","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1844,7 +1910,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:12:48 GMT
+      - Thu, 02 Nov 2023 19:07:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1854,7 +1920,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10be2720-4c10-4758-a846-97ae0d6c8cca
+      - 3713798d-48a5-4bed-9749-28686b35805c
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-with-cluster.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-with-cluster.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:05 GMT
+      - Thu, 02 Nov 2023 18:46:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d19e2160-bf8c-434b-a22b-d70e24ab357d
+      - 638fc704-f112-4c4d-8ecc-8f023d5c716e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-with-cluster","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s8cret","node_type":"db-dev-m","is_ha_cluster":true,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_instance","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-with-cluster","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s8cret","node_type":"db-dev-m","is_ha_cluster":true,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_instance","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.206817Z","retention":7},"created_at":"2023-10-20T15:51:10.206817Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"061f3940-c35d-40ef-a5af-dd8b60065d5f","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "816"
+      - "787"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:10 GMT
+      - Thu, 02 Nov 2023 18:46:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 037d8099-b0b9-44a4-add8-586ddf222244
+      - 5647a829-039c-447c-bed7-a3cc1fa62251
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/061f3940-c35d-40ef-a5af-dd8b60065d5f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.206817Z","retention":7},"created_at":"2023-10-20T15:51:10.206817Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"061f3940-c35d-40ef-a5af-dd8b60065d5f","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "816"
+      - "787"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:10 GMT
+      - Thu, 02 Nov 2023 18:46:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1425229-b62f-4eb6-8677-73b1734fc91a
+      - 41921265-2831-45de-8991-a908e4f8c56f
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/061f3940-c35d-40ef-a5af-dd8b60065d5f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.206817Z","retention":7},"created_at":"2023-10-20T15:51:10.206817Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"061f3940-c35d-40ef-a5af-dd8b60065d5f","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "816"
+      - "787"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:40 GMT
+      - Thu, 02 Nov 2023 18:47:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 322d2b72-1fa5-4d4e-aeb3-3a2e8a14198a
+      - 3b1f70d2-3f80-424d-b7b4-5994c37c9313
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/061f3940-c35d-40ef-a5af-dd8b60065d5f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.206817Z","retention":7},"created_at":"2023-10-20T15:51:10.206817Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"061f3940-c35d-40ef-a5af-dd8b60065d5f","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "816"
+      - "787"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:52:10 GMT
+      - Thu, 02 Nov 2023 18:47:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca2672c3-69dd-4a3f-a33e-2acadd00f965
+      - 152e69b5-81f6-4a05-9c1b-e15ce44bd21b
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/061f3940-c35d-40ef-a5af-dd8b60065d5f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.206817Z","retention":7},"created_at":"2023-10-20T15:51:10.206817Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"061f3940-c35d-40ef-a5af-dd8b60065d5f","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "816"
+      - "787"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:52:41 GMT
+      - Thu, 02 Nov 2023 18:48:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7eb58b81-19ad-4fed-8bf3-bc51b35449a1
+      - 7655966e-b82b-4a8d-9486-5207a23ea655
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/061f3940-c35d-40ef-a5af-dd8b60065d5f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.206817Z","retention":7},"created_at":"2023-10-20T15:51:10.206817Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"061f3940-c35d-40ef-a5af-dd8b60065d5f","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "816"
+      - "787"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:53:11 GMT
+      - Thu, 02 Nov 2023 18:48:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2cc95272-7a26-4390-9e06-13e4dc059a8f
+      - 7753cd69-1f41-4c2a-a7d3-17cbcee6265e
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/061f3940-c35d-40ef-a5af-dd8b60065d5f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.206817Z","retention":7},"created_at":"2023-10-20T15:51:10.206817Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"061f3940-c35d-40ef-a5af-dd8b60065d5f","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "816"
+      - "787"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:53:41 GMT
+      - Thu, 02 Nov 2023 18:49:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de009950-ec9c-4195-8d89-83f642e9e1d1
+      - debe5407-0086-4298-a336-32bacdad579f
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/061f3940-c35d-40ef-a5af-dd8b60065d5f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.206817Z","retention":7},"created_at":"2023-10-20T15:51:10.206817Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"061f3940-c35d-40ef-a5af-dd8b60065d5f","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215},"endpoints":[{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215}],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "816"
+      - "1256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,78 +594,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34f574d2-6976-43dd-b751-e3b4fe51b77f
+      - f012887d-7e6b-4780-a94d-9ef273e973d5
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/061f3940-c35d-40ef-a5af-dd8b60065d5f
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.206817Z","retention":7},"created_at":"2023-10-20T15:51:10.206817Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"061f3940-c35d-40ef-a5af-dd8b60065d5f","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "816"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 630855f5-8d60-4050-9c61-89b340086912
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/061f3940-c35d-40ef-a5af-dd8b60065d5f
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.206817Z","retention":7},"created_at":"2023-10-20T15:51:10.206817Z","endpoint":{"id":"6b3a79d5-fbda-4999-a0c3-19783fdb3ebd","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27414},"endpoints":[{"id":"6b3a79d5-fbda-4999-a0c3-19783fdb3ebd","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27414}],"engine":"PostgreSQL-15","id":"061f3940-c35d-40ef-a5af-dd8b60065d5f","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1308"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:55:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 197e45ce-d7a6-4848-8c0a-e224c00890be
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"backup_schedule_frequency":null,"backup_schedule_retention":null,"is_backup_schedule_disabled":false,"name":null,"tags":null,"logs_policy":null,"backup_same_region":false,"backup_schedule_start_hour":null}'
+    body: '{"is_backup_schedule_disabled":false,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -673,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/061f3940-c35d-40ef-a5af-dd8b60065d5f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.206817Z","retention":7},"created_at":"2023-10-20T15:51:10.206817Z","endpoint":{"id":"6b3a79d5-fbda-4999-a0c3-19783fdb3ebd","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27414},"endpoints":[{"id":"6b3a79d5-fbda-4999-a0c3-19783fdb3ebd","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27414}],"engine":"PostgreSQL-15","id":"061f3940-c35d-40ef-a5af-dd8b60065d5f","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215},"endpoints":[{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215}],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1308"
+      - "1256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:12 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94945bfb-38ea-4f67-893d-8db6a63be81b
+      - 6bf684d9-2130-4b65-86d1-5f1b1656594a
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/061f3940-c35d-40ef-a5af-dd8b60065d5f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.206817Z","retention":7},"created_at":"2023-10-20T15:51:10.206817Z","endpoint":{"id":"6b3a79d5-fbda-4999-a0c3-19783fdb3ebd","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27414},"endpoints":[{"id":"6b3a79d5-fbda-4999-a0c3-19783fdb3ebd","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27414}],"engine":"PostgreSQL-15","id":"061f3940-c35d-40ef-a5af-dd8b60065d5f","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215},"endpoints":[{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215}],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1308"
+      - "1256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:12 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c26edc40-2264-4fd3-919a-8ae0a2429498
+      - bf6c74ca-b96f-49b8-ac74-0bf64ecd34e5
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/061f3940-c35d-40ef-a5af-dd8b60065d5f/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURxakNDQXBLZ0F3SUJBZ0lVRnRueElSL0VIdXdoM0VsQ3ZkbVRObTNVaEVvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU1qQTVXaGNOTXpNeE1ERTNNVFUxTWpBNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQVBGZEozdUttTFdWY1pVKzFuOGx0QnFnZlQxWnJDbFdDNmYzaHRkNnB1bXJiMUIvRmJrSmN2ZlEKbFc0Sm8vQUhUZ0owT0ZNQnhJTDVXdXA3WFlEZ0Qyekp1WEpqK21EcWdWVS9ub3FJSGIvcVN6YjNubUhzYWswKwpHQk82Um5tY0hpTzNrVG1XVEszQ0c5OG9FS2dpc2g0TVBjUTBiV2NIUnRIMEhCNFBEc1Q5ZTdoeXNsRWx3SFZyCjhDb3BqMmZ0c2xmbzJtY3NGYWw2K3lydG5WdU95RUIwZ25RelBicitJek1TVG40a0FrUERBWXh3bW1nN0k4Q0MKMHh3WElhc2JtT3I1ZDdjRUNYMmhNUDhWTUpKendXSmVXV203dkNOYVJaTFlOOGZ1ZndTMFIvUnpxWVZYME16cQpmVDlJS0NvT1ptQ3Mrb1NPTzVNUWMvc3BESkpjWFNVQ0F3RUFBYU5zTUdvd2FBWURWUjBSQkdFd1g0SU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0TURZeFpqTTVOREF0WXpNMVpDMDBNR1ZtTFdFMVlXWXRaR1E0WWpZd01EWTEKWkRWbUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm1IK2h3UXpEOTg1aHdRem54cVVNQTBHQ1NxRwpTSWIzRFFFQkN3VUFBNElCQVFBRm9tc1VDKzgzZ3BXTDRUSGxWWFEwc1lqRlJyMThVenAvTU82dUx5dHVoN2NYCkR2S1ZtZVdJNUFPcGtWNFl6QlFKbk9lNU03bDNJNUhvdlpHdnZNVmhBcXRENGp2NFR0MUhWQVh4bUt4RHMwYTQKbzZ1WXpwNFNWejhiSzRMUUZtRkhPQlVGR0xRVUc4SGVuNkdqcDRnMGpWdHhVQUcyQmRzWlROZmZaT3lpRy9nRgptQjU0TENpVlZyWDlDVmFFVy9EczMxbHd4M2pUVXQzNlQwL3psMEc0czRaU2lWdFRQR2lSeCtJZ3V4emNvRm1nCkZHTmd4N1BiTm5YZmFLeEZ2T1gzTk5qZDc5N0QrVGJOKytTeVFBOEN0cGpldjZKV0ovWm5EaERrTWNXcWJiWEIKZU5yR1JhV1dXamhnZy9SSXRla0E1NEFEV1l4WDN6T216RUhTUWNJTAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVRFJMRW5qODVrQ2NwYkhqR3ZGc3g4Wkg2dXp3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR5TlM0Mk5UQWVGdzB5Ck16RXhNREl4T0RRM016UmFGdzB6TXpFd016QXhPRFEzTXpSYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1qVXVOalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURRbVZyS1pHblZKcDBkTFZNTHhyVjA3TXR4Tm1FZVY3OXpJamFaQThjcEJ0TXM1dlNFV1JvcXg4bFcKQnY2R2tCWE9HMmZaSzlmeDZPRytLVWl2UDN3THp0RkhyRThlMTVsek5lYWRCcmdQMHBHckZWbk14dVloM3dyUgo0bXlIK3JncS9RTWtHdXFRNURLWFdGdjhacWRyZDA5SVl2OFZYZWlOL1p5b2JBRm5yRVJJM0U5aEFseFZTUUlvCmRMNmluQVEyMnJIaThHenF3cFJpTDRLS2hENUxER1lxRUhWeUtFK2I5bHQ4OGdpczgrSnJXN2FodkYrY0NwUzUKZGIrMzU5dkxHVzEyRlZ0d3JvM3haVDczTVlRbmUwSVpnRUlNUHA5Z0tmZU5rMFBqVW5kWW9kbngvbENOWW5zRgpnU0tJV2hYUnJORmZWdktrQThhUkRLbnpKYlREQWdNQkFBR2phekJwTUdjR0ExVWRFUVJnTUY2Q0REVXhMakUxCk9TNHlOUzQyTllJOGNuY3RaVFZoWkRrelpXUXRaR1kxWVMwMFpqZzNMV0U1WVdJdFlqWmxZemd6Tm1OalltTmwKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVMK3JCaHdRekQrZWhod1F6bnhsQk1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNiakxkY1hScUoveGhMcUJZR21NcitrUnJFdjkxeXlsaWVoTlA0azJjUGZGR2FlMUZWCjNhRHhZN1cvQmpPUFVNSjJnRWwrSTVtbzlnbEUzV1FVdElxN3E3dGhCZ01NTXhJTG9HRGpWT3MzSDM3cUt5THkKYkJQZDZvbkRHeXpjZDNLVjNFaUxSSmVNOE1GL3dOdXdYcVNWVlIwQ3dFTWRkdFlnOW5LQTdIdEhTZHFlY2l4cQp4RENWYnZJN204RmNkdmZHNmh6bVNWejB3ZVFaZS9MNGxteGZ2V1F0Q2pUdHRJa3V0Q1phNlRKUXpycVRIMUtxCnpiS0Z2cWxIbzc1U1FQYlhER0FUOUhaQzJkbDBaNUJnc0ZYc1E3V0RZN05aN3VKQmN2WUovRjYzU25DSG9NajIKSkVKSzYvNGVraDJ3Tys1alZ5eEk0N3c0cGVGT05obGxiNW5VCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1857"
+      - "1847"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:13 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77110f7e-562a-4103-9117-0e338dd96ff8
+      - 83b71ba5-e4ae-4480-aaa1-184b4a06c93d
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/061f3940-c35d-40ef-a5af-dd8b60065d5f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.206817Z","retention":7},"created_at":"2023-10-20T15:51:10.206817Z","endpoint":{"id":"6b3a79d5-fbda-4999-a0c3-19783fdb3ebd","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27414},"endpoints":[{"id":"6b3a79d5-fbda-4999-a0c3-19783fdb3ebd","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27414}],"engine":"PostgreSQL-15","id":"061f3940-c35d-40ef-a5af-dd8b60065d5f","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215},"endpoints":[{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215}],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1308"
+      - "1256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:13 GMT
+      - Thu, 02 Nov 2023 18:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 050bf0e3-5441-4302-9460-cd924bae20e5
+      - 12298d4d-b8ca-4d68-a293-d5f43ddc8c27
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/061f3940-c35d-40ef-a5af-dd8b60065d5f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.206817Z","retention":7},"created_at":"2023-10-20T15:51:10.206817Z","endpoint":{"id":"6b3a79d5-fbda-4999-a0c3-19783fdb3ebd","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27414},"endpoints":[{"id":"6b3a79d5-fbda-4999-a0c3-19783fdb3ebd","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27414}],"engine":"PostgreSQL-15","id":"061f3940-c35d-40ef-a5af-dd8b60065d5f","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215},"endpoints":[{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215}],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1308"
+      - "1256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:14 GMT
+      - Thu, 02 Nov 2023 18:49:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3589f30a-437f-44ab-a3ea-4cefcc7a2342
+      - c7e9b367-5d7a-4295-b958-872207294421
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/061f3940-c35d-40ef-a5af-dd8b60065d5f/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURxakNDQXBLZ0F3SUJBZ0lVRnRueElSL0VIdXdoM0VsQ3ZkbVRObTNVaEVvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU1qQTVXaGNOTXpNeE1ERTNNVFUxTWpBNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQVBGZEozdUttTFdWY1pVKzFuOGx0QnFnZlQxWnJDbFdDNmYzaHRkNnB1bXJiMUIvRmJrSmN2ZlEKbFc0Sm8vQUhUZ0owT0ZNQnhJTDVXdXA3WFlEZ0Qyekp1WEpqK21EcWdWVS9ub3FJSGIvcVN6YjNubUhzYWswKwpHQk82Um5tY0hpTzNrVG1XVEszQ0c5OG9FS2dpc2g0TVBjUTBiV2NIUnRIMEhCNFBEc1Q5ZTdoeXNsRWx3SFZyCjhDb3BqMmZ0c2xmbzJtY3NGYWw2K3lydG5WdU95RUIwZ25RelBicitJek1TVG40a0FrUERBWXh3bW1nN0k4Q0MKMHh3WElhc2JtT3I1ZDdjRUNYMmhNUDhWTUpKendXSmVXV203dkNOYVJaTFlOOGZ1ZndTMFIvUnpxWVZYME16cQpmVDlJS0NvT1ptQ3Mrb1NPTzVNUWMvc3BESkpjWFNVQ0F3RUFBYU5zTUdvd2FBWURWUjBSQkdFd1g0SU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0TURZeFpqTTVOREF0WXpNMVpDMDBNR1ZtTFdFMVlXWXRaR1E0WWpZd01EWTEKWkRWbUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm1IK2h3UXpEOTg1aHdRem54cVVNQTBHQ1NxRwpTSWIzRFFFQkN3VUFBNElCQVFBRm9tc1VDKzgzZ3BXTDRUSGxWWFEwc1lqRlJyMThVenAvTU82dUx5dHVoN2NYCkR2S1ZtZVdJNUFPcGtWNFl6QlFKbk9lNU03bDNJNUhvdlpHdnZNVmhBcXRENGp2NFR0MUhWQVh4bUt4RHMwYTQKbzZ1WXpwNFNWejhiSzRMUUZtRkhPQlVGR0xRVUc4SGVuNkdqcDRnMGpWdHhVQUcyQmRzWlROZmZaT3lpRy9nRgptQjU0TENpVlZyWDlDVmFFVy9EczMxbHd4M2pUVXQzNlQwL3psMEc0czRaU2lWdFRQR2lSeCtJZ3V4emNvRm1nCkZHTmd4N1BiTm5YZmFLeEZ2T1gzTk5qZDc5N0QrVGJOKytTeVFBOEN0cGpldjZKV0ovWm5EaERrTWNXcWJiWEIKZU5yR1JhV1dXamhnZy9SSXRla0E1NEFEV1l4WDN6T216RUhTUWNJTAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVRFJMRW5qODVrQ2NwYkhqR3ZGc3g4Wkg2dXp3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR5TlM0Mk5UQWVGdzB5Ck16RXhNREl4T0RRM016UmFGdzB6TXpFd016QXhPRFEzTXpSYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1qVXVOalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURRbVZyS1pHblZKcDBkTFZNTHhyVjA3TXR4Tm1FZVY3OXpJamFaQThjcEJ0TXM1dlNFV1JvcXg4bFcKQnY2R2tCWE9HMmZaSzlmeDZPRytLVWl2UDN3THp0RkhyRThlMTVsek5lYWRCcmdQMHBHckZWbk14dVloM3dyUgo0bXlIK3JncS9RTWtHdXFRNURLWFdGdjhacWRyZDA5SVl2OFZYZWlOL1p5b2JBRm5yRVJJM0U5aEFseFZTUUlvCmRMNmluQVEyMnJIaThHenF3cFJpTDRLS2hENUxER1lxRUhWeUtFK2I5bHQ4OGdpczgrSnJXN2FodkYrY0NwUzUKZGIrMzU5dkxHVzEyRlZ0d3JvM3haVDczTVlRbmUwSVpnRUlNUHA5Z0tmZU5rMFBqVW5kWW9kbngvbENOWW5zRgpnU0tJV2hYUnJORmZWdktrQThhUkRLbnpKYlREQWdNQkFBR2phekJwTUdjR0ExVWRFUVJnTUY2Q0REVXhMakUxCk9TNHlOUzQyTllJOGNuY3RaVFZoWkRrelpXUXRaR1kxWVMwMFpqZzNMV0U1WVdJdFlqWmxZemd6Tm1OalltTmwKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVMK3JCaHdRekQrZWhod1F6bnhsQk1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNiakxkY1hScUoveGhMcUJZR21NcitrUnJFdjkxeXlsaWVoTlA0azJjUGZGR2FlMUZWCjNhRHhZN1cvQmpPUFVNSjJnRWwrSTVtbzlnbEUzV1FVdElxN3E3dGhCZ01NTXhJTG9HRGpWT3MzSDM3cUt5THkKYkJQZDZvbkRHeXpjZDNLVjNFaUxSSmVNOE1GL3dOdXdYcVNWVlIwQ3dFTWRkdFlnOW5LQTdIdEhTZHFlY2l4cQp4RENWYnZJN204RmNkdmZHNmh6bVNWejB3ZVFaZS9MNGxteGZ2V1F0Q2pUdHRJa3V0Q1phNlRKUXpycVRIMUtxCnpiS0Z2cWxIbzc1U1FQYlhER0FUOUhaQzJkbDBaNUJnc0ZYc1E3V0RZN05aN3VKQmN2WUovRjYzU25DSG9NajIKSkVKSzYvNGVraDJ3Tys1alZ5eEk0N3c0cGVGT05obGxiNW5VCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1857"
+      - "1847"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:14 GMT
+      - Thu, 02 Nov 2023 18:49:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6517089a-6ebf-4c70-8fb5-581aed5050d4
+      - 0e3d2354-8477-40af-8624-0db28c29b20b
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/061f3940-c35d-40ef-a5af-dd8b60065d5f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.206817Z","retention":7},"created_at":"2023-10-20T15:51:10.206817Z","endpoint":{"id":"6b3a79d5-fbda-4999-a0c3-19783fdb3ebd","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27414},"endpoints":[{"id":"6b3a79d5-fbda-4999-a0c3-19783fdb3ebd","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27414}],"engine":"PostgreSQL-15","id":"061f3940-c35d-40ef-a5af-dd8b60065d5f","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215},"endpoints":[{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215}],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1308"
+      - "1256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:15 GMT
+      - Thu, 02 Nov 2023 18:49:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51811e7c-8d7b-4fd2-9771-54523fdb7031
+      - 9d9022fd-c440-4a93-99d5-19afe3b4d3fa
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/061f3940-c35d-40ef-a5af-dd8b60065d5f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.206817Z","retention":7},"created_at":"2023-10-20T15:51:10.206817Z","endpoint":{"id":"6b3a79d5-fbda-4999-a0c3-19783fdb3ebd","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27414},"endpoints":[{"id":"6b3a79d5-fbda-4999-a0c3-19783fdb3ebd","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27414}],"engine":"PostgreSQL-15","id":"061f3940-c35d-40ef-a5af-dd8b60065d5f","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215},"endpoints":[{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215}],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1311"
+      - "1259"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:15 GMT
+      - Thu, 02 Nov 2023 18:49:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 463d99e0-2296-4ff7-b381-25782d218244
+      - 7b335bfa-24f7-4232-9f53-ac8f9c553b10
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/061f3940-c35d-40ef-a5af-dd8b60065d5f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.206817Z","retention":7},"created_at":"2023-10-20T15:51:10.206817Z","endpoint":{"id":"6b3a79d5-fbda-4999-a0c3-19783fdb3ebd","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27414},"endpoints":[{"id":"6b3a79d5-fbda-4999-a0c3-19783fdb3ebd","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27414}],"engine":"PostgreSQL-15","id":"061f3940-c35d-40ef-a5af-dd8b60065d5f","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215},"endpoints":[{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215}],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1311"
+      - "1259"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:15 GMT
+      - Thu, 02 Nov 2023 18:49:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e70750b-f12d-458b-b762-5d5a8d7ebef0
+      - 9e8a458c-7440-410a-a46b-2ba42da78d66
     status: 200 OK
     code: 200
     duration: ""
@@ -970,10 +904,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/061f3940-c35d-40ef-a5af-dd8b60065d5f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"061f3940-c35d-40ef-a5af-dd8b60065d5f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -982,7 +916,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:47 GMT
+      - Thu, 02 Nov 2023 18:50:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00e31e09-c916-4a23-affb-bb88057e8196
+      - 18217d22-e842-490b-8d4d-42232106b1bf
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1003,10 +937,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/061f3940-c35d-40ef-a5af-dd8b60065d5f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"061f3940-c35d-40ef-a5af-dd8b60065d5f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1015,7 +949,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:51 GMT
+      - Thu, 02 Nov 2023 18:50:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e4d2af8-52b0-4363-9979-649f61c36711
+      - 0a86fe32-a85f-440d-9050-593ab3b0e420
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-privilege-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-privilege-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:07 GMT
+      - Thu, 02 Nov 2023 18:46:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3fcb400-aabc-413c-bfb3-83ab069c7f1e
+      - 722d7645-ca2b-44a2-9c5b-60cf89b7a6aa
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayRdbPrivilege_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayRdbPrivilege_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "824"
+      - "795"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:16 GMT
+      - Thu, 02 Nov 2023 18:50:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7cf06db-2b90-44b9-8269-19ac232e0410
+      - fa1e9414-147a-4f65-8bf9-46c8174ccf2a
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "824"
+      - "795"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:16 GMT
+      - Thu, 02 Nov 2023 18:50:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40938402-444f-4787-af09-f3ae935dc6f5
+      - 092e481f-0f5a-4339-aa29-875ab4d24382
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "824"
+      - "795"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:46 GMT
+      - Thu, 02 Nov 2023 18:51:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89e6d26f-c75f-4457-b9f0-613f086db21f
+      - 2a10c4f4-7f60-479d-b88b-264db2d6ccf1
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "824"
+      - "795"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:56:16 GMT
+      - Thu, 02 Nov 2023 18:51:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f85040ac-172b-4f74-bdfb-b38c9ee6f6b2
+      - 48fb480b-370d-40b7-8e34-7f959bf5f00d
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "824"
+      - "795"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:56:47 GMT
+      - Thu, 02 Nov 2023 18:52:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f7f9dac-3200-46de-bca7-3ac6a0ddec2e
+      - 402decd5-cdd1-438a-8a3b-70b637a5ee29
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "824"
+      - "795"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:17 GMT
+      - Thu, 02 Nov 2023 18:52:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7593877-3323-4313-83b6-c4fd6e74154c
+      - 4774675e-2033-492b-9c48-dde2c66a8c59
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:50 GMT
+      - Thu, 02 Nov 2023 18:53:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,12 +561,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3fbac842-3737-43b9-bdc7-87dd2e84aba9
+      - 5e1159e2-920a-4619-83b0-ef842ae90e0b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"backup_schedule_frequency":null,"backup_schedule_retention":null,"is_backup_schedule_disabled":false,"name":null,"tags":null,"logs_policy":null,"backup_same_region":false,"backup_schedule_start_hour":null}'
+    body: '{"is_backup_schedule_disabled":false,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -574,19 +574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:51 GMT
+      - Thu, 02 Nov 2023 18:53:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f88d746-8d72-4747-b7f5-41e61003df9a
+      - 98c8f3c7-cef4-41de-a999-ef8c9efa0ca7
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:51 GMT
+      - Thu, 02 Nov 2023 18:53:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 786661f6-2086-45c6-a54a-a16ab5d42611
+      - dbdad24d-a190-4d36-ab42-a28dd7dedb50
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTEt3ZU1sTkw2RDJhZW53UHREQnM4VnowaHFRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5UVTVXaGNOTXpNeE1ERTNNVFUxTlRVNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUkwQVJDTnh4a2NyMHk5QzhIbnAxak5qT3pvWlI1L3k1dW5icnVxUTJuSTRwaXdwNzQrZUN5OGQKaXpxQlN3Mjl5cFZCejFrcnNKeHpUVDhBRVdTL1FqN3BseVBHbXA3YzU0OHZnTHdCTXhUTkw3RGo2VFJsQksxeAoxeEhpUkJGcDY5cTBzOWxBNUpGNGUySGo2K0N1cHR3Wk5aQlV3YzliTFRqU0ZxK2kzTkZ2Ynptd2FpaVVoV3diCklLOXZWQ0NYOHJ1N0hqRlp2TXhNV0hkTGFuYTJ5dUlvMTRHUUlEQTRHWExtZjlzbzBVZ0JKOTBxc2tEMDhiQmcKUkQwS3dkZmxpRzJBNk1taVlMekl5WWQvTXAyMmRaU3dkYjhNaCt0L0dzQ2dlYmlOdmJXRXViVlptcjBsNmF6Tworck1DZ3VTNjJiS0pxWlR2VE96WlcxcjlhS0pJV1RrQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0WmpabU56STRPVEV0WXpWaE9TMDBOREJtTFdJelpHUXRNRFkyTldZM05UYzAKT1dKakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhEWGh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQUJncHBBL0Y4K1ZSMXBydFNJSVduSlBOU2VxTmFRTmMrTVIwTjUvVUQrOENYcTRaTG9va0tVClRza1pwSjVNUS9hVlF6eFdaSlNRR2lDNmZPcHR4cWhyR25zTk90d2ZxY0VBTk02UWJEQUVDK29zUmJ4WE8zd24KTnlzaW1JbE9NdmczaGtlaTJYY3ZtNU8vMGE3dlJxZnZVeDJDaGkyUmdISkQyVHVxdFU3bEVxZW9LNkkvUUdTUQpyQVFXOEhBellaS3l4azFFQ0Q4ejhkUlBqYlNSOGxHK1EzQTdqWGcwUnNENll4cnllQ0NvbmtNN0MwZktpc3hVCmd2U2FqZ2tsQmZzMWpOb05BOFNDaS8xaUVpNjV6dFlRSFBraDkzRlRreDROSnpuaXBsbE9GWEI4dlFlSVRBM3cKdXlCVExITHRoK1AwZXU5WHB1RVJHUHVtKy9pMzhsemIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTVRIM1R0Rk84N3NvNURydENXSkRXbUpQVGo4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1UTXdXaGNOTXpNeE1ETXdNVGcxTVRNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUt5WW9PNGNIZ0tKVmVuY0xpL1FLMTlHcTBzTzczL1BMRy91QU1IMkJXMXB5THNXbkphRWZKRUgKbUpuTTNQOTdhVGJVZkwzQUYyOXVEaEhqMWI0ZHMyLzA0RWQ3SmgvaXhUQnE4WXRwc3dtVmZCcTBkTWJYTkVXZApjRlpYdERxbHExOGhuc1JJS2VMNEVpQ21KWHRxS0dnNk1KQm44ejNiTkREZk1QOWFtZUFVMFJuVkk5U1N0Q1hiCmFJN2N6eDY3L2lkRXdzT2NkWXdLYTlxTEZNdjBzL25WRWZIdXdkc2RLaEhBOC9Ub3dOSEVHMElYSFN5ay9JcHAKdkxWeENQNGtwN0VsSnpwZnFJZkxUV3hhQlV6cDZadWxHZy9RNlBtTm1VMVZPelFaUnYxMXJZbytVYk9YMUFLWgpyVmRaRTJkbnVTUC9UNlN6UXhuQlc5VVE1TmtjSzBzQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TldKbE1URm1NelF0Wm1Nek9TMDBOell3TFdJME5qRXROV1l5WW1FM1lXVTMKTmpNMUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1N5RXZjNDArczdzRk0rdlNCN05OWGV6ZFo3eFRlZVZjYmhFTVJMY0xaK2VNN0VRK1NaT1BaCnhzZjhXejh2Zk5RQ2lwWEttQ0ZCZjhnaFFnVE85djVzTi9aK0xhZ1FpV1o1VlNhNzI0dTMySkMzWTdQV3ExWC8KT1V6RWJXeFJxL2ZDUmhhcFNYUzJGbmUycDJsVVBTV3hic2YzZlJ1azBtNVk4dzZaSVJnOGRUN1ptcVd3Y1pJRgoxQmVlTDdWOVd0QWd4QitIMjNvZG1FZVNFTnlrVDF2eXB5Rk4wSjkvVXNKN2QxTDNrNTUrOXlXbkVpaC9lbHdHCk00Y1NYRWgyOHQ0YjM5eklJT2MyNEVJTXRwV1JnQ3owVG4rOE5PTml3RkRBcTNjcU5POWhGK2VtOHZud2RuRVAKY1ZHZHU0SXFKdFpMZ0t2ZkpCVTBmQ3FsUThIRmVGWXEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:52 GMT
+      - Thu, 02 Nov 2023 18:53:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b644f28-29b7-4abd-9d1a-222848161e35
+      - dd615584-849f-4000-88df-f6098e1b01be
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:52 GMT
+      - Thu, 02 Nov 2023 18:53:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9385f748-4dc6-4ab8-b1ac-a8029115b985
+      - 82f198ac-65f3-429a-a01a-7949a2736f9a
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:52 GMT
+      - Thu, 02 Nov 2023 18:53:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf60bac8-b86f-4b7a-a4df-da87aa660e9f
+      - 6338c314-734f-4380-974c-6f2ae979b3db
     status: 200 OK
     code: 200
     duration: ""
@@ -741,19 +741,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users
     method: POST
   response:
     body: '{"is_admin":true,"name":"user_01"}'
     headers:
       Content-Length:
-      - "35"
+      - "34"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:53 GMT
+      - Thu, 02 Nov 2023 18:53:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +763,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da59f361-d7d3-442b-9ce1-2a3e45a3cfbf
+      - 33e33823-9889-46df-bf8e-7a6187f423ab
     status: 200 OK
     code: 200
     duration: ""
@@ -776,19 +776,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/databases
     method: POST
   response:
     body: '{"managed":true,"name":"foo","owner":"","size":0}'
     headers:
       Content-Length:
-      - "52"
+      - "49"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:53 GMT
+      - Thu, 02 Nov 2023 18:53:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -798,7 +798,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed339121-3e0a-43ed-b8a6-12cc41805efb
+      - b4c883ac-5e3f-486e-a5e5-eedbba9626bf
     status: 200 OK
     code: 200
     duration: ""
@@ -809,19 +809,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:53 GMT
+      - Thu, 02 Nov 2023 18:53:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -831,7 +831,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77300245-5a97-4d92-9021-e0092e6d9256
+      - 7efd763c-c2ec-4582-9393-07368ea29ab2
     status: 200 OK
     code: 200
     duration: ""
@@ -842,19 +842,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:53 GMT
+      - Thu, 02 Nov 2023 18:53:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -864,7 +864,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ae9b518-5a89-43bd-a3a1-974182403109
+      - 98af6a3e-282c-43b4-856f-1ec60fdf6841
     status: 200 OK
     code: 200
     duration: ""
@@ -875,19 +875,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:54 GMT
+      - Thu, 02 Nov 2023 18:53:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -897,7 +897,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4f6d6c5-b608-49f8-9222-1b1ea700be03
+      - 7306f016-d1fd-4777-8b3e-d096f19afff1
     status: 200 OK
     code: 200
     duration: ""
@@ -908,19 +908,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
     headers:
       Content-Length:
-      - "64"
+      - "62"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:54 GMT
+      - Thu, 02 Nov 2023 18:53:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -930,7 +930,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2c06481-2420-4603-8b65-8908327878eb
+      - ebed79ee-df68-4ff9-9c39-c56eb4a4ac6f
     status: 200 OK
     code: 200
     duration: ""
@@ -941,19 +941,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:54 GMT
+      - Thu, 02 Nov 2023 18:53:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -963,7 +963,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b4ce2b9-fdd5-4b83-ae15-560adece1837
+      - 2488d07d-30bb-4fd5-8ef5-0ea01ca29c4b
     status: 200 OK
     code: 200
     duration: ""
@@ -976,118 +976,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"all","user_name":"user_01"}'
     headers:
       Content-Length:
-      - "66"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:57:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 07dc6917-2032-446a-9cf3-3bceb67aee6e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:57:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7a034325-2500-49b9-a935-b404a31c4ee3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:57:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f0aba280-351e-4805-81fb-62992544de8f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_01&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
-    headers:
-      Content-Length:
       - "64"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:00 GMT
+      - Thu, 02 Nov 2023 18:53:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1097,7 +998,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3028ecce-7b12-48e9-845e-bea4f7bede0a
+      - 8f7e5c54-2d60-473c-ac3a-e2d87412e070
     status: 200 OK
     code: 200
     duration: ""
@@ -1108,19 +1009,118 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1266"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2280cdc0-85ed-40bf-add9-211060371ca2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1266"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bbf6a1c0-67fc-4d38-ad36-6cdc518b351f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
+    headers:
+      Content-Length:
+      - "62"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5ebfecab-f324-45a4-b6cb-8aacf703ab89
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
     headers:
       Content-Length:
-      - "100"
+      - "97"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:00 GMT
+      - Thu, 02 Nov 2023 18:53:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1130,7 +1130,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5fad610-42fa-436b-a45d-c9a7922cf81d
+      - 0403963b-ac13-4eb9-860a-1879cbcb48bb
     status: 200 OK
     code: 200
     duration: ""
@@ -1141,19 +1141,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
     headers:
       Content-Length:
-      - "100"
+      - "97"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:02 GMT
+      - Thu, 02 Nov 2023 18:53:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1163,7 +1163,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - efb7e0f9-6f41-4309-862c-41347712e67b
+      - 1a4dc32b-a641-409e-975c-45293517abb4
     status: 200 OK
     code: 200
     duration: ""
@@ -1174,19 +1174,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:03 GMT
+      - Thu, 02 Nov 2023 18:53:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1196,7 +1196,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74e353cc-7137-407e-bde3-a4357a15cc21
+      - 4aba7612-5bc3-4a35-aa72-f91553c3b986
     status: 200 OK
     code: 200
     duration: ""
@@ -1207,19 +1207,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTEt3ZU1sTkw2RDJhZW53UHREQnM4VnowaHFRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5UVTVXaGNOTXpNeE1ERTNNVFUxTlRVNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUkwQVJDTnh4a2NyMHk5QzhIbnAxak5qT3pvWlI1L3k1dW5icnVxUTJuSTRwaXdwNzQrZUN5OGQKaXpxQlN3Mjl5cFZCejFrcnNKeHpUVDhBRVdTL1FqN3BseVBHbXA3YzU0OHZnTHdCTXhUTkw3RGo2VFJsQksxeAoxeEhpUkJGcDY5cTBzOWxBNUpGNGUySGo2K0N1cHR3Wk5aQlV3YzliTFRqU0ZxK2kzTkZ2Ynptd2FpaVVoV3diCklLOXZWQ0NYOHJ1N0hqRlp2TXhNV0hkTGFuYTJ5dUlvMTRHUUlEQTRHWExtZjlzbzBVZ0JKOTBxc2tEMDhiQmcKUkQwS3dkZmxpRzJBNk1taVlMekl5WWQvTXAyMmRaU3dkYjhNaCt0L0dzQ2dlYmlOdmJXRXViVlptcjBsNmF6Tworck1DZ3VTNjJiS0pxWlR2VE96WlcxcjlhS0pJV1RrQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0WmpabU56STRPVEV0WXpWaE9TMDBOREJtTFdJelpHUXRNRFkyTldZM05UYzAKT1dKakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhEWGh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQUJncHBBL0Y4K1ZSMXBydFNJSVduSlBOU2VxTmFRTmMrTVIwTjUvVUQrOENYcTRaTG9va0tVClRza1pwSjVNUS9hVlF6eFdaSlNRR2lDNmZPcHR4cWhyR25zTk90d2ZxY0VBTk02UWJEQUVDK29zUmJ4WE8zd24KTnlzaW1JbE9NdmczaGtlaTJYY3ZtNU8vMGE3dlJxZnZVeDJDaGkyUmdISkQyVHVxdFU3bEVxZW9LNkkvUUdTUQpyQVFXOEhBellaS3l4azFFQ0Q4ejhkUlBqYlNSOGxHK1EzQTdqWGcwUnNENll4cnllQ0NvbmtNN0MwZktpc3hVCmd2U2FqZ2tsQmZzMWpOb05BOFNDaS8xaUVpNjV6dFlRSFBraDkzRlRreDROSnpuaXBsbE9GWEI4dlFlSVRBM3cKdXlCVExITHRoK1AwZXU5WHB1RVJHUHVtKy9pMzhsemIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTVRIM1R0Rk84N3NvNURydENXSkRXbUpQVGo4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1UTXdXaGNOTXpNeE1ETXdNVGcxTVRNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUt5WW9PNGNIZ0tKVmVuY0xpL1FLMTlHcTBzTzczL1BMRy91QU1IMkJXMXB5THNXbkphRWZKRUgKbUpuTTNQOTdhVGJVZkwzQUYyOXVEaEhqMWI0ZHMyLzA0RWQ3SmgvaXhUQnE4WXRwc3dtVmZCcTBkTWJYTkVXZApjRlpYdERxbHExOGhuc1JJS2VMNEVpQ21KWHRxS0dnNk1KQm44ejNiTkREZk1QOWFtZUFVMFJuVkk5U1N0Q1hiCmFJN2N6eDY3L2lkRXdzT2NkWXdLYTlxTEZNdjBzL25WRWZIdXdkc2RLaEhBOC9Ub3dOSEVHMElYSFN5ay9JcHAKdkxWeENQNGtwN0VsSnpwZnFJZkxUV3hhQlV6cDZadWxHZy9RNlBtTm1VMVZPelFaUnYxMXJZbytVYk9YMUFLWgpyVmRaRTJkbnVTUC9UNlN6UXhuQlc5VVE1TmtjSzBzQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TldKbE1URm1NelF0Wm1Nek9TMDBOell3TFdJME5qRXROV1l5WW1FM1lXVTMKTmpNMUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1N5RXZjNDArczdzRk0rdlNCN05OWGV6ZFo3eFRlZVZjYmhFTVJMY0xaK2VNN0VRK1NaT1BaCnhzZjhXejh2Zk5RQ2lwWEttQ0ZCZjhnaFFnVE85djVzTi9aK0xhZ1FpV1o1VlNhNzI0dTMySkMzWTdQV3ExWC8KT1V6RWJXeFJxL2ZDUmhhcFNYUzJGbmUycDJsVVBTV3hic2YzZlJ1azBtNVk4dzZaSVJnOGRUN1ptcVd3Y1pJRgoxQmVlTDdWOVd0QWd4QitIMjNvZG1FZVNFTnlrVDF2eXB5Rk4wSjkvVXNKN2QxTDNrNTUrOXlXbkVpaC9lbHdHCk00Y1NYRWgyOHQ0YjM5eklJT2MyNEVJTXRwV1JnQ3owVG4rOE5PTml3RkRBcTNjcU5POWhGK2VtOHZud2RuRVAKY1ZHZHU0SXFKdFpMZ0t2ZkpCVTBmQ3FsUThIRmVGWXEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:04 GMT
+      - Thu, 02 Nov 2023 18:53:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1229,7 +1229,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4382bb4-a916-4d6c-b634-50195ac58f57
+      - 95ff7b51-843d-432c-b3e5-bfb7d5737e10
     status: 200 OK
     code: 200
     duration: ""
@@ -1240,19 +1240,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:04 GMT
+      - Thu, 02 Nov 2023 18:53:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1262,7 +1262,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dcae69a8-518a-4d0f-856c-c0e72d921df7
+      - 5e729bde-d091-4f10-bde0-fda5f2ef533d
     status: 200 OK
     code: 200
     duration: ""
@@ -1273,19 +1273,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:04 GMT
+      - Thu, 02 Nov 2023 18:53:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1295,7 +1295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6cf44c71-f686-411c-a182-d2521e74ed3f
+      - c92363bc-18be-48b1-b9eb-5d434d641e3f
     status: 200 OK
     code: 200
     duration: ""
@@ -1306,19 +1306,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
     headers:
       Content-Length:
-      - "64"
+      - "62"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:04 GMT
+      - Thu, 02 Nov 2023 18:53:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1328,7 +1328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c06d374-ef6f-466f-b224-bb058c2eab59
+      - 4f5cc41b-d8ed-4579-9f51-c11929aaa00c
     status: 200 OK
     code: 200
     duration: ""
@@ -1339,19 +1339,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:04 GMT
+      - Thu, 02 Nov 2023 18:53:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1361,7 +1361,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c9e49c3-f6a8-48bc-aecc-da215fb9cccc
+      - fda2252f-5f43-4257-9e2f-73eb0c521035
     status: 200 OK
     code: 200
     duration: ""
@@ -1372,19 +1372,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
     headers:
       Content-Length:
-      - "64"
+      - "62"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:04 GMT
+      - Thu, 02 Nov 2023 18:53:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1394,7 +1394,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98f765ef-c527-4e29-817d-d51c71312fe9
+      - 796b6e03-8525-43a1-bbd6-94ec8c2a1fc4
     status: 200 OK
     code: 200
     duration: ""
@@ -1405,19 +1405,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
     headers:
       Content-Length:
-      - "100"
+      - "97"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:04 GMT
+      - Thu, 02 Nov 2023 18:53:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1427,7 +1427,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5152cde-a71c-45e2-a220-56f86d878027
+      - a2403594-5dd0-4533-bc08-2fded96b8f99
     status: 200 OK
     code: 200
     duration: ""
@@ -1438,19 +1438,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:05 GMT
+      - Thu, 02 Nov 2023 18:53:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1460,7 +1460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c591291-e817-4086-9a4f-a2a927c82b76
+      - e89816f5-919d-4f70-8352-884bbba8f427
     status: 200 OK
     code: 200
     duration: ""
@@ -1471,19 +1471,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTEt3ZU1sTkw2RDJhZW53UHREQnM4VnowaHFRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5UVTVXaGNOTXpNeE1ERTNNVFUxTlRVNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUkwQVJDTnh4a2NyMHk5QzhIbnAxak5qT3pvWlI1L3k1dW5icnVxUTJuSTRwaXdwNzQrZUN5OGQKaXpxQlN3Mjl5cFZCejFrcnNKeHpUVDhBRVdTL1FqN3BseVBHbXA3YzU0OHZnTHdCTXhUTkw3RGo2VFJsQksxeAoxeEhpUkJGcDY5cTBzOWxBNUpGNGUySGo2K0N1cHR3Wk5aQlV3YzliTFRqU0ZxK2kzTkZ2Ynptd2FpaVVoV3diCklLOXZWQ0NYOHJ1N0hqRlp2TXhNV0hkTGFuYTJ5dUlvMTRHUUlEQTRHWExtZjlzbzBVZ0JKOTBxc2tEMDhiQmcKUkQwS3dkZmxpRzJBNk1taVlMekl5WWQvTXAyMmRaU3dkYjhNaCt0L0dzQ2dlYmlOdmJXRXViVlptcjBsNmF6Tworck1DZ3VTNjJiS0pxWlR2VE96WlcxcjlhS0pJV1RrQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0WmpabU56STRPVEV0WXpWaE9TMDBOREJtTFdJelpHUXRNRFkyTldZM05UYzAKT1dKakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhEWGh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQUJncHBBL0Y4K1ZSMXBydFNJSVduSlBOU2VxTmFRTmMrTVIwTjUvVUQrOENYcTRaTG9va0tVClRza1pwSjVNUS9hVlF6eFdaSlNRR2lDNmZPcHR4cWhyR25zTk90d2ZxY0VBTk02UWJEQUVDK29zUmJ4WE8zd24KTnlzaW1JbE9NdmczaGtlaTJYY3ZtNU8vMGE3dlJxZnZVeDJDaGkyUmdISkQyVHVxdFU3bEVxZW9LNkkvUUdTUQpyQVFXOEhBellaS3l4azFFQ0Q4ejhkUlBqYlNSOGxHK1EzQTdqWGcwUnNENll4cnllQ0NvbmtNN0MwZktpc3hVCmd2U2FqZ2tsQmZzMWpOb05BOFNDaS8xaUVpNjV6dFlRSFBraDkzRlRreDROSnpuaXBsbE9GWEI4dlFlSVRBM3cKdXlCVExITHRoK1AwZXU5WHB1RVJHUHVtKy9pMzhsemIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTVRIM1R0Rk84N3NvNURydENXSkRXbUpQVGo4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1UTXdXaGNOTXpNeE1ETXdNVGcxTVRNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUt5WW9PNGNIZ0tKVmVuY0xpL1FLMTlHcTBzTzczL1BMRy91QU1IMkJXMXB5THNXbkphRWZKRUgKbUpuTTNQOTdhVGJVZkwzQUYyOXVEaEhqMWI0ZHMyLzA0RWQ3SmgvaXhUQnE4WXRwc3dtVmZCcTBkTWJYTkVXZApjRlpYdERxbHExOGhuc1JJS2VMNEVpQ21KWHRxS0dnNk1KQm44ejNiTkREZk1QOWFtZUFVMFJuVkk5U1N0Q1hiCmFJN2N6eDY3L2lkRXdzT2NkWXdLYTlxTEZNdjBzL25WRWZIdXdkc2RLaEhBOC9Ub3dOSEVHMElYSFN5ay9JcHAKdkxWeENQNGtwN0VsSnpwZnFJZkxUV3hhQlV6cDZadWxHZy9RNlBtTm1VMVZPelFaUnYxMXJZbytVYk9YMUFLWgpyVmRaRTJkbnVTUC9UNlN6UXhuQlc5VVE1TmtjSzBzQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TldKbE1URm1NelF0Wm1Nek9TMDBOell3TFdJME5qRXROV1l5WW1FM1lXVTMKTmpNMUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1N5RXZjNDArczdzRk0rdlNCN05OWGV6ZFo3eFRlZVZjYmhFTVJMY0xaK2VNN0VRK1NaT1BaCnhzZjhXejh2Zk5RQ2lwWEttQ0ZCZjhnaFFnVE85djVzTi9aK0xhZ1FpV1o1VlNhNzI0dTMySkMzWTdQV3ExWC8KT1V6RWJXeFJxL2ZDUmhhcFNYUzJGbmUycDJsVVBTV3hic2YzZlJ1azBtNVk4dzZaSVJnOGRUN1ptcVd3Y1pJRgoxQmVlTDdWOVd0QWd4QitIMjNvZG1FZVNFTnlrVDF2eXB5Rk4wSjkvVXNKN2QxTDNrNTUrOXlXbkVpaC9lbHdHCk00Y1NYRWgyOHQ0YjM5eklJT2MyNEVJTXRwV1JnQ3owVG4rOE5PTml3RkRBcTNjcU5POWhGK2VtOHZud2RuRVAKY1ZHZHU0SXFKdFpMZ0t2ZkpCVTBmQ3FsUThIRmVGWXEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:05 GMT
+      - Thu, 02 Nov 2023 18:53:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1493,7 +1493,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75c9f495-dca7-48a9-8418-0bcf595eb265
+      - d3d479d5-837e-41fd-a015-0678ceb53833
     status: 200 OK
     code: 200
     duration: ""
@@ -1504,19 +1504,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:06 GMT
+      - Thu, 02 Nov 2023 18:53:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1526,7 +1526,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81f58ff7-a8e2-48fb-b0bf-da287b0f7acb
+      - d1ef8b05-bc38-40c0-bd55-16dbee2a643e
     status: 200 OK
     code: 200
     duration: ""
@@ -1537,19 +1537,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:06 GMT
+      - Thu, 02 Nov 2023 18:53:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1559,7 +1559,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8fb7b96-2548-4e41-97c3-1a65d8a829fc
+      - 6c5060eb-3374-4731-84a1-f0cec64782ff
     status: 200 OK
     code: 200
     duration: ""
@@ -1570,19 +1570,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
     headers:
       Content-Length:
-      - "64"
+      - "62"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:06 GMT
+      - Thu, 02 Nov 2023 18:53:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1592,7 +1592,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54203ff1-aab9-42c5-80e1-c0c7a74c2f3e
+      - cd18335e-58c2-41d9-a914-a44c8ad853e2
     status: 200 OK
     code: 200
     duration: ""
@@ -1603,19 +1603,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:07 GMT
+      - Thu, 02 Nov 2023 18:53:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1625,7 +1625,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a0b9a03-3f4c-4289-a036-d3c8dea161cc
+      - 4dfeb65f-6b7c-427a-80e6-e40b0d0e416a
     status: 200 OK
     code: 200
     duration: ""
@@ -1636,19 +1636,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
     headers:
       Content-Length:
-      - "64"
+      - "62"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:07 GMT
+      - Thu, 02 Nov 2023 18:53:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1658,7 +1658,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6dfef1cd-f0fe-44b4-a999-f5229c360085
+      - 33bbecff-4c2f-48f3-afdc-7a5bb70700f6
     status: 200 OK
     code: 200
     duration: ""
@@ -1669,19 +1669,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
     headers:
       Content-Length:
-      - "100"
+      - "97"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:07 GMT
+      - Thu, 02 Nov 2023 18:53:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1691,7 +1691,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b23e0cb4-9231-4d17-bdc5-1c61e362d577
+      - f4bc5f61-f049-4d28-957f-a3a9309e852f
     status: 200 OK
     code: 200
     duration: ""
@@ -1702,19 +1702,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:08 GMT
+      - Thu, 02 Nov 2023 18:53:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1724,7 +1724,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4102377-26e0-4182-847d-391b284a2437
+      - be1b95a4-ca62-4865-b4e7-bb5ca0aeb48c
     status: 200 OK
     code: 200
     duration: ""
@@ -1737,19 +1737,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users
     method: POST
   response:
     body: '{"is_admin":false,"name":"user_02"}'
     headers:
       Content-Length:
-      - "36"
+      - "35"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:08 GMT
+      - Thu, 02 Nov 2023 18:53:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1759,7 +1759,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3693367e-0532-4e61-855b-73d0b6ce628e
+      - 06703ee1-9c43-4c47-b78c-3b7efd1fbfb4
     status: 200 OK
     code: 200
     duration: ""
@@ -1770,19 +1770,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:09 GMT
+      - Thu, 02 Nov 2023 18:53:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1792,7 +1792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfc2d3b1-8f8c-477b-a677-105a7dd152cd
+      - 0448a712-dade-4625-ae4b-89edfa2cc1d5
     status: 200 OK
     code: 200
     duration: ""
@@ -1803,19 +1803,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
     headers:
       Content-Length:
-      - "65"
+      - "63"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:09 GMT
+      - Thu, 02 Nov 2023 18:53:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1825,7 +1825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa37fb66-5953-4492-ac4f-ad7b3a3d5d17
+      - 121af875-4719-4b2c-9551-cdcf00987744
     status: 200 OK
     code: 200
     duration: ""
@@ -1836,19 +1836,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:10 GMT
+      - Thu, 02 Nov 2023 18:53:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1858,7 +1858,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3149166e-8a49-425e-90b5-1a4adecee12c
+      - f9cbada7-6fd6-4f9c-bf06-5705fe7f043f
     status: 200 OK
     code: 200
     duration: ""
@@ -1871,19 +1871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"readwrite","user_name":"user_02"}'
     headers:
       Content-Length:
-      - "72"
+      - "70"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:10 GMT
+      - Thu, 02 Nov 2023 18:53:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1893,7 +1893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a00b9511-1ba1-4421-a72a-c190f661f054
+      - bc3309d9-6567-4421-b00e-0781d63e2da5
     status: 200 OK
     code: 200
     duration: ""
@@ -1904,19 +1904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:10 GMT
+      - Thu, 02 Nov 2023 18:53:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1926,7 +1926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9893a377-d59c-4f19-9aa5-e02279a0b395
+      - b2d9c780-f912-4de5-b89f-dc99e4562916
     status: 200 OK
     code: 200
     duration: ""
@@ -1937,19 +1937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:10 GMT
+      - Thu, 02 Nov 2023 18:53:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1959,7 +1959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86613c9b-cd9c-4963-bbf0-2f8d8c3d7e59
+      - 36ac581e-819b-4ea6-94d6-20d3cd4be2ee
     status: 200 OK
     code: 200
     duration: ""
@@ -1970,19 +1970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
     headers:
       Content-Length:
-      - "65"
+      - "63"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:10 GMT
+      - Thu, 02 Nov 2023 18:53:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1992,7 +1992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4044baea-426c-4980-9007-f6ed3a4f00c1
+      - c07f5cf7-9937-42a7-b72e-9ecd0a0c676f
     status: 200 OK
     code: 200
     duration: ""
@@ -2003,19 +2003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "103"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:11 GMT
+      - Thu, 02 Nov 2023 18:53:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2025,7 +2025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24d5ff32-e764-4744-8718-bbca2f73d3e3
+      - 358ce703-51f7-4a8d-a20b-d3a720144d4d
     status: 200 OK
     code: 200
     duration: ""
@@ -2036,19 +2036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "103"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:11 GMT
+      - Thu, 02 Nov 2023 18:53:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2058,7 +2058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef6bfe76-6862-48f0-be60-a95b12adca8b
+      - 5cd13737-44cd-4847-911d-c6ca2eaf54d1
     status: 200 OK
     code: 200
     duration: ""
@@ -2069,19 +2069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:12 GMT
+      - Thu, 02 Nov 2023 18:53:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2091,7 +2091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 666e7ec3-2a45-471c-8499-9061ebeb2785
+      - 30e8a66e-108d-49ba-a034-bcd48311687c
     status: 200 OK
     code: 200
     duration: ""
@@ -2102,19 +2102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTEt3ZU1sTkw2RDJhZW53UHREQnM4VnowaHFRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5UVTVXaGNOTXpNeE1ERTNNVFUxTlRVNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUkwQVJDTnh4a2NyMHk5QzhIbnAxak5qT3pvWlI1L3k1dW5icnVxUTJuSTRwaXdwNzQrZUN5OGQKaXpxQlN3Mjl5cFZCejFrcnNKeHpUVDhBRVdTL1FqN3BseVBHbXA3YzU0OHZnTHdCTXhUTkw3RGo2VFJsQksxeAoxeEhpUkJGcDY5cTBzOWxBNUpGNGUySGo2K0N1cHR3Wk5aQlV3YzliTFRqU0ZxK2kzTkZ2Ynptd2FpaVVoV3diCklLOXZWQ0NYOHJ1N0hqRlp2TXhNV0hkTGFuYTJ5dUlvMTRHUUlEQTRHWExtZjlzbzBVZ0JKOTBxc2tEMDhiQmcKUkQwS3dkZmxpRzJBNk1taVlMekl5WWQvTXAyMmRaU3dkYjhNaCt0L0dzQ2dlYmlOdmJXRXViVlptcjBsNmF6Tworck1DZ3VTNjJiS0pxWlR2VE96WlcxcjlhS0pJV1RrQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0WmpabU56STRPVEV0WXpWaE9TMDBOREJtTFdJelpHUXRNRFkyTldZM05UYzAKT1dKakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhEWGh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQUJncHBBL0Y4K1ZSMXBydFNJSVduSlBOU2VxTmFRTmMrTVIwTjUvVUQrOENYcTRaTG9va0tVClRza1pwSjVNUS9hVlF6eFdaSlNRR2lDNmZPcHR4cWhyR25zTk90d2ZxY0VBTk02UWJEQUVDK29zUmJ4WE8zd24KTnlzaW1JbE9NdmczaGtlaTJYY3ZtNU8vMGE3dlJxZnZVeDJDaGkyUmdISkQyVHVxdFU3bEVxZW9LNkkvUUdTUQpyQVFXOEhBellaS3l4azFFQ0Q4ejhkUlBqYlNSOGxHK1EzQTdqWGcwUnNENll4cnllQ0NvbmtNN0MwZktpc3hVCmd2U2FqZ2tsQmZzMWpOb05BOFNDaS8xaUVpNjV6dFlRSFBraDkzRlRreDROSnpuaXBsbE9GWEI4dlFlSVRBM3cKdXlCVExITHRoK1AwZXU5WHB1RVJHUHVtKy9pMzhsemIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTVRIM1R0Rk84N3NvNURydENXSkRXbUpQVGo4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1UTXdXaGNOTXpNeE1ETXdNVGcxTVRNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUt5WW9PNGNIZ0tKVmVuY0xpL1FLMTlHcTBzTzczL1BMRy91QU1IMkJXMXB5THNXbkphRWZKRUgKbUpuTTNQOTdhVGJVZkwzQUYyOXVEaEhqMWI0ZHMyLzA0RWQ3SmgvaXhUQnE4WXRwc3dtVmZCcTBkTWJYTkVXZApjRlpYdERxbHExOGhuc1JJS2VMNEVpQ21KWHRxS0dnNk1KQm44ejNiTkREZk1QOWFtZUFVMFJuVkk5U1N0Q1hiCmFJN2N6eDY3L2lkRXdzT2NkWXdLYTlxTEZNdjBzL25WRWZIdXdkc2RLaEhBOC9Ub3dOSEVHMElYSFN5ay9JcHAKdkxWeENQNGtwN0VsSnpwZnFJZkxUV3hhQlV6cDZadWxHZy9RNlBtTm1VMVZPelFaUnYxMXJZbytVYk9YMUFLWgpyVmRaRTJkbnVTUC9UNlN6UXhuQlc5VVE1TmtjSzBzQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TldKbE1URm1NelF0Wm1Nek9TMDBOell3TFdJME5qRXROV1l5WW1FM1lXVTMKTmpNMUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1N5RXZjNDArczdzRk0rdlNCN05OWGV6ZFo3eFRlZVZjYmhFTVJMY0xaK2VNN0VRK1NaT1BaCnhzZjhXejh2Zk5RQ2lwWEttQ0ZCZjhnaFFnVE85djVzTi9aK0xhZ1FpV1o1VlNhNzI0dTMySkMzWTdQV3ExWC8KT1V6RWJXeFJxL2ZDUmhhcFNYUzJGbmUycDJsVVBTV3hic2YzZlJ1azBtNVk4dzZaSVJnOGRUN1ptcVd3Y1pJRgoxQmVlTDdWOVd0QWd4QitIMjNvZG1FZVNFTnlrVDF2eXB5Rk4wSjkvVXNKN2QxTDNrNTUrOXlXbkVpaC9lbHdHCk00Y1NYRWgyOHQ0YjM5eklJT2MyNEVJTXRwV1JnQ3owVG4rOE5PTml3RkRBcTNjcU5POWhGK2VtOHZud2RuRVAKY1ZHZHU0SXFKdFpMZ0t2ZkpCVTBmQ3FsUThIRmVGWXEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:12 GMT
+      - Thu, 02 Nov 2023 18:53:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2124,7 +2124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb64835e-9b5f-4f87-881b-43169698ac90
+      - 9efff1af-ee02-421d-8d0c-30240320712d
     status: 200 OK
     code: 200
     duration: ""
@@ -2135,19 +2135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:12 GMT
+      - Thu, 02 Nov 2023 18:53:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2157,7 +2157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04b8922b-f02e-456d-ba7e-577deded1bf2
+      - e28412db-afa8-48fb-97da-082de5831a3a
     status: 200 OK
     code: 200
     duration: ""
@@ -2168,19 +2168,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1266"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f84d2736-194c-4dd4-83b1-7a2c5b519f42
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:12 GMT
+      - Thu, 02 Nov 2023 18:53:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2190,7 +2223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40662e1e-2446-4c13-b8db-49ff14b36dd5
+      - e3050118-f0db-4160-891a-6a5f7c304ad9
     status: 200 OK
     code: 200
     duration: ""
@@ -2201,85 +2234,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d08d1da2-5bd9-4b2c-8cb4-153866915554
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_01&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
-    headers:
-      Content-Length:
-      - "64"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b3b5ec67-a877-4361-8e04-836dc9486437
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
     headers:
       Content-Length:
-      - "65"
+      - "63"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:12 GMT
+      - Thu, 02 Nov 2023 18:53:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2289,7 +2256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 482f0299-ea95-4abd-8bd8-dc9774ab3894
+      - 8f3007c8-dc7f-4d1a-9c21-8a3af5263d47
     status: 200 OK
     code: 200
     duration: ""
@@ -2300,85 +2267,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f0a039ef-5f9a-4de8-ae31-7243c95e3b0a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cd76fbe4-1e97-4adf-a7a3-51642ba237ba
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
     headers:
       Content-Length:
-      - "64"
+      - "62"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:13 GMT
+      - Thu, 02 Nov 2023 18:53:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2388,7 +2289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63e7f4f4-2de9-489d-8cc2-b8ba14a31808
+      - 3221d669-aeca-491d-bc4b-d205e2bdc91b
     status: 200 OK
     code: 200
     duration: ""
@@ -2399,19 +2300,85 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1266"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a4dd7f08-d357-48c9-aa4a-b0dcbd138121
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1266"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 60c74cc8-aa14-411c-a5b6-b4eeede612cd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
     headers:
       Content-Length:
-      - "65"
+      - "63"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:13 GMT
+      - Thu, 02 Nov 2023 18:53:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2421,7 +2388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08f12f77-8832-4274-afc7-d1360b32c00a
+      - 14cdcfa4-b10a-4401-a245-825bee2a370d
     status: 200 OK
     code: 200
     duration: ""
@@ -2432,19 +2399,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
     method: GET
   response:
-    body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
     headers:
       Content-Length:
-      - "100"
+      - "62"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:13 GMT
+      - Thu, 02 Nov 2023 18:53:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2454,7 +2421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76367f01-de6f-43fe-a304-9800929cf8e9
+      - f15e2a8b-0313-43ea-bf67-55d9abf22459
     status: 200 OK
     code: 200
     duration: ""
@@ -2465,19 +2432,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "103"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:13 GMT
+      - Thu, 02 Nov 2023 18:53:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2487,7 +2454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71d9ffbd-2e08-4964-8b97-725987bc9dbc
+      - 6c761522-760f-4033-bfc0-9bd8daef2892
     status: 200 OK
     code: 200
     duration: ""
@@ -2498,19 +2465,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1316"
+      - "97"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:14 GMT
+      - Thu, 02 Nov 2023 18:53:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2520,7 +2487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43a2d536-8ba6-4555-ace8-540adcdacbbd
+      - 32991456-7c8f-4f52-837c-d37cf5e67054
     status: 200 OK
     code: 200
     duration: ""
@@ -2531,19 +2498,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTEt3ZU1sTkw2RDJhZW53UHREQnM4VnowaHFRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5UVTVXaGNOTXpNeE1ERTNNVFUxTlRVNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUkwQVJDTnh4a2NyMHk5QzhIbnAxak5qT3pvWlI1L3k1dW5icnVxUTJuSTRwaXdwNzQrZUN5OGQKaXpxQlN3Mjl5cFZCejFrcnNKeHpUVDhBRVdTL1FqN3BseVBHbXA3YzU0OHZnTHdCTXhUTkw3RGo2VFJsQksxeAoxeEhpUkJGcDY5cTBzOWxBNUpGNGUySGo2K0N1cHR3Wk5aQlV3YzliTFRqU0ZxK2kzTkZ2Ynptd2FpaVVoV3diCklLOXZWQ0NYOHJ1N0hqRlp2TXhNV0hkTGFuYTJ5dUlvMTRHUUlEQTRHWExtZjlzbzBVZ0JKOTBxc2tEMDhiQmcKUkQwS3dkZmxpRzJBNk1taVlMekl5WWQvTXAyMmRaU3dkYjhNaCt0L0dzQ2dlYmlOdmJXRXViVlptcjBsNmF6Tworck1DZ3VTNjJiS0pxWlR2VE96WlcxcjlhS0pJV1RrQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0WmpabU56STRPVEV0WXpWaE9TMDBOREJtTFdJelpHUXRNRFkyTldZM05UYzAKT1dKakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhEWGh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQUJncHBBL0Y4K1ZSMXBydFNJSVduSlBOU2VxTmFRTmMrTVIwTjUvVUQrOENYcTRaTG9va0tVClRza1pwSjVNUS9hVlF6eFdaSlNRR2lDNmZPcHR4cWhyR25zTk90d2ZxY0VBTk02UWJEQUVDK29zUmJ4WE8zd24KTnlzaW1JbE9NdmczaGtlaTJYY3ZtNU8vMGE3dlJxZnZVeDJDaGkyUmdISkQyVHVxdFU3bEVxZW9LNkkvUUdTUQpyQVFXOEhBellaS3l4azFFQ0Q4ejhkUlBqYlNSOGxHK1EzQTdqWGcwUnNENll4cnllQ0NvbmtNN0MwZktpc3hVCmd2U2FqZ2tsQmZzMWpOb05BOFNDaS8xaUVpNjV6dFlRSFBraDkzRlRreDROSnpuaXBsbE9GWEI4dlFlSVRBM3cKdXlCVExITHRoK1AwZXU5WHB1RVJHUHVtKy9pMzhsemIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1845"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:14 GMT
+      - Thu, 02 Nov 2023 18:53:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2553,7 +2520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0615bd1f-3e9e-41b9-abbb-a915f5b41f03
+      - 3704077e-7e9e-42f2-a348-c3de5909276b
     status: 200 OK
     code: 200
     duration: ""
@@ -2564,19 +2531,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTVRIM1R0Rk84N3NvNURydENXSkRXbUpQVGo4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1UTXdXaGNOTXpNeE1ETXdNVGcxTVRNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUt5WW9PNGNIZ0tKVmVuY0xpL1FLMTlHcTBzTzczL1BMRy91QU1IMkJXMXB5THNXbkphRWZKRUgKbUpuTTNQOTdhVGJVZkwzQUYyOXVEaEhqMWI0ZHMyLzA0RWQ3SmgvaXhUQnE4WXRwc3dtVmZCcTBkTWJYTkVXZApjRlpYdERxbHExOGhuc1JJS2VMNEVpQ21KWHRxS0dnNk1KQm44ejNiTkREZk1QOWFtZUFVMFJuVkk5U1N0Q1hiCmFJN2N6eDY3L2lkRXdzT2NkWXdLYTlxTEZNdjBzL25WRWZIdXdkc2RLaEhBOC9Ub3dOSEVHMElYSFN5ay9JcHAKdkxWeENQNGtwN0VsSnpwZnFJZkxUV3hhQlV6cDZadWxHZy9RNlBtTm1VMVZPelFaUnYxMXJZbytVYk9YMUFLWgpyVmRaRTJkbnVTUC9UNlN6UXhuQlc5VVE1TmtjSzBzQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TldKbE1URm1NelF0Wm1Nek9TMDBOell3TFdJME5qRXROV1l5WW1FM1lXVTMKTmpNMUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1N5RXZjNDArczdzRk0rdlNCN05OWGV6ZFo3eFRlZVZjYmhFTVJMY0xaK2VNN0VRK1NaT1BaCnhzZjhXejh2Zk5RQ2lwWEttQ0ZCZjhnaFFnVE85djVzTi9aK0xhZ1FpV1o1VlNhNzI0dTMySkMzWTdQV3ExWC8KT1V6RWJXeFJxL2ZDUmhhcFNYUzJGbmUycDJsVVBTV3hic2YzZlJ1azBtNVk4dzZaSVJnOGRUN1ptcVd3Y1pJRgoxQmVlTDdWOVd0QWd4QitIMjNvZG1FZVNFTnlrVDF2eXB5Rk4wSjkvVXNKN2QxTDNrNTUrOXlXbkVpaC9lbHdHCk00Y1NYRWgyOHQ0YjM5eklJT2MyNEVJTXRwV1JnQ3owVG4rOE5PTml3RkRBcTNjcU5POWhGK2VtOHZud2RuRVAKY1ZHZHU0SXFKdFpMZ0t2ZkpCVTBmQ3FsUThIRmVGWXEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1316"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:14 GMT
+      - Thu, 02 Nov 2023 18:53:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2586,7 +2553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c28bc2c-38ac-4e34-bc0b-85071a0ef61e
+      - e560fda6-6e2a-45c0-b40d-c61b2733329d
     status: 200 OK
     code: 200
     duration: ""
@@ -2597,19 +2564,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:14 GMT
+      - Thu, 02 Nov 2023 18:53:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2619,7 +2586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7342f048-c75d-446d-82ea-dd8edeb16356
+      - cdcf9218-c94a-4c9d-851d-a7178b598178
     status: 200 OK
     code: 200
     duration: ""
@@ -2630,19 +2597,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1266"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5c0a8a2f-035f-4dd1-9207-22563de6c4b2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:14 GMT
+      - Thu, 02 Nov 2023 18:53:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2652,7 +2652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8cc1f96-d9ae-4de3-b6fe-9cede6ea0af4
+      - 3d3b613b-5c5b-4224-94f2-82b4ff3e4f90
     status: 200 OK
     code: 200
     duration: ""
@@ -2663,52 +2663,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_02&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
-    headers:
-      Content-Length:
-      - "65"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3f56d9b1-3057-4298-9b19-45657c8596ab
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
     headers:
       Content-Length:
-      - "64"
+      - "62"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:14 GMT
+      - Thu, 02 Nov 2023 18:53:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2718,7 +2685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 056b0fb0-95c9-4dd7-81c2-45d7109d7f90
+      - 30e7e348-a6e1-41cc-8a3d-78b799b28053
     status: 200 OK
     code: 200
     duration: ""
@@ -2729,118 +2696,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0ee39005-7b1b-4350-8b3f-fe0386e50f0d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 28ea547e-3f13-43db-accc-3f60fc26f519
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_01&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
-    headers:
-      Content-Length:
-      - "64"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9d6d97c4-3840-4ad7-9720-730cf9d423ab
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
     headers:
       Content-Length:
-      - "65"
+      - "63"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:15 GMT
+      - Thu, 02 Nov 2023 18:53:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2850,7 +2718,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc66e27c-450c-4167-9fd1-acf4ea7f44c9
+      - b328ba51-f2a5-4ebd-930a-ae87d277918e
     status: 200 OK
     code: 200
     duration: ""
@@ -2861,19 +2729,151 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1266"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 929bfd0d-addc-4211-833c-9470b2e5081a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1266"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 42fe5f65-ff19-4af2-b928-3eb7746d1483
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
+    headers:
+      Content-Length:
+      - "62"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a25e8d49-20e3-4974-b78a-22db05860ce5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_02&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c7777d57-6b4f-4d84-a984-b434e588d925
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
     headers:
       Content-Length:
-      - "100"
+      - "97"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:15 GMT
+      - Thu, 02 Nov 2023 18:53:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2883,7 +2883,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45b8094a-9a28-4938-8036-dac69c993e87
+      - 7a0b87aa-198e-4d7b-894c-37ba0b9c2c21
     status: 200 OK
     code: 200
     duration: ""
@@ -2894,19 +2894,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "103"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:15 GMT
+      - Thu, 02 Nov 2023 18:53:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2916,7 +2916,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e314137-421f-494e-83db-3bc6068e4cfb
+      - dee64079-64b2-4ed8-bee2-9f9d1e351820
     status: 200 OK
     code: 200
     duration: ""
@@ -2927,19 +2927,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:16 GMT
+      - Thu, 02 Nov 2023 18:53:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2949,7 +2949,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c42b0fac-9701-47de-9805-dfc3946e1685
+      - 3f65e28b-f406-41eb-bea9-bd4eed30ee53
     status: 200 OK
     code: 200
     duration: ""
@@ -2962,19 +2962,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users
     method: POST
   response:
     body: '{"is_admin":false,"name":"user_03"}'
     headers:
       Content-Length:
-      - "36"
+      - "35"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:16 GMT
+      - Thu, 02 Nov 2023 18:53:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2984,7 +2984,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2caff050-2be7-425d-ae98-9e58cc59275e
+      - 481bc9c4-5c16-4505-b9fb-d6c38a88cac2
     status: 200 OK
     code: 200
     duration: ""
@@ -2995,19 +2995,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:16 GMT
+      - Thu, 02 Nov 2023 18:53:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3017,7 +3017,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34f0ba7d-39fe-4c94-9190-e8dae8b44d4d
+      - 3f643d9d-6493-472c-88cd-96155af4a7b8
     status: 200 OK
     code: 200
     duration: ""
@@ -3028,19 +3028,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_03&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_03&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
     headers:
       Content-Length:
-      - "65"
+      - "63"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:17 GMT
+      - Thu, 02 Nov 2023 18:53:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3050,7 +3050,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97fca3e2-12ea-4420-bd15-186432ffd749
+      - 87983389-e461-468b-9d72-f5f816683a97
     status: 200 OK
     code: 200
     duration: ""
@@ -3061,19 +3061,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:17 GMT
+      - Thu, 02 Nov 2023 18:53:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3083,7 +3083,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14e8ac47-d283-43af-8fe1-586e974c3786
+      - 5d874698-7ae3-4b3d-a140-a292e8654f43
     status: 200 OK
     code: 200
     duration: ""
@@ -3096,118 +3096,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"none","user_name":"user_03"}'
     headers:
       Content-Length:
-      - "67"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b494f0b2-baea-47d4-844f-f1e7073d84d2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0eabd6c4-ddf5-461f-9657-bd7572b66c34
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 15550a09-35bf-4810-8942-b11606b5f5ca
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_03&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
-    headers:
-      Content-Length:
       - "65"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:18 GMT
+      - Thu, 02 Nov 2023 18:53:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3217,7 +3118,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93c68b56-117e-4f04-b9e0-977624f88dcd
+      - 2b8d052c-b346-4867-9801-713411da3de5
     status: 200 OK
     code: 200
     duration: ""
@@ -3228,19 +3129,118 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1266"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c5962e64-005c-47a7-8eb5-9049dffe17db
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1266"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3b44f152-f325-454b-80e0-fdcf8c3c3514
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_03&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 00fbc1c3-51d6-4017-8c56-d7e3044a6e71
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"none","user_name":"user_03"}],"total_count":1}'
     headers:
       Content-Length:
-      - "101"
+      - "98"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:18 GMT
+      - Thu, 02 Nov 2023 18:53:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3250,7 +3250,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35f856a8-9649-461f-9bc7-c8ed73c21669
+      - bd95e02c-1a49-46a1-bca2-f4efc024bf59
     status: 200 OK
     code: 200
     duration: ""
@@ -3261,19 +3261,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"none","user_name":"user_03"}],"total_count":1}'
     headers:
       Content-Length:
-      - "101"
+      - "98"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:18 GMT
+      - Thu, 02 Nov 2023 18:53:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3283,7 +3283,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6fccdc4-289e-4a7a-ba48-2ffc827aad7a
+      - 1800380e-7a1d-4618-90ef-deb393c2d731
     status: 200 OK
     code: 200
     duration: ""
@@ -3294,19 +3294,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:19 GMT
+      - Thu, 02 Nov 2023 18:53:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3316,7 +3316,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b2e0cbd-e5c4-4e28-b065-77e5c6d10127
+      - 6306b919-f921-468d-8122-46ec5adc786d
     status: 200 OK
     code: 200
     duration: ""
@@ -3327,19 +3327,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTEt3ZU1sTkw2RDJhZW53UHREQnM4VnowaHFRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5UVTVXaGNOTXpNeE1ERTNNVFUxTlRVNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUkwQVJDTnh4a2NyMHk5QzhIbnAxak5qT3pvWlI1L3k1dW5icnVxUTJuSTRwaXdwNzQrZUN5OGQKaXpxQlN3Mjl5cFZCejFrcnNKeHpUVDhBRVdTL1FqN3BseVBHbXA3YzU0OHZnTHdCTXhUTkw3RGo2VFJsQksxeAoxeEhpUkJGcDY5cTBzOWxBNUpGNGUySGo2K0N1cHR3Wk5aQlV3YzliTFRqU0ZxK2kzTkZ2Ynptd2FpaVVoV3diCklLOXZWQ0NYOHJ1N0hqRlp2TXhNV0hkTGFuYTJ5dUlvMTRHUUlEQTRHWExtZjlzbzBVZ0JKOTBxc2tEMDhiQmcKUkQwS3dkZmxpRzJBNk1taVlMekl5WWQvTXAyMmRaU3dkYjhNaCt0L0dzQ2dlYmlOdmJXRXViVlptcjBsNmF6Tworck1DZ3VTNjJiS0pxWlR2VE96WlcxcjlhS0pJV1RrQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0WmpabU56STRPVEV0WXpWaE9TMDBOREJtTFdJelpHUXRNRFkyTldZM05UYzAKT1dKakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhEWGh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQUJncHBBL0Y4K1ZSMXBydFNJSVduSlBOU2VxTmFRTmMrTVIwTjUvVUQrOENYcTRaTG9va0tVClRza1pwSjVNUS9hVlF6eFdaSlNRR2lDNmZPcHR4cWhyR25zTk90d2ZxY0VBTk02UWJEQUVDK29zUmJ4WE8zd24KTnlzaW1JbE9NdmczaGtlaTJYY3ZtNU8vMGE3dlJxZnZVeDJDaGkyUmdISkQyVHVxdFU3bEVxZW9LNkkvUUdTUQpyQVFXOEhBellaS3l4azFFQ0Q4ejhkUlBqYlNSOGxHK1EzQTdqWGcwUnNENll4cnllQ0NvbmtNN0MwZktpc3hVCmd2U2FqZ2tsQmZzMWpOb05BOFNDaS8xaUVpNjV6dFlRSFBraDkzRlRreDROSnpuaXBsbE9GWEI4dlFlSVRBM3cKdXlCVExITHRoK1AwZXU5WHB1RVJHUHVtKy9pMzhsemIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTVRIM1R0Rk84N3NvNURydENXSkRXbUpQVGo4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1UTXdXaGNOTXpNeE1ETXdNVGcxTVRNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUt5WW9PNGNIZ0tKVmVuY0xpL1FLMTlHcTBzTzczL1BMRy91QU1IMkJXMXB5THNXbkphRWZKRUgKbUpuTTNQOTdhVGJVZkwzQUYyOXVEaEhqMWI0ZHMyLzA0RWQ3SmgvaXhUQnE4WXRwc3dtVmZCcTBkTWJYTkVXZApjRlpYdERxbHExOGhuc1JJS2VMNEVpQ21KWHRxS0dnNk1KQm44ejNiTkREZk1QOWFtZUFVMFJuVkk5U1N0Q1hiCmFJN2N6eDY3L2lkRXdzT2NkWXdLYTlxTEZNdjBzL25WRWZIdXdkc2RLaEhBOC9Ub3dOSEVHMElYSFN5ay9JcHAKdkxWeENQNGtwN0VsSnpwZnFJZkxUV3hhQlV6cDZadWxHZy9RNlBtTm1VMVZPelFaUnYxMXJZbytVYk9YMUFLWgpyVmRaRTJkbnVTUC9UNlN6UXhuQlc5VVE1TmtjSzBzQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TldKbE1URm1NelF0Wm1Nek9TMDBOell3TFdJME5qRXROV1l5WW1FM1lXVTMKTmpNMUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1N5RXZjNDArczdzRk0rdlNCN05OWGV6ZFo3eFRlZVZjYmhFTVJMY0xaK2VNN0VRK1NaT1BaCnhzZjhXejh2Zk5RQ2lwWEttQ0ZCZjhnaFFnVE85djVzTi9aK0xhZ1FpV1o1VlNhNzI0dTMySkMzWTdQV3ExWC8KT1V6RWJXeFJxL2ZDUmhhcFNYUzJGbmUycDJsVVBTV3hic2YzZlJ1azBtNVk4dzZaSVJnOGRUN1ptcVd3Y1pJRgoxQmVlTDdWOVd0QWd4QitIMjNvZG1FZVNFTnlrVDF2eXB5Rk4wSjkvVXNKN2QxTDNrNTUrOXlXbkVpaC9lbHdHCk00Y1NYRWgyOHQ0YjM5eklJT2MyNEVJTXRwV1JnQ3owVG4rOE5PTml3RkRBcTNjcU5POWhGK2VtOHZud2RuRVAKY1ZHZHU0SXFKdFpMZ0t2ZkpCVTBmQ3FsUThIRmVGWXEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:19 GMT
+      - Thu, 02 Nov 2023 18:53:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3349,7 +3349,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d971ae10-833f-45f4-9012-cafcecac31d6
+      - 6a552f7c-40c4-4ed7-b731-734a41d0c4e9
     status: 200 OK
     code: 200
     duration: ""
@@ -3360,19 +3360,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:19 GMT
+      - Thu, 02 Nov 2023 18:53:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3382,7 +3382,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72973dca-14a4-440d-aa00-6b24253433d4
+      - 077648d3-c9cc-4018-87b7-7183ef85ca9b
     status: 200 OK
     code: 200
     duration: ""
@@ -3393,52 +3393,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a658e718-9400-495f-a6a6-724a0310a157
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
-      - "106"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:19 GMT
+      - Thu, 02 Nov 2023 18:53:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3448,7 +3415,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f10bd0bc-04b6-4a50-ad0a-d4f542043e4a
+      - 4c0d70c8-d45f-4144-ab2a-439658311721
     status: 200 OK
     code: 200
     duration: ""
@@ -3459,19 +3426,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:19 GMT
+      - Thu, 02 Nov 2023 18:53:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3481,7 +3448,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ace59456-49df-4ec8-a4b3-17922cd9aee8
+      - 3a022f6d-bd81-4857-99a7-34e8277cf5ce
     status: 200 OK
     code: 200
     duration: ""
@@ -3492,19 +3459,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "65"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:19 GMT
+      - Thu, 02 Nov 2023 18:53:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3514,7 +3481,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0d83b3f-3f14-43a8-aa77-d907e00bc1df
+      - 0c1918ff-34a4-45d7-9927-6f9696f57d97
     status: 200 OK
     code: 200
     duration: ""
@@ -3525,184 +3492,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_01&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
-    headers:
-      Content-Length:
-      - "64"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e8ff0e25-0388-49e3-8c0a-a71344ba2361
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_03&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
-    headers:
-      Content-Length:
-      - "65"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b808e827-12cc-4618-9ce9-94d4d0b96b86
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c321a01f-4e8f-4ba0-96ee-88421d3471af
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b1f98939-e917-4033-8c6a-78164586fb3f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7d4376ad-f898-408d-a7d0-ed265419cecf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
     headers:
       Content-Length:
-      - "64"
+      - "62"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:20 GMT
+      - Thu, 02 Nov 2023 18:53:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3712,7 +3514,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7f7c48d-09ae-49a5-852c-17a65830fd37
+      - ebef4a87-0a90-4277-91c4-7353a476d8e9
     status: 200 OK
     code: 200
     duration: ""
@@ -3723,52 +3525,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_02&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
-    headers:
-      Content-Length:
-      - "65"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 97b1c896-19fb-4f96-9655-8fd3beceec83
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_03&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_03&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
     headers:
       Content-Length:
-      - "65"
+      - "63"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:20 GMT
+      - Thu, 02 Nov 2023 18:53:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3778,7 +3547,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7480579-1dfe-4a39-8a20-9e4743429e46
+      - 809416d5-9607-4d44-8c80-2eff9097cc98
     status: 200 OK
     code: 200
     duration: ""
@@ -3789,19 +3558,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"privileges":[{"database_name":"foo","permission":"none","user_name":"user_03"}],"total_count":1}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "101"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:20 GMT
+      - Thu, 02 Nov 2023 18:53:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3811,7 +3580,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d74232d4-908f-4074-8830-49722deeda9a
+      - 2255aa28-bb1f-4fe1-b632-6e4472bfee06
     status: 200 OK
     code: 200
     duration: ""
@@ -3822,19 +3591,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "106"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:20 GMT
+      - Thu, 02 Nov 2023 18:53:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3844,7 +3613,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29a5faac-de05-4c36-9ed6-a362ca1f4011
+      - ff6553be-1bdf-4cb2-88be-7a586e77e8f2
     status: 200 OK
     code: 200
     duration: ""
@@ -3855,19 +3624,151 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
+    headers:
+      Content-Length:
+      - "62"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7a42d7a7-9423-4c63-a95b-74008f5c4ba2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_02&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8ccc2e31-c89a-4e2b-8f28-ca07a70715a4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_03&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 46701dd9-66fd-429a-8fd2-83ba51cc54e8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1266"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 757bf973-7a5f-4471-9f96-8ef69c9aa8cf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
     headers:
       Content-Length:
-      - "100"
+      - "97"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:20 GMT
+      - Thu, 02 Nov 2023 18:53:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3877,7 +3778,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 295013b9-e858-4052-8438-2e88743cb77a
+      - 9aa6149f-897d-41ed-925f-3e7a96e5ee08
     status: 200 OK
     code: 200
     duration: ""
@@ -3888,184 +3789,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 438fd716-e5f1-4876-b9b2-f740504dd1b6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d54134f6-d83d-4c9e-85ca-c1843860fede
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a7bf677a-8874-48a8-8971-34ef8dc46faa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_01&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
-    headers:
-      Content-Length:
-      - "64"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 57b0da1c-5d9e-4dc4-95aa-247b7f483733
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_03&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
-    headers:
-      Content-Length:
-      - "65"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fff50aa9-8de4-4be6-8ec1-f700f37ede8e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
     headers:
       Content-Length:
-      - "65"
+      - "63"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:22 GMT
+      - Thu, 02 Nov 2023 18:53:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4075,7 +3811,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f83d9770-07e1-4274-b9ce-9e0019e73648
+      - 20709132-d725-41c0-bd09-c7742033e56f
     status: 200 OK
     code: 200
     duration: ""
@@ -4086,19 +3822,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
     method: GET
   response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
+    body: '{"privileges":[{"database_name":"foo","permission":"none","user_name":"user_03"}],"total_count":1}'
     headers:
       Content-Length:
-      - "64"
+      - "98"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:22 GMT
+      - Thu, 02 Nov 2023 18:53:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4108,7 +3844,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9cc1db0-3164-4f0a-aeac-99f93495a1d2
+      - d049d741-55c2-4204-b53f-7e6b6fea0d3e
     status: 200 OK
     code: 200
     duration: ""
@@ -4119,19 +3855,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_03&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
     method: GET
   response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
+    body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
     headers:
       Content-Length:
-      - "65"
+      - "103"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:22 GMT
+      - Thu, 02 Nov 2023 18:53:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4141,7 +3877,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4ee3cec-ea7a-4218-9518-bb883dc333a2
+      - 6e1e2603-9427-4c6c-83d2-a4fe8eb6e808
     status: 200 OK
     code: 200
     duration: ""
@@ -4152,19 +3888,118 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1266"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6bee0eec-0943-4117-8916-5902f80a14e3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1266"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f3d0bb8d-b23f-47b2-a208-af068cc9641d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1266"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 477377d7-800e-4e57-83f4-752f5bc37547
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
     headers:
       Content-Length:
-      - "65"
+      - "63"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:22 GMT
+      - Thu, 02 Nov 2023 18:53:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4174,7 +4009,172 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d28bd18c-55f3-4229-933c-d9cdcee8fe6b
+      - 25ae02ee-c6d1-432a-a871-8d7b79368b94
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_03&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 90e34249-033b-44be-b136-471d7bf9f9b4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
+    headers:
+      Content-Length:
+      - "62"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 22a75ec7-5015-4cd3-adfb-f5d025b61a28
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_02&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d8abf053-d721-418d-a746-6a1697c1c97e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
+    headers:
+      Content-Length:
+      - "62"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - eac80cca-43ce-49ae-ae49-0b151741b90d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_03&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6f074872-70d3-4a0b-9e5b-8f4f30a0141c
     status: 200 OK
     code: 200
     duration: ""
@@ -4187,309 +4187,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"none","user_name":"user_02"}'
-    headers:
-      Content-Length:
-      - "67"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b0d3e0d2-c32e-427d-9c68-d02fcddf54ef
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"database_name":"foo","user_name":"user_03","permission":"none"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges
-    method: PUT
-  response:
-    body: '{"message":"Tuple concurrently updated"}'
-    headers:
-      Content-Length:
-      - "40"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5cdd272b-1b75-4544-98bd-a8a15ffc02ce
-    status: 409 Conflict
-    code: 409
-    duration: ""
-- request:
-    body: '{"database_name":"foo","user_name":"user_01","permission":"none"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges
-    method: PUT
-  response:
-    body: '{"message":"Tuple concurrently updated"}'
-    headers:
-      Content-Length:
-      - "40"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - febe20f9-b4b7-4d04-8eda-03dc567caf69
-    status: 409 Conflict
-    code: 409
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7b1e9dad-a192-4df5-a355-935eb7e3082d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1eec4439-c9bb-42eb-8e5c-fb1ee5600abc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fa1b3b18-2406-45db-980b-f7c8f0cb41c0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d94fb11f-7454-404e-978c-cadbfa7d32a5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users/user_02
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 87fa22d3-dc3d-44e2-90ad-aa0f543e023d
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_01&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
-    headers:
-      Content-Length:
-      - "64"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 81f71894-c38c-48f5-883e-564221c7eb22
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_03&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
     headers:
       Content-Length:
       - "65"
@@ -4498,7 +4199,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:23 GMT
+      - Thu, 02 Nov 2023 18:53:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4508,7 +4209,42 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6714256a-0d03-4200-ac74-fac509ca9859
+      - 1916e48b-7c40-40c7-a6af-862efbe8136c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"database_name":"foo","user_name":"user_01","permission":"none"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges
+    method: PUT
+  response:
+    body: '{"database_name":"foo","permission":"none","user_name":"user_01"}'
+    headers:
+      Content-Length:
+      - "65"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b09a536a-aded-466f-9815-33dacbf7ccea
     status: 200 OK
     code: 200
     duration: ""
@@ -4521,19 +4257,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"none","user_name":"user_03"}'
     headers:
       Content-Length:
-      - "67"
+      - "65"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:23 GMT
+      - Thu, 02 Nov 2023 18:53:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4543,44 +4279,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3f98cf5-d53a-42bd-9b35-685adedeadfb
+      - ec39096c-6884-4aa3-bf0f-6730f399f03b
     status: 200 OK
     code: 200
-    duration: ""
-- request:
-    body: '{"database_name":"foo","user_name":"user_01","permission":"none"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges
-    method: PUT
-  response:
-    body: '{"message":"Tuple concurrently updated"}'
-    headers:
-      Content-Length:
-      - "40"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9deaf3a3-d015-47bb-8bb9-7705eac04ed0
-    status: 409 Conflict
-    code: 409
     duration: ""
 - request:
     body: ""
@@ -4589,19 +4290,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:23 GMT
+      - Thu, 02 Nov 2023 18:53:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4611,7 +4312,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9fcc5f6f-b5cf-41a0-89ff-7f1f9bcdd8e3
+      - 98ef50d4-8986-4b26-925a-06f0ba543743
     status: 200 OK
     code: 200
     duration: ""
@@ -4622,19 +4323,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:23 GMT
+      - Thu, 02 Nov 2023 18:53:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4644,7 +4345,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7192b4c5-141c-40a5-85d9-71c4628b63e5
+      - 023bf09e-bedc-4431-a0f8-7a2e14b6fda2
     status: 200 OK
     code: 200
     duration: ""
@@ -4655,19 +4356,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1316"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:23 GMT
+      - Thu, 02 Nov 2023 18:53:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4677,7 +4378,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2129003-86b1-4cf8-b9dd-2921cddc9d3b
+      - 205dd890-f930-4112-b97c-e8d026541df0
     status: 200 OK
     code: 200
     duration: ""
@@ -4688,7 +4389,139 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users/user_03
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1266"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a129ea4b-f287-46d4-9fdf-daf1a2d58306
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1266"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 67570150-7e0a-4844-bd3e-ff18bd4e8020
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1266"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bc26207f-7434-44ce-a0cf-549805fe1748
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1266"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 75927181-e3d6-45a9-8db1-51fa932ef0cb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users/user_01
     method: DELETE
   response:
     body: ""
@@ -4698,7 +4531,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:24 GMT
+      - Thu, 02 Nov 2023 18:53:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4708,7 +4541,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f19eb58b-e084-445a-873d-ecf7176d55b3
+      - 8b35c887-beba-470c-a7d2-80674ed5953b
     status: 204 No Content
     code: 204
     duration: ""
@@ -4719,174 +4552,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users?name=user_01&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
-    headers:
-      Content-Length:
-      - "64"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 53a0ae12-25f9-4234-b5e7-e153654562fc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"database_name":"foo","user_name":"user_01","permission":"none"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/privileges
-    method: PUT
-  response:
-    body: '{"database_name":"foo","permission":"none","user_name":"user_01"}'
-    headers:
-      Content-Length:
-      - "67"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 983272b9-8151-4560-a8d8-da9171c3ea74
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d59aaa3f-effe-4bb2-94a2-6034aa43914d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 139e2711-2b54-4897-a1b8-92f5b6b7caba
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7767e81d-7d84-40f6-a674-4bbd2ea541a0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/users/user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users/user_03
     method: DELETE
   response:
     body: ""
@@ -4896,7 +4562,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:25 GMT
+      - Thu, 02 Nov 2023 18:53:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4906,7 +4572,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b543c4c-89ec-4e50-aa26-309f93ab4c76
+      - 61692c51-b449-4039-b7a4-a65540b1b4f8
     status: 204 No Content
     code: 204
     duration: ""
@@ -4917,7 +4583,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc/databases/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users/user_02
     method: DELETE
   response:
     body: ""
@@ -4927,7 +4593,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:25 GMT
+      - Thu, 02 Nov 2023 18:53:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4937,7 +4603,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a508052b-8470-43c0-a438-273ae874b7bd
+      - 56fa3998-60c3-4dc5-a1ed-a7850997911f
     status: 204 No Content
     code: 204
     duration: ""
@@ -4948,85 +4614,17 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fe2e945e-0d5d-4ddf-8b64-5c07088fe2f9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:58:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 64d3c8b9-1b09-4b74-acdf-9e37f7e52cb6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/databases/foo
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: ""
     headers:
-      Content-Length:
-      - "1319"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:26 GMT
+      - Thu, 02 Nov 2023 18:53:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5036,7 +4634,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8eb0e97-6309-4634-94dd-45c87f283c38
+      - 31ac2a79-7a4a-4dc6-ade7-d2323348e6b7
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1266"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c96d5619-f932-4381-905e-e1c7ae88e76a
     status: 200 OK
     code: 200
     duration: ""
@@ -5047,19 +4678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:55:15.914178Z","retention":7},"created_at":"2023-10-20T15:55:15.914178Z","endpoint":{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874},"endpoints":[{"id":"f5fa93bd-66d0-4f32-9cd5-573654e06dd1","ip":"51.159.26.148","load_balancer":{},"name":null,"port":27874}],"engine":"PostgreSQL-15","id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1319"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:26 GMT
+      - Thu, 02 Nov 2023 18:53:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5069,7 +4700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2eaf5cc8-31ff-491c-9a95-0f5ba83913b3
+      - 904439a5-085b-42fd-8e9a-48f201d59e2c
     status: 200 OK
     code: 200
     duration: ""
@@ -5080,10 +4711,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    method: DELETE
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1269"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3ad66ee9-88ec-400f-9259-aecd17bce26b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","type":"not_found"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1269"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d1586854-0848-43c6-ad10-0f88ac632af0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -5092,7 +4789,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:57 GMT
+      - Thu, 02 Nov 2023 18:54:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5102,7 +4799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dfe5aa21-4103-4bc6-a9b4-14016071e340
+      - 660e184d-e75c-4ee2-a572-90e744248bd4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5113,10 +4810,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f6f72891-c5a9-440f-b3dd-0665f75749bc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"f6f72891-c5a9-440f-b3dd-0665f75749bc","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -5125,7 +4822,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:58 GMT
+      - Thu, 02 Nov 2023 18:54:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5135,7 +4832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90496c4d-0ecc-438c-af77-b47f8e25c9c6
+      - 25d89a00-471f-4954-93c5-bd9b36e8de18
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:07 GMT
+      - Thu, 02 Nov 2023 18:46:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bbd636d9-8cef-4de1-9191-8efbf8d8a3ae
+      - 72f0c057-690f-4125-b16e-ee89cb5bee18
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-basic","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-basic","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:20.199545Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6b3a8078-c07a-438c-8745-4c783c8d091d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "761"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:20 GMT
+      - Thu, 02 Nov 2023 18:55:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9e95ad3-519f-4a37-ad71-81e6f30c3523
+      - 72f37f5d-bfa9-4d1c-a626-3167c236f796
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b3a8078-c07a-438c-8745-4c783c8d091d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:20.199545Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6b3a8078-c07a-438c-8745-4c783c8d091d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "761"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:20 GMT
+      - Thu, 02 Nov 2023 18:55:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39af4d7a-ed3c-4bbc-a902-3cdf9c50a179
+      - 38dfb1fa-89a9-4ec9-9756-c5bf71a21e34
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b3a8078-c07a-438c-8745-4c783c8d091d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:20.199545Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6b3a8078-c07a-438c-8745-4c783c8d091d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "761"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:51 GMT
+      - Thu, 02 Nov 2023 18:55:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce28705f-09ea-4f54-aea5-6b6b4bfc0a6f
+      - 490c9f98-ecb4-40a7-a505-fc96a872b1c2
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b3a8078-c07a-438c-8745-4c783c8d091d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:20.199545Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6b3a8078-c07a-438c-8745-4c783c8d091d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "761"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:21 GMT
+      - Thu, 02 Nov 2023 18:56:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bdc429f0-4cdc-452e-a7c2-c5f6222a2b73
+      - ce422b62-5327-44b3-a307-1d11b7ed084b
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b3a8078-c07a-438c-8745-4c783c8d091d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:20.199545Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6b3a8078-c07a-438c-8745-4c783c8d091d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "761"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:51 GMT
+      - Thu, 02 Nov 2023 18:56:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e47fc5f8-b273-4c2b-8956-60d0234f981d
+      - c242036a-3e2a-43cd-889d-9a8f84135cce
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b3a8078-c07a-438c-8745-4c783c8d091d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:20.199545Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6b3a8078-c07a-438c-8745-4c783c8d091d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "761"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:22 GMT
+      - Thu, 02 Nov 2023 18:57:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 522cd6c2-eca7-43bb-a32d-0d911c5e7485
+      - 08643e86-152d-4308-ad67-e30077aff338
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b3a8078-c07a-438c-8745-4c783c8d091d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:20.199545Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6b3a8078-c07a-438c-8745-4c783c8d091d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "761"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:52 GMT
+      - Thu, 02 Nov 2023 18:57:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09cb61aa-a0d5-433c-9706-6aa8a105bd70
+      - cac49795-15ac-493a-80be-9aaa3aff8354
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b3a8078-c07a-438c-8745-4c783c8d091d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:20.199545Z","endpoint":{"id":"075e3bbe-40ae-4ef0-b23a-e5ea0a5b6c00","ip":"51.159.26.148","load_balancer":{},"name":null,"port":18311},"endpoints":[{"id":"075e3bbe-40ae-4ef0-b23a-e5ea0a5b6c00","ip":"51.159.26.148","load_balancer":{},"name":null,"port":18311}],"engine":"PostgreSQL-15","id":"6b3a8078-c07a-438c-8745-4c783c8d091d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":{"id":"98a23d73-ee9a-458d-b37b-9e9e859cccca","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16286},"endpoints":[{"id":"98a23d73-ee9a-458d-b37b-9e9e859cccca","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16286}],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1282"
+      - "1234"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:22 GMT
+      - Thu, 02 Nov 2023 18:58:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf445ea4-bb98-4268-868c-d4bfe4006b77
+      - 4cad62a7-10ad-420d-a225-ec4847721fdc
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b3a8078-c07a-438c-8745-4c783c8d091d/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVRVpQakx1ZzBMMGJIMDdnYVNEaXVmaC9ldXY0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU9EVTVXaGNOTXpNeE1ERTNNVFUxT0RVNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1sVkgvTzZoZW95eHB3MmxEdFJVck9RVXJzOFhaMWVtV21qbmxWWTVNNC9MUFE5Q09UWlBCek0KQUliUDNSem4rci8zanM0OTRBNzhuS3JaMVNiYWxFT2M3cTBNOUd6TnQ2R1BSbjRlS0FYbUtwcHpSQ2pMc2NEdAo0OVdtTmNpS0Y3REZVSDVxMWxmQjdHalZQc0lHcEUyYitPMFNEVFJ4ZlZBM1Ywd1FSRm5nRGpuZzdKbnRvZVRMCitrcnROWDFrNldvTUlsVEkzcUt6NG9NREF3b0hhS3NTdVVYZXlDZDVSRzVzUlUwYXJDV1lwZFdDRFlZS0JzR1oKekdVazRjUEdxaWVMaVNkVFB3ODU0SDRJbGkrOGJnU0w2Z1RYUFIwVFZ3WTZGdjFBdkxYWGlHdWdPazZaeWdXWQo4bnpBMXk2Nzdza3cvNVM2YkpteDdEMkRmNC9tMTFjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0Tm1JellUZ3dOemd0WXpBM1lTMDBNemhqTFRnM05EVXROR00zT0ROak9HUXcKT1RGa0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhaYWh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRREZEMlBEenFnVHc2NDlCQy9memtHWnllMXkxSTh3MW5SOTFDUC81RHVGMzdwWHAyekVWd2VqCkJhOFhLU1p2VmRETUJ2d2tpZ1RMTklTdG04TzhIdzhFYWxIMGlTTENYM2ZwYlJJRVV2T2tlTHJ0ZFZJbGU1OEgKN3Qyem1LRlVQUnpPcWxJdGpvK1dkeXFqR0VaRC9ScXR3aFBkWXJZSkVJc2ZiTDZsd3N1Y3N1UnFkTlJGSDROaQpoMkNhaUozL1IwRFBkbE1lUTlwdVdzT1pmb3FHTWNoRHgzZTVzU01sZVNRL2xSV3Zoc214d3g3N1c0K21nWi9BCmx1cDh1VTYzTHVidmZyd3M1MWFlZk1UQlU5VGZ2Rmg4TGJiNHlHVy83V09ZN2ltUEgvY0lJa0d3WTROK2JZVFgKcnI2WW5tZXZxeENGMHEreCtsMkhpRXFRN3c1NG9LMU8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmhOU1RDc0JCeURnb3IyZmZNT0dsYXRlRE5Fd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnMU5UUXhXaGNOTXpNeE1ETXdNVGcxTlRReFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU56K2Y0dGdFWG1tSEk1dkE3VDVZVjhHeUlMenMreWxtNzBWbnlUdll4ZUovSDhLL0ZwUXZMVmYKMFhjSEVVUHhPdDJNQXgza2dFM2RGVHFvMjUyZkswcFY5MWNFKzdnM2lYd3Nya1JzZGFNVktscHByYVhtYjRpNgpQZ1NDZ0xUcmIwMFNiVFYzMDhaNmZNY0Q1K1g2Tm1OalRBWXNhbUlSdWRzcGxwSGVHM3g5THNRZ3JMTDJNTWhMCm9wUjRnQno5Q3hyVXZZbWFnaHpUYm43NHQrZkdsLzRPUnZleWFoWUo2cSt0UEFIWHVLYnM1RDRneXAwVmF6OUoKSThXaW5MTjlkamJiYURkNXhZMllUZXA4VC9yMVZmVk9nYy8xM0pMOGpUQldFQlVYUmhKODY5QkxpQ09oOVZiZApva00zNE5ES0t6S3VkUm5hMmkzTG04NzhlWUtaWFhFQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WXpka01qRTJOamt0T1dNMU1pMDBOelUyTFRsaE4yVXRaak16WkRkak4yWmwKTURFMkxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1VqRXhTMWJTclNOWHEweThESUg0SDQ2Z2lWcDJyem9Ibm82N2hLUm95aXU5RWxPcGY4emR1CmdDZmFBK2UzbmVkKytPdDcwOExDNmVRelRqcVFqMG5TT1p1MmhUQjFPUSs5NjhFbWVXclJWS3ZGZ3RsYlpJZkoKVmEycXgxQzhHZnc5dURzaFZYWjFwSTk0Qm9kVm9GbVNiNnF5YmxJalp4SFBPSzcwNVBrTitvVHFINzBBeDQxZAo5UzZGK3pUamVZZnpBejVWdXBQbkNwazI5cmMwNUkxMHhFR0RjbFpxMmxEZDlDQzZFRmZjeE5ROEtrcm5peFg5CjFUbEN5alZkWTNPOERpekV2Mk4zUVZQOEE4M1NtMzZES2pHVXBPMTVCWkk1eGtibDJWS2k0Ukd1b1Y4UlhNMmEKSlgwUy8vdk9zdVRxYXNhK0ZJamlBUFBHSVRwOUpwa0MKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:22 GMT
+      - Thu, 02 Nov 2023 18:58:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,12 +627,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d165e7eb-14ec-4a9a-b7e9-148637ca60e5
+      - d3cea81a-fcb6-4fef-bbaa-ae753af6c0a7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"6b3a8078-c07a-438c-8745-4c783c8d091d","endpoint_spec":[{"direct_access":{}}],"same_zone":null}'
+    body: '{"instance_id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","endpoint_spec":[{"direct_access":{}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
@@ -643,16 +643,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[],"id":"2666f31a-938d-4da8-a504-61ade33abcff","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "123"
+      - "119"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:23 GMT
+      - Thu, 02 Nov 2023 18:58:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7308fec6-3eed-44eb-8c30-f389dfa9d432
+      - 3b6db845-8709-4ae6-a5b4-98bd18b0b57f
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2666f31a-938d-4da8-a504-61ade33abcff
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
     method: GET
   response:
-    body: '{"endpoints":[],"id":"2666f31a-938d-4da8-a504-61ade33abcff","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "123"
+      - "119"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:23 GMT
+      - Thu, 02 Nov 2023 18:58:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7bb540c-d3b1-4046-961d-bfdc5f31aaf3
+      - a5b127ec-c53d-4128-8e51-f93bba9f1fe1
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2666f31a-938d-4da8-a504-61ade33abcff
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"de60c04b-f548-4b5b-994e-f93908a78ff2","ip":"51.158.106.174","name":null,"port":5432}],"id":"2666f31a-938d-4da8-a504-61ade33abcff","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "237"
+      - "119"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:53 GMT
+      - Thu, 02 Nov 2023 18:58:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 310707d6-3758-4473-af6f-f9529a36b67f
+      - d1bda7af-5c33-4a6b-951a-0234a25d15bf
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2666f31a-938d-4da8-a504-61ade33abcff
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"de60c04b-f548-4b5b-994e-f93908a78ff2","ip":"51.158.106.174","name":null,"port":5432}],"id":"2666f31a-938d-4da8-a504-61ade33abcff","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "237"
+      - "228"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:23 GMT
+      - Thu, 02 Nov 2023 18:59:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b359f3d-e911-47ac-8936-10037f03b93c
+      - a6f0c81b-dc24-4e25-9c11-052171a8dcc1
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2666f31a-938d-4da8-a504-61ade33abcff
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"de60c04b-f548-4b5b-994e-f93908a78ff2","ip":"51.158.106.174","name":null,"port":5432}],"id":"2666f31a-938d-4da8-a504-61ade33abcff","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "237"
+      - "228"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:53 GMT
+      - Thu, 02 Nov 2023 18:59:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d5fe29e-41df-42c2-9d65-092b52512043
+      - 8b0348db-625b-4d2b-b7aa-95cf17679308
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2666f31a-938d-4da8-a504-61ade33abcff
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"de60c04b-f548-4b5b-994e-f93908a78ff2","ip":"51.158.106.174","name":null,"port":5432}],"id":"2666f31a-938d-4da8-a504-61ade33abcff","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "237"
+      - "228"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:23 GMT
+      - Thu, 02 Nov 2023 19:00:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd5e89d4-0dee-4bfd-a9d1-ff7d2a3da5fe
+      - c7201690-ed63-400f-96cc-5b466cae6369
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2666f31a-938d-4da8-a504-61ade33abcff
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"de60c04b-f548-4b5b-994e-f93908a78ff2","ip":"51.158.106.174","name":null,"port":5432}],"id":"2666f31a-938d-4da8-a504-61ade33abcff","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "230"
+      - "228"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:53 GMT
+      - Thu, 02 Nov 2023 19:00:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43eaa8ef-2df8-4d94-a48d-f5564b5bd7ea
+      - 77f395de-1b83-448b-9dcf-0eee413bf827
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2666f31a-938d-4da8-a504-61ade33abcff
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"de60c04b-f548-4b5b-994e-f93908a78ff2","ip":"51.158.106.174","name":null,"port":5432}],"id":"2666f31a-938d-4da8-a504-61ade33abcff","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "230"
+      - "221"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:53 GMT
+      - Thu, 02 Nov 2023 19:01:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85cdafda-c630-4c02-b54b-b2629d98530e
+      - d476699a-73fc-47af-b869-3b63411f8149
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2666f31a-938d-4da8-a504-61ade33abcff
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"de60c04b-f548-4b5b-994e-f93908a78ff2","ip":"51.158.106.174","name":null,"port":5432}],"id":"2666f31a-938d-4da8-a504-61ade33abcff","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "230"
+      - "221"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:54 GMT
+      - Thu, 02 Nov 2023 19:01:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d33f3e2a-6ffc-4b66-a0c6-88402471bb12
+      - 748305b1-2293-4cf9-9ec8-ede408c833d8
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b3a8078-c07a-438c-8745-4c783c8d091d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:20.199545Z","endpoint":{"id":"075e3bbe-40ae-4ef0-b23a-e5ea0a5b6c00","ip":"51.159.26.148","load_balancer":{},"name":null,"port":18311},"endpoints":[{"id":"075e3bbe-40ae-4ef0-b23a-e5ea0a5b6c00","ip":"51.159.26.148","load_balancer":{},"name":null,"port":18311}],"engine":"PostgreSQL-15","id":"6b3a8078-c07a-438c-8745-4c783c8d091d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"direct_access":{},"id":"de60c04b-f548-4b5b-994e-f93908a78ff2","ip":"51.158.106.174","name":null,"port":5432}],"id":"2666f31a-938d-4da8-a504-61ade33abcff","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "1512"
+      - "221"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:54 GMT
+      - Thu, 02 Nov 2023 19:01:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60f3762f-5c2e-4f45-b0b9-55f24d416679
+      - 9c87c23c-3f52-4bb5-9ef4-f86960b555e7
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b3a8078-c07a-438c-8745-4c783c8d091d/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVRVpQakx1ZzBMMGJIMDdnYVNEaXVmaC9ldXY0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU9EVTVXaGNOTXpNeE1ERTNNVFUxT0RVNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1sVkgvTzZoZW95eHB3MmxEdFJVck9RVXJzOFhaMWVtV21qbmxWWTVNNC9MUFE5Q09UWlBCek0KQUliUDNSem4rci8zanM0OTRBNzhuS3JaMVNiYWxFT2M3cTBNOUd6TnQ2R1BSbjRlS0FYbUtwcHpSQ2pMc2NEdAo0OVdtTmNpS0Y3REZVSDVxMWxmQjdHalZQc0lHcEUyYitPMFNEVFJ4ZlZBM1Ywd1FSRm5nRGpuZzdKbnRvZVRMCitrcnROWDFrNldvTUlsVEkzcUt6NG9NREF3b0hhS3NTdVVYZXlDZDVSRzVzUlUwYXJDV1lwZFdDRFlZS0JzR1oKekdVazRjUEdxaWVMaVNkVFB3ODU0SDRJbGkrOGJnU0w2Z1RYUFIwVFZ3WTZGdjFBdkxYWGlHdWdPazZaeWdXWQo4bnpBMXk2Nzdza3cvNVM2YkpteDdEMkRmNC9tMTFjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0Tm1JellUZ3dOemd0WXpBM1lTMDBNemhqTFRnM05EVXROR00zT0ROak9HUXcKT1RGa0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhaYWh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRREZEMlBEenFnVHc2NDlCQy9memtHWnllMXkxSTh3MW5SOTFDUC81RHVGMzdwWHAyekVWd2VqCkJhOFhLU1p2VmRETUJ2d2tpZ1RMTklTdG04TzhIdzhFYWxIMGlTTENYM2ZwYlJJRVV2T2tlTHJ0ZFZJbGU1OEgKN3Qyem1LRlVQUnpPcWxJdGpvK1dkeXFqR0VaRC9ScXR3aFBkWXJZSkVJc2ZiTDZsd3N1Y3N1UnFkTlJGSDROaQpoMkNhaUozL1IwRFBkbE1lUTlwdVdzT1pmb3FHTWNoRHgzZTVzU01sZVNRL2xSV3Zoc214d3g3N1c0K21nWi9BCmx1cDh1VTYzTHVidmZyd3M1MWFlZk1UQlU5VGZ2Rmg4TGJiNHlHVy83V09ZN2ltUEgvY0lJa0d3WTROK2JZVFgKcnI2WW5tZXZxeENGMHEreCtsMkhpRXFRN3c1NG9LMU8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":{"id":"98a23d73-ee9a-458d-b37b-9e9e859cccca","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16286},"endpoints":[{"id":"98a23d73-ee9a-458d-b37b-9e9e859cccca","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16286}],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1845"
+      - "1455"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:58 GMT
+      - Thu, 02 Nov 2023 19:01:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a3bfa50-140d-4f8f-9884-8f50512c7998
+      - ba99985c-1e85-4cd8-8ae7-35b537ae347b
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,19 +1003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2666f31a-938d-4da8-a504-61ade33abcff
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016/certificate
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"de60c04b-f548-4b5b-994e-f93908a78ff2","ip":"51.158.106.174","name":null,"port":5432}],"id":"2666f31a-938d-4da8-a504-61ade33abcff","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmhOU1RDc0JCeURnb3IyZmZNT0dsYXRlRE5Fd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnMU5UUXhXaGNOTXpNeE1ETXdNVGcxTlRReFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU56K2Y0dGdFWG1tSEk1dkE3VDVZVjhHeUlMenMreWxtNzBWbnlUdll4ZUovSDhLL0ZwUXZMVmYKMFhjSEVVUHhPdDJNQXgza2dFM2RGVHFvMjUyZkswcFY5MWNFKzdnM2lYd3Nya1JzZGFNVktscHByYVhtYjRpNgpQZ1NDZ0xUcmIwMFNiVFYzMDhaNmZNY0Q1K1g2Tm1OalRBWXNhbUlSdWRzcGxwSGVHM3g5THNRZ3JMTDJNTWhMCm9wUjRnQno5Q3hyVXZZbWFnaHpUYm43NHQrZkdsLzRPUnZleWFoWUo2cSt0UEFIWHVLYnM1RDRneXAwVmF6OUoKSThXaW5MTjlkamJiYURkNXhZMllUZXA4VC9yMVZmVk9nYy8xM0pMOGpUQldFQlVYUmhKODY5QkxpQ09oOVZiZApva00zNE5ES0t6S3VkUm5hMmkzTG04NzhlWUtaWFhFQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WXpka01qRTJOamt0T1dNMU1pMDBOelUyTFRsaE4yVXRaak16WkRkak4yWmwKTURFMkxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1VqRXhTMWJTclNOWHEweThESUg0SDQ2Z2lWcDJyem9Ibm82N2hLUm95aXU5RWxPcGY4emR1CmdDZmFBK2UzbmVkKytPdDcwOExDNmVRelRqcVFqMG5TT1p1MmhUQjFPUSs5NjhFbWVXclJWS3ZGZ3RsYlpJZkoKVmEycXgxQzhHZnc5dURzaFZYWjFwSTk0Qm9kVm9GbVNiNnF5YmxJalp4SFBPSzcwNVBrTitvVHFINzBBeDQxZAo5UzZGK3pUamVZZnpBejVWdXBQbkNwazI5cmMwNUkxMHhFR0RjbFpxMmxEZDlDQzZFRmZjeE5ROEtrcm5peFg5CjFUbEN5alZkWTNPOERpekV2Mk4zUVZQOEE4M1NtMzZES2pHVXBPMTVCWkk1eGtibDJWS2k0Ukd1b1Y4UlhNMmEKSlgwUy8vdk9zdVRxYXNhK0ZJamlBUFBHSVRwOUpwa0MKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "230"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:04:01 GMT
+      - Thu, 02 Nov 2023 19:01:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3726097-a34f-4b40-a942-87d24409706f
+      - f2817e8f-f4d9-4195-81aa-9bbbbe8ded84
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,19 +1036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2666f31a-938d-4da8-a504-61ade33abcff
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"de60c04b-f548-4b5b-994e-f93908a78ff2","ip":"51.158.106.174","name":null,"port":5432}],"id":"2666f31a-938d-4da8-a504-61ade33abcff","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "230"
+      - "221"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:04:01 GMT
+      - Thu, 02 Nov 2023 19:01:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1058,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe8ee8ee-da5b-48de-bb4a-0483d3bebe69
+      - fe6e9f83-9197-44ec-97b5-b58019972dec
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,19 +1069,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2666f31a-938d-4da8-a504-61ade33abcff
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
+    method: GET
+  response:
+    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "221"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 19:01:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 959193e4-0f16-44dd-b297-acbc19c1f0f5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
     method: DELETE
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"de60c04b-f548-4b5b-994e-f93908a78ff2","ip":"51.158.106.174","name":null,"port":5432}],"id":"2666f31a-938d-4da8-a504-61ade33abcff","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "233"
+      - "224"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:04:02 GMT
+      - Thu, 02 Nov 2023 19:01:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1091,7 +1124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7bf4c1a-e5da-452b-8b82-fda12dccae1d
+      - 43fcd36c-5524-4bb4-8e05-aa50f36e30aa
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,19 +1135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2666f31a-938d-4da8-a504-61ade33abcff
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"de60c04b-f548-4b5b-994e-f93908a78ff2","ip":"51.158.106.174","name":null,"port":5432}],"id":"2666f31a-938d-4da8-a504-61ade33abcff","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "233"
+      - "224"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:04:02 GMT
+      - Thu, 02 Nov 2023 19:01:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1124,7 +1157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de2c84b7-98c3-4553-9aae-b7965823a2cb
+      - 87a3e8a8-1540-4674-b15e-6756efb39b92
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,10 +1168,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2666f31a-938d-4da8-a504-61ade33abcff
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"2666f31a-938d-4da8-a504-61ade33abcff","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"da662a4d-a49c-42e5-9238-c245a62bf58e","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1147,7 +1180,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:04:32 GMT
+      - Thu, 02 Nov 2023 19:01:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1157,7 +1190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2e6e238-8b36-4512-b53f-48131ae5e1ca
+      - 9ef3a16d-8e07-4edc-b205-8fc79412aafa
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1168,19 +1201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b3a8078-c07a-438c-8745-4c783c8d091d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:20.199545Z","endpoint":{"id":"075e3bbe-40ae-4ef0-b23a-e5ea0a5b6c00","ip":"51.159.26.148","load_balancer":{},"name":null,"port":18311},"endpoints":[{"id":"075e3bbe-40ae-4ef0-b23a-e5ea0a5b6c00","ip":"51.159.26.148","load_balancer":{},"name":null,"port":18311}],"engine":"PostgreSQL-15","id":"6b3a8078-c07a-438c-8745-4c783c8d091d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":{"id":"98a23d73-ee9a-458d-b37b-9e9e859cccca","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16286},"endpoints":[{"id":"98a23d73-ee9a-458d-b37b-9e9e859cccca","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16286}],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1282"
+      - "1234"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:04:32 GMT
+      - Thu, 02 Nov 2023 19:01:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d437de1-814e-44b9-8d22-0bfe97452f9e
+      - e3f13121-038c-4174-8b27-4c043d63534e
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,19 +1234,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b3a8078-c07a-438c-8745-4c783c8d091d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:20.199545Z","endpoint":{"id":"075e3bbe-40ae-4ef0-b23a-e5ea0a5b6c00","ip":"51.159.26.148","load_balancer":{},"name":null,"port":18311},"endpoints":[{"id":"075e3bbe-40ae-4ef0-b23a-e5ea0a5b6c00","ip":"51.159.26.148","load_balancer":{},"name":null,"port":18311}],"engine":"PostgreSQL-15","id":"6b3a8078-c07a-438c-8745-4c783c8d091d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":{"id":"98a23d73-ee9a-458d-b37b-9e9e859cccca","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16286},"endpoints":[{"id":"98a23d73-ee9a-458d-b37b-9e9e859cccca","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16286}],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1285"
+      - "1237"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:04:32 GMT
+      - Thu, 02 Nov 2023 19:01:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,7 +1256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7937d6a7-2457-4a27-9230-50f12ef31f8a
+      - 5cbc6c75-5829-41fc-8a0c-8c2b5f86ceec
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,19 +1267,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b3a8078-c07a-438c-8745-4c783c8d091d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:58:20.199545Z","endpoint":{"id":"075e3bbe-40ae-4ef0-b23a-e5ea0a5b6c00","ip":"51.159.26.148","load_balancer":{},"name":null,"port":18311},"endpoints":[{"id":"075e3bbe-40ae-4ef0-b23a-e5ea0a5b6c00","ip":"51.159.26.148","load_balancer":{},"name":null,"port":18311}],"engine":"PostgreSQL-15","id":"6b3a8078-c07a-438c-8745-4c783c8d091d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":{"id":"98a23d73-ee9a-458d-b37b-9e9e859cccca","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16286},"endpoints":[{"id":"98a23d73-ee9a-458d-b37b-9e9e859cccca","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16286}],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1285"
+      - "1237"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:04:33 GMT
+      - Thu, 02 Nov 2023 19:01:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1256,7 +1289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3757e77b-5fec-4642-b5c6-262d69bcd64b
+      - b4ab6d64-2208-4e38-9168-745b2394f261
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,10 +1300,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b3a8078-c07a-438c-8745-4c783c8d091d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"6b3a8078-c07a-438c-8745-4c783c8d091d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1279,7 +1312,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:03 GMT
+      - Thu, 02 Nov 2023 19:02:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1289,7 +1322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4e19718-d22e-4edf-8915-6a40bde30574
+      - 81486d28-cfc1-4156-8ba2-0208d078ca0d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1300,10 +1333,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b3a8078-c07a-438c-8745-4c783c8d091d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"6b3a8078-c07a-438c-8745-4c783c8d091d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1312,7 +1345,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:03 GMT
+      - Thu, 02 Nov 2023 19:02:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1322,7 +1355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f0204ec-d6c9-41eb-8b93-1132ff595223
+      - 4a51f780-63e0-43be-b6c9-14231bad96b6
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1333,10 +1366,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2666f31a-938d-4da8-a504-61ade33abcff
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"2666f31a-938d-4da8-a504-61ade33abcff","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"da662a4d-a49c-42e5-9238-c245a62bf58e","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1345,7 +1378,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:05:03 GMT
+      - Thu, 02 Nov 2023 19:02:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1355,7 +1388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2c93a3c-294c-4edb-902d-1086d31a46f0
+      - 8d48c3f9-8552-40dd-ab61-7552a28b8303
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-different-zone.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-different-zone.cassette.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-different-zone","engine":"PostgreSQL-14","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-different-zone","engine":"PostgreSQL-14","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -13,16 +13,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T13:51:52.438402Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"74b78673-7af5-4133-a052-78060b4532b6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "915"
+      - "883"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:51:52 GMT
+      - Thu, 02 Nov 2023 18:51:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56c2d0d5-8c0d-4dbe-8302-258c7ff2c3ad
+      - d0ce84d2-e673-4ac7-b994-749ebe8ce612
     status: 200 OK
     code: 200
     duration: ""
@@ -43,19 +43,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74b78673-7af5-4133-a052-78060b4532b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T13:51:52.438402Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"74b78673-7af5-4133-a052-78060b4532b6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "915"
+      - "883"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:51:52 GMT
+      - Thu, 02 Nov 2023 18:51:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,12 +65,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 933c9c74-ebe5-45ee-9589-6b6c88c9e620
+      - b2cabc2f-40c4-449b-9458-5351a08d827f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-rdb-rr-different-zone","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"test-rdb-rr-different-zone","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -81,16 +81,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-20T13:51:52.206160Z","dhcp_enabled":true,"id":"88788df1-c166-4633-8271-d9e244577053","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:51:52.206160Z","id":"716e3f19-3a55-40d9-acba-9602513e22d9","subnet":"172.16.20.0/22","updated_at":"2023-10-20T13:51:52.206160Z"},{"created_at":"2023-10-20T13:51:52.206160Z","id":"afcc9d9c-bf6a-4f54-a2cb-a88b32349844","subnet":"fd63:256c:45f7:daf3::/64","updated_at":"2023-10-20T13:51:52.206160Z"}],"tags":[],"updated_at":"2023-10-20T13:51:52.206160Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-02T18:51:42.626490Z","dhcp_enabled":true,"id":"6638dd56-857d-4602-a836-dc564d3eff6d","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:51:42.626490Z","id":"f5ebbf64-601e-4198-ac41-ec60e55600f8","subnet":"172.16.20.0/22","updated_at":"2023-11-02T18:51:42.626490Z"},{"created_at":"2023-11-02T18:51:42.626490Z","id":"5edc57aa-f173-4234-aae4-bbec1c6797d3","subnet":"fd63:256c:45f7:eb34::/64","updated_at":"2023-11-02T18:51:42.626490Z"}],"tags":[],"updated_at":"2023-11-02T18:51:42.626490Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "727"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:51:52 GMT
+      - Thu, 02 Nov 2023 18:51:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -100,7 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06f0a23f-7e45-49bf-854a-679ab664b9f5
+      - 3c697b19-9b95-4ad0-9ac2-e6edbcca6cc5
     status: 200 OK
     code: 200
     duration: ""
@@ -111,19 +111,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/88788df1-c166-4633-8271-d9e244577053
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6638dd56-857d-4602-a836-dc564d3eff6d
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T13:51:52.206160Z","dhcp_enabled":true,"id":"88788df1-c166-4633-8271-d9e244577053","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:51:52.206160Z","id":"716e3f19-3a55-40d9-acba-9602513e22d9","subnet":"172.16.20.0/22","updated_at":"2023-10-20T13:51:52.206160Z"},{"created_at":"2023-10-20T13:51:52.206160Z","id":"afcc9d9c-bf6a-4f54-a2cb-a88b32349844","subnet":"fd63:256c:45f7:daf3::/64","updated_at":"2023-10-20T13:51:52.206160Z"}],"tags":[],"updated_at":"2023-10-20T13:51:52.206160Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-02T18:51:42.626490Z","dhcp_enabled":true,"id":"6638dd56-857d-4602-a836-dc564d3eff6d","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:51:42.626490Z","id":"f5ebbf64-601e-4198-ac41-ec60e55600f8","subnet":"172.16.20.0/22","updated_at":"2023-11-02T18:51:42.626490Z"},{"created_at":"2023-11-02T18:51:42.626490Z","id":"5edc57aa-f173-4234-aae4-bbec1c6797d3","subnet":"fd63:256c:45f7:eb34::/64","updated_at":"2023-11-02T18:51:42.626490Z"}],"tags":[],"updated_at":"2023-11-02T18:51:42.626490Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "727"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:51:54 GMT
+      - Thu, 02 Nov 2023 18:51:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -133,7 +133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8697e29-2422-48e9-bea8-5ebe6a4d73eb
+      - ce980378-04d5-49af-aa39-5fa35d0045ae
     status: 200 OK
     code: 200
     duration: ""
@@ -144,19 +144,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74b78673-7af5-4133-a052-78060b4532b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T13:51:52.438402Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"74b78673-7af5-4133-a052-78060b4532b6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "915"
+      - "883"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:52:22 GMT
+      - Thu, 02 Nov 2023 18:52:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -166,7 +166,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da0b5b92-0072-4513-94f0-97edeef2aed8
+      - 3d8d26f8-2dd2-4577-a42c-1be5a471836b
     status: 200 OK
     code: 200
     duration: ""
@@ -177,19 +177,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74b78673-7af5-4133-a052-78060b4532b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T13:51:52.438402Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"74b78673-7af5-4133-a052-78060b4532b6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "915"
+      - "883"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:52:53 GMT
+      - Thu, 02 Nov 2023 18:52:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -199,7 +199,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7b5e429-cd5a-4dfd-bcab-07240f2ef6fd
+      - 10a8d302-b4ee-4771-8f24-fe6c8eb9cb88
     status: 200 OK
     code: 200
     duration: ""
@@ -210,19 +210,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74b78673-7af5-4133-a052-78060b4532b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T13:51:52.438402Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"74b78673-7af5-4133-a052-78060b4532b6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "915"
+      - "883"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:53:23 GMT
+      - Thu, 02 Nov 2023 18:53:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -232,7 +232,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6bd980e-0dee-410b-982e-d4210248f505
+      - d8a032b2-8790-4cf4-8be0-4a33101793f2
     status: 200 OK
     code: 200
     duration: ""
@@ -243,19 +243,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74b78673-7af5-4133-a052-78060b4532b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T13:51:52.438402Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"74b78673-7af5-4133-a052-78060b4532b6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "915"
+      - "883"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:53:53 GMT
+      - Thu, 02 Nov 2023 18:53:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -265,7 +265,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1217aad5-f174-4b9c-b7de-4ba1ff63f28c
+      - 36412343-5779-4dcd-8bfa-47e8a3223fa0
     status: 200 OK
     code: 200
     duration: ""
@@ -276,19 +276,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74b78673-7af5-4133-a052-78060b4532b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T13:51:52.438402Z","endpoint":{"id":"4fa52573-d70f-4a9b-a86a-16b5d4b02605","ip":"51.159.25.173","load_balancer":{},"name":null,"port":24399},"endpoints":[{"id":"4fa52573-d70f-4a9b-a86a-16b5d4b02605","ip":"51.159.25.173","load_balancer":{},"name":null,"port":24399}],"engine":"PostgreSQL-14","id":"74b78673-7af5-4133-a052-78060b4532b6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1407"
+      - "883"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:54:23 GMT
+      - Thu, 02 Nov 2023 18:54:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -298,7 +298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea685a6e-ba75-4c17-bc44-1935c66d17ea
+      - 7d0ba1d6-d56f-4090-9bc9-4c0ff621550f
     status: 200 OK
     code: 200
     duration: ""
@@ -309,19 +309,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74b78673-7af5-4133-a052-78060b4532b6/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVU2dBTDFrVXRkcnQrOHVCWXZUcjB3YzVMRE5Jd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5TlM0eE56TXdIaGNOCk1qTXhNREl3TVRNMU1qTXlXaGNOTXpNeE1ERTNNVE0xTWpNeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTFMakUzTXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUt3d3VmaThmaUlLbElFYmhZVGNCenpMN09UeDJ2K0xMd1FWMldEak5nL0dLUG5PUnQ3MUxsMUsKd3FzOE9IMnZzYlJLd3JLc3NRRUlDUERGODdYcy9YYmhMZEpsVXlzMVdmUG1nNm45dktZNWdjZm94RTZiVHpwSQpjc3h6NGZEek1tU1NXL1VpTXZPRG5lMGlTakZYRUJ4REFVbUFPMmlxK0NIeEsyMUdGQnVicXNsS2ExeUxNOCt2CnpSN2dianlCWFNzL0IrdWJrWnVQY2N3dnhrd3dEN0xZZURpNFVCWHBxR1ZTUUFTY0s5cWsrK205VnA0Zy9UTGUKVlhNVFgyTTAzTXpOUW1ybFVES3dHdTk3U0l5MzI4NVh6aWxLVHJpcCtQTGlFTHN1QkV1eU5KeHpudHM2RmVlVwo2ejg1UDlka3U5R3FrVEMzQ1RadUNUUEtCSmtqTXRjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkxTGpFM000SThjbmN0TnpSaU56ZzJOek10TjJGbU5TMDBNVE16TFdFd05USXROemd3TmpCaU5EVXoKTW1JMkxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckkySGh3UXpueG10TUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQVk1ei9UWm1zQXIxSy9MZUlmVGVFNlFQdFZjQWRGbEhvUWpzZldJdDBwSHBvdWk3WE16bTBUClE4N3NXb1drTVhNbmsweEhvL0g0OGtTUGhiSHdZdnRveVprSi82elJEbWpQV1AvS2J3bm9kRDhBWDUzVWR6di8KTitqNWxKODBCR0J6N2RDY2Z5c05HdzVGUktEL0JWcjZMS0ZEMUtzSXhEM2lrYmJNak5uQVBGbml2ZVZqRG1sQwpCU3BYK28xbzcwcjk2TVRGNTJjeWNUWVpjQnpkN3ZKVFh6bzJkNkNIYlZsNDhyVW5kYVpDL205K05IWXFFVXlPCitaYWtldjN2SzZaMlhxNkg0Zk4yT2JkelFtS3dOa0txYmx5aW9YQWZSeFZJOE0yYTVUczBOSXAvR3QvRlVydmsKWFB3WStnbG15SVIzU2pGSCt0SzROc0ZuR2RpaGhOZmsKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184},"endpoints":[{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184}],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1845"
+      - "1356"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:54:23 GMT
+      - Thu, 02 Nov 2023 18:54:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -331,12 +331,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae81b850-0389-44b9-9f40-f63876f0cc3d
+      - 92d7b757-c54c-4fe3-8aa0-67f4310296d8
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"74b78673-7af5-4133-a052-78060b4532b6","endpoint_spec":[{"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","ipam_config":{}}}],"same_zone":false}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVYkVjM0IxcU92MHc4QUY0d096SXpSZGpvdUZrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1qSTBXaGNOTXpNeE1ETXdNVGcxTWpJMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU90bm00TDV2ajBqWDJJblNTQXhncTBOU05TaHdtelF4QWIyeHg4elo1K3hLbERubGFCK2xwOXYKUG1MZnkzRmZJM1hqLyt5SlFjTnh3M0RVOWQ2a2pnbFNRWFQvUVpGNkFiWUxsMkF4OU9MR1RXaUFFQW5TSEU3LwowTnF6RGJ3M3JnYVpMbFFmYmFQdnZBNzRmTFJFNUZOalRBMlh5UGM0RXJra05KWjNOQnl3OEt3WThiWVVMVkswCmZ2WUZhbEZCSEdrM1pNTkZ1YXQ4VjVoYmlrTmZvYjlGT3ExbTZvL1NFUEpqazlIYXprTGJobHd0MUJ5Slp5VUIKc0psdWliOXp0YlNBMUY1Q3VIaC9WbC9nN3RRL1dPMHBrV2tmbWN3WnMrcXBjaVg2TC9iaVp2TDlkT2UwVXVHNwptcmlNaVQ4MmVlYmUyMmZVUnBXdmh1enVXMGk4WmtjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TVdGaVlqUTBaREF0T1dNMU55MDBNall4TFRsa09UWXROREE0WVRRek9USTQKWTJVMkxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm1PSmh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRRFpFaVNHakZwMVl2NjIwL1MrZzF0MUs2d2JJVS8rUzVLUklkVmJMdWlaSkRqaXVyb3dMQXhQCm0yaUdqdWJOSkJsTWIzYmlaOCsrUG5pemErclBHckN6d1pXVFdXd0ZkWng0U24zUzc5Tm5WRytlTkcxQitIa2kKTnRpc2lERCtrSWR1RUFmcGNFRVE5U3B2SGZ4eXRHYWhua3VLSyt6bmIxOWM2cTd0UUJ5SHA2WmVPcVErOEIwcApHbnlleWdzeW5sTS8xQnRzZlYzS3lja3I2V0lsRDBRemRoSUFOVWNtN1FBdzF1VEJ6a0RrdElqOHBKMndNejNEClVBME5ONDBCN2Jlb2c5N3pZRHpGWmFqQWRKNWJHT3hLaVo5V3hoUXd2KzRwNVdvMENIUXp5OVRRSTV2elpQM1MKbkNlSFM1bWN3azZDMkdKemJ5QnkxcVk1TTJ2cjlSdnQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1843"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:54:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e6bac3bc-bcfc-4dbf-b326-705a84c1db17
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"instance_id":"1abb44d0-9c57-4261-9d96-408a43928ce6","endpoint_spec":[{"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","ipam_config":{}}}],"same_zone":false}'
     form: {}
     headers:
       Content-Type:
@@ -347,16 +380,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[{"id":"06519591-cf28-4a5b-8c0e-1d9e99899690","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"dde26e8a-871f-473d-9c6d-7651e1d0ce8b","region":"fr-par","same_zone":false,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "346"
+      - "336"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:54:24 GMT
+      - Thu, 02 Nov 2023 18:54:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -366,7 +399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63b32871-e574-44ff-9b05-7bd45e1b8def
+      - 1d7cb98b-d759-4e81-a802-c422e906ce9b
     status: 200 OK
     code: 200
     duration: ""
@@ -377,19 +410,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dde26e8a-871f-473d-9c6d-7651e1d0ce8b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
     method: GET
   response:
-    body: '{"endpoints":[{"id":"06519591-cf28-4a5b-8c0e-1d9e99899690","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"dde26e8a-871f-473d-9c6d-7651e1d0ce8b","region":"fr-par","same_zone":false,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "346"
+      - "336"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:54:24 GMT
+      - Thu, 02 Nov 2023 18:54:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -399,7 +432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dfc2e540-f85f-4645-9c57-93c7b81b5ce4
+      - fd5a5fbf-e6bc-4ea1-bb02-2f275da57f7a
     status: 200 OK
     code: 200
     duration: ""
@@ -410,19 +443,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dde26e8a-871f-473d-9c6d-7651e1d0ce8b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
     method: GET
   response:
-    body: '{"endpoints":[{"id":"06519591-cf28-4a5b-8c0e-1d9e99899690","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"dde26e8a-871f-473d-9c6d-7651e1d0ce8b","region":"fr-par","same_zone":false,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "346"
+      - "336"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:54:58 GMT
+      - Thu, 02 Nov 2023 18:55:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -432,7 +465,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91b39ae5-0a5f-4086-bddb-c71fc9fb0dc9
+      - c80566bd-a61e-45a5-b69f-310f7b14a2b1
     status: 200 OK
     code: 200
     duration: ""
@@ -443,19 +476,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dde26e8a-871f-473d-9c6d-7651e1d0ce8b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
     method: GET
   response:
-    body: '{"endpoints":[{"id":"06519591-cf28-4a5b-8c0e-1d9e99899690","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"dde26e8a-871f-473d-9c6d-7651e1d0ce8b","region":"fr-par","same_zone":false,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "346"
+      - "336"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:55:28 GMT
+      - Thu, 02 Nov 2023 18:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -465,7 +498,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2552bd3-7555-4e35-97b9-255b3bdf0902
+      - 586c26b2-fa7f-442c-9db9-1d7ef72def5d
     status: 200 OK
     code: 200
     duration: ""
@@ -476,19 +509,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dde26e8a-871f-473d-9c6d-7651e1d0ce8b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
     method: GET
   response:
-    body: '{"endpoints":[{"id":"06519591-cf28-4a5b-8c0e-1d9e99899690","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"dde26e8a-871f-473d-9c6d-7651e1d0ce8b","region":"fr-par","same_zone":false,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"initializing"}'
     headers:
       Content-Length:
-      - "346"
+      - "336"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:55:59 GMT
+      - Thu, 02 Nov 2023 18:56:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -498,7 +531,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec208ec6-8d44-4484-8f14-1e571534e46f
+      - c4b58c35-7d93-4901-9c4d-1ec0337f453c
     status: 200 OK
     code: 200
     duration: ""
@@ -509,19 +542,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dde26e8a-871f-473d-9c6d-7651e1d0ce8b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
     method: GET
   response:
-    body: '{"endpoints":[{"id":"06519591-cf28-4a5b-8c0e-1d9e99899690","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"dde26e8a-871f-473d-9c6d-7651e1d0ce8b","region":"fr-par","same_zone":false,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"initializing"}'
     headers:
       Content-Length:
-      - "346"
+      - "336"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:56:29 GMT
+      - Thu, 02 Nov 2023 18:56:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -531,7 +564,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9710914-7e36-424a-988e-8a80de0c8362
+      - 996e7c05-db3d-4fd5-bb26-fb2a47f2c22f
     status: 200 OK
     code: 200
     duration: ""
@@ -542,19 +575,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dde26e8a-871f-473d-9c6d-7651e1d0ce8b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
     method: GET
   response:
-    body: '{"endpoints":[{"id":"06519591-cf28-4a5b-8c0e-1d9e99899690","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"dde26e8a-871f-473d-9c6d-7651e1d0ce8b","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
-      - "339"
+      - "329"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:56:59 GMT
+      - Thu, 02 Nov 2023 18:57:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -564,7 +597,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc7201b5-aaa4-4f2a-a6a4-f4218d857f74
+      - 6fada8ab-d32f-4a01-8253-978149bce501
     status: 200 OK
     code: 200
     duration: ""
@@ -575,19 +608,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dde26e8a-871f-473d-9c6d-7651e1d0ce8b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
     method: GET
   response:
-    body: '{"endpoints":[{"id":"06519591-cf28-4a5b-8c0e-1d9e99899690","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"dde26e8a-871f-473d-9c6d-7651e1d0ce8b","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
-      - "339"
+      - "329"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:57:00 GMT
+      - Thu, 02 Nov 2023 18:57:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -597,7 +630,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac4a44bf-77ce-4ee2-93d4-cd0d36f1a842
+      - 321593da-59e8-4b27-b42e-54986ac5ac24
     status: 200 OK
     code: 200
     duration: ""
@@ -608,19 +641,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dde26e8a-871f-473d-9c6d-7651e1d0ce8b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
     method: GET
   response:
-    body: '{"endpoints":[{"id":"06519591-cf28-4a5b-8c0e-1d9e99899690","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"dde26e8a-871f-473d-9c6d-7651e1d0ce8b","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
-      - "339"
+      - "329"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:57:00 GMT
+      - Thu, 02 Nov 2023 18:57:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -630,7 +663,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7665ff6-aba1-4690-a8e0-ab4ce277c03a
+      - 30b8c836-f5fe-4be3-91c1-13d205ea9757
     status: 200 OK
     code: 200
     duration: ""
@@ -641,19 +674,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/88788df1-c166-4633-8271-d9e244577053
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6638dd56-857d-4602-a836-dc564d3eff6d
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T13:51:52.206160Z","dhcp_enabled":true,"id":"88788df1-c166-4633-8271-d9e244577053","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:51:52.206160Z","id":"716e3f19-3a55-40d9-acba-9602513e22d9","subnet":"172.16.20.0/22","updated_at":"2023-10-20T13:51:52.206160Z"},{"created_at":"2023-10-20T13:51:52.206160Z","id":"afcc9d9c-bf6a-4f54-a2cb-a88b32349844","subnet":"fd63:256c:45f7:daf3::/64","updated_at":"2023-10-20T13:51:52.206160Z"}],"tags":[],"updated_at":"2023-10-20T13:51:52.206160Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-02T18:51:42.626490Z","dhcp_enabled":true,"id":"6638dd56-857d-4602-a836-dc564d3eff6d","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:51:42.626490Z","id":"f5ebbf64-601e-4198-ac41-ec60e55600f8","subnet":"172.16.20.0/22","updated_at":"2023-11-02T18:51:42.626490Z"},{"created_at":"2023-11-02T18:51:42.626490Z","id":"5edc57aa-f173-4234-aae4-bbec1c6797d3","subnet":"fd63:256c:45f7:eb34::/64","updated_at":"2023-11-02T18:51:42.626490Z"}],"tags":[],"updated_at":"2023-11-02T18:51:42.626490Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "727"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:57:00 GMT
+      - Thu, 02 Nov 2023 18:57:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -663,7 +696,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd337cf2-a5f9-41fe-80b2-b6b51fbd1f98
+      - e49988d4-1cd5-40a5-b8d4-b206188d1b18
     status: 200 OK
     code: 200
     duration: ""
@@ -674,19 +707,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/88788df1-c166-4633-8271-d9e244577053
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6638dd56-857d-4602-a836-dc564d3eff6d
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T13:51:52.206160Z","dhcp_enabled":true,"id":"88788df1-c166-4633-8271-d9e244577053","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:51:52.206160Z","id":"716e3f19-3a55-40d9-acba-9602513e22d9","subnet":"172.16.20.0/22","updated_at":"2023-10-20T13:51:52.206160Z"},{"created_at":"2023-10-20T13:51:52.206160Z","id":"afcc9d9c-bf6a-4f54-a2cb-a88b32349844","subnet":"fd63:256c:45f7:daf3::/64","updated_at":"2023-10-20T13:51:52.206160Z"}],"tags":[],"updated_at":"2023-10-20T13:51:52.206160Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-02T18:51:42.626490Z","dhcp_enabled":true,"id":"6638dd56-857d-4602-a836-dc564d3eff6d","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:51:42.626490Z","id":"f5ebbf64-601e-4198-ac41-ec60e55600f8","subnet":"172.16.20.0/22","updated_at":"2023-11-02T18:51:42.626490Z"},{"created_at":"2023-11-02T18:51:42.626490Z","id":"5edc57aa-f173-4234-aae4-bbec1c6797d3","subnet":"fd63:256c:45f7:eb34::/64","updated_at":"2023-11-02T18:51:42.626490Z"}],"tags":[],"updated_at":"2023-11-02T18:51:42.626490Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "727"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:57:00 GMT
+      - Thu, 02 Nov 2023 18:57:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -696,7 +729,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 124f7fe9-6470-4215-8b44-7e80c084601d
+      - 0d08eb25-fc37-4f13-afc5-9bed138128e7
     status: 200 OK
     code: 200
     duration: ""
@@ -707,19 +740,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74b78673-7af5-4133-a052-78060b4532b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T13:51:52.438402Z","endpoint":{"id":"4fa52573-d70f-4a9b-a86a-16b5d4b02605","ip":"51.159.25.173","load_balancer":{},"name":null,"port":24399},"endpoints":[{"id":"4fa52573-d70f-4a9b-a86a-16b5d4b02605","ip":"51.159.25.173","load_balancer":{},"name":null,"port":24399}],"engine":"PostgreSQL-14","id":"74b78673-7af5-4133-a052-78060b4532b6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"06519591-cf28-4a5b-8c0e-1d9e99899690","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"dde26e8a-871f-473d-9c6d-7651e1d0ce8b","region":"fr-par","same_zone":false,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184},"endpoints":[{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184}],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1746"
+      - "1685"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:57:01 GMT
+      - Thu, 02 Nov 2023 18:57:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -729,7 +762,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a4b6e53-bd3b-43fa-92d8-62fc248f3ede
+      - d8438957-6036-4dc6-a0f1-6099533a612e
     status: 200 OK
     code: 200
     duration: ""
@@ -740,19 +773,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74b78673-7af5-4133-a052-78060b4532b6/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVU2dBTDFrVXRkcnQrOHVCWXZUcjB3YzVMRE5Jd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5TlM0eE56TXdIaGNOCk1qTXhNREl3TVRNMU1qTXlXaGNOTXpNeE1ERTNNVE0xTWpNeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTFMakUzTXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUt3d3VmaThmaUlLbElFYmhZVGNCenpMN09UeDJ2K0xMd1FWMldEak5nL0dLUG5PUnQ3MUxsMUsKd3FzOE9IMnZzYlJLd3JLc3NRRUlDUERGODdYcy9YYmhMZEpsVXlzMVdmUG1nNm45dktZNWdjZm94RTZiVHpwSQpjc3h6NGZEek1tU1NXL1VpTXZPRG5lMGlTakZYRUJ4REFVbUFPMmlxK0NIeEsyMUdGQnVicXNsS2ExeUxNOCt2CnpSN2dianlCWFNzL0IrdWJrWnVQY2N3dnhrd3dEN0xZZURpNFVCWHBxR1ZTUUFTY0s5cWsrK205VnA0Zy9UTGUKVlhNVFgyTTAzTXpOUW1ybFVES3dHdTk3U0l5MzI4NVh6aWxLVHJpcCtQTGlFTHN1QkV1eU5KeHpudHM2RmVlVwo2ejg1UDlka3U5R3FrVEMzQ1RadUNUUEtCSmtqTXRjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkxTGpFM000SThjbmN0TnpSaU56ZzJOek10TjJGbU5TMDBNVE16TFdFd05USXROemd3TmpCaU5EVXoKTW1JMkxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckkySGh3UXpueG10TUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQVk1ei9UWm1zQXIxSy9MZUlmVGVFNlFQdFZjQWRGbEhvUWpzZldJdDBwSHBvdWk3WE16bTBUClE4N3NXb1drTVhNbmsweEhvL0g0OGtTUGhiSHdZdnRveVprSi82elJEbWpQV1AvS2J3bm9kRDhBWDUzVWR6di8KTitqNWxKODBCR0J6N2RDY2Z5c05HdzVGUktEL0JWcjZMS0ZEMUtzSXhEM2lrYmJNak5uQVBGbml2ZVZqRG1sQwpCU3BYK28xbzcwcjk2TVRGNTJjeWNUWVpjQnpkN3ZKVFh6bzJkNkNIYlZsNDhyVW5kYVpDL205K05IWXFFVXlPCitaYWtldjN2SzZaMlhxNkg0Zk4yT2JkelFtS3dOa0txYmx5aW9YQWZSeFZJOE0yYTVUczBOSXAvR3QvRlVydmsKWFB3WStnbG15SVIzU2pGSCt0SzROc0ZuR2RpaGhOZmsKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVYkVjM0IxcU92MHc4QUY0d096SXpSZGpvdUZrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1qSTBXaGNOTXpNeE1ETXdNVGcxTWpJMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU90bm00TDV2ajBqWDJJblNTQXhncTBOU05TaHdtelF4QWIyeHg4elo1K3hLbERubGFCK2xwOXYKUG1MZnkzRmZJM1hqLyt5SlFjTnh3M0RVOWQ2a2pnbFNRWFQvUVpGNkFiWUxsMkF4OU9MR1RXaUFFQW5TSEU3LwowTnF6RGJ3M3JnYVpMbFFmYmFQdnZBNzRmTFJFNUZOalRBMlh5UGM0RXJra05KWjNOQnl3OEt3WThiWVVMVkswCmZ2WUZhbEZCSEdrM1pNTkZ1YXQ4VjVoYmlrTmZvYjlGT3ExbTZvL1NFUEpqazlIYXprTGJobHd0MUJ5Slp5VUIKc0psdWliOXp0YlNBMUY1Q3VIaC9WbC9nN3RRL1dPMHBrV2tmbWN3WnMrcXBjaVg2TC9iaVp2TDlkT2UwVXVHNwptcmlNaVQ4MmVlYmUyMmZVUnBXdmh1enVXMGk4WmtjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TVdGaVlqUTBaREF0T1dNMU55MDBNall4TFRsa09UWXROREE0WVRRek9USTQKWTJVMkxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm1PSmh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRRFpFaVNHakZwMVl2NjIwL1MrZzF0MUs2d2JJVS8rUzVLUklkVmJMdWlaSkRqaXVyb3dMQXhQCm0yaUdqdWJOSkJsTWIzYmlaOCsrUG5pemErclBHckN6d1pXVFdXd0ZkWng0U24zUzc5Tm5WRytlTkcxQitIa2kKTnRpc2lERCtrSWR1RUFmcGNFRVE5U3B2SGZ4eXRHYWhua3VLSyt6bmIxOWM2cTd0UUJ5SHA2WmVPcVErOEIwcApHbnlleWdzeW5sTS8xQnRzZlYzS3lja3I2V0lsRDBRemRoSUFOVWNtN1FBdzF1VEJ6a0RrdElqOHBKMndNejNEClVBME5ONDBCN2Jlb2c5N3pZRHpGWmFqQWRKNWJHT3hLaVo5V3hoUXd2KzRwNVdvMENIUXp5OVRRSTV2elpQM1MKbkNlSFM1bWN3azZDMkdKemJ5QnkxcVk1TTJ2cjlSdnQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:57:01 GMT
+      - Thu, 02 Nov 2023 18:57:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -762,7 +795,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d03919f2-8de9-4cdf-8625-7520d74b3cef
+      - c5e8c015-88e8-46c1-b0b7-ae28cc9924a4
     status: 200 OK
     code: 200
     duration: ""
@@ -773,19 +806,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dde26e8a-871f-473d-9c6d-7651e1d0ce8b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
     method: GET
   response:
-    body: '{"endpoints":[{"id":"06519591-cf28-4a5b-8c0e-1d9e99899690","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"dde26e8a-871f-473d-9c6d-7651e1d0ce8b","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
-      - "339"
+      - "329"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:57:01 GMT
+      - Thu, 02 Nov 2023 18:57:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -795,7 +828,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1914f333-fa37-429c-9a84-615a2259995a
+      - 23de90ef-6008-4744-a5c8-1c7a5d4a9a59
     status: 200 OK
     code: 200
     duration: ""
@@ -806,19 +839,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/88788df1-c166-4633-8271-d9e244577053
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6638dd56-857d-4602-a836-dc564d3eff6d
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T13:51:52.206160Z","dhcp_enabled":true,"id":"88788df1-c166-4633-8271-d9e244577053","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:51:52.206160Z","id":"716e3f19-3a55-40d9-acba-9602513e22d9","subnet":"172.16.20.0/22","updated_at":"2023-10-20T13:51:52.206160Z"},{"created_at":"2023-10-20T13:51:52.206160Z","id":"afcc9d9c-bf6a-4f54-a2cb-a88b32349844","subnet":"fd63:256c:45f7:daf3::/64","updated_at":"2023-10-20T13:51:52.206160Z"}],"tags":[],"updated_at":"2023-10-20T13:51:52.206160Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-02T18:51:42.626490Z","dhcp_enabled":true,"id":"6638dd56-857d-4602-a836-dc564d3eff6d","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:51:42.626490Z","id":"f5ebbf64-601e-4198-ac41-ec60e55600f8","subnet":"172.16.20.0/22","updated_at":"2023-11-02T18:51:42.626490Z"},{"created_at":"2023-11-02T18:51:42.626490Z","id":"5edc57aa-f173-4234-aae4-bbec1c6797d3","subnet":"fd63:256c:45f7:eb34::/64","updated_at":"2023-11-02T18:51:42.626490Z"}],"tags":[],"updated_at":"2023-11-02T18:51:42.626490Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "727"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:57:01 GMT
+      - Thu, 02 Nov 2023 18:57:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -828,7 +861,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8cc0d411-e0cb-4552-83e8-c16bbcf5549c
+      - bbcb5166-6b19-4437-9abc-8fab2a7990d8
     status: 200 OK
     code: 200
     duration: ""
@@ -839,19 +872,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74b78673-7af5-4133-a052-78060b4532b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T13:51:52.438402Z","endpoint":{"id":"4fa52573-d70f-4a9b-a86a-16b5d4b02605","ip":"51.159.25.173","load_balancer":{},"name":null,"port":24399},"endpoints":[{"id":"4fa52573-d70f-4a9b-a86a-16b5d4b02605","ip":"51.159.25.173","load_balancer":{},"name":null,"port":24399}],"engine":"PostgreSQL-14","id":"74b78673-7af5-4133-a052-78060b4532b6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"06519591-cf28-4a5b-8c0e-1d9e99899690","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"dde26e8a-871f-473d-9c6d-7651e1d0ce8b","region":"fr-par","same_zone":false,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184},"endpoints":[{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184}],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1746"
+      - "1685"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:57:02 GMT
+      - Thu, 02 Nov 2023 18:57:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -861,7 +894,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4614d7e8-2c42-4de4-9de9-978942b0a59b
+      - eb52e466-a315-4a5e-8d1d-27025f91738e
     status: 200 OK
     code: 200
     duration: ""
@@ -872,19 +905,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74b78673-7af5-4133-a052-78060b4532b6/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVU2dBTDFrVXRkcnQrOHVCWXZUcjB3YzVMRE5Jd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5TlM0eE56TXdIaGNOCk1qTXhNREl3TVRNMU1qTXlXaGNOTXpNeE1ERTNNVE0xTWpNeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTFMakUzTXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUt3d3VmaThmaUlLbElFYmhZVGNCenpMN09UeDJ2K0xMd1FWMldEak5nL0dLUG5PUnQ3MUxsMUsKd3FzOE9IMnZzYlJLd3JLc3NRRUlDUERGODdYcy9YYmhMZEpsVXlzMVdmUG1nNm45dktZNWdjZm94RTZiVHpwSQpjc3h6NGZEek1tU1NXL1VpTXZPRG5lMGlTakZYRUJ4REFVbUFPMmlxK0NIeEsyMUdGQnVicXNsS2ExeUxNOCt2CnpSN2dianlCWFNzL0IrdWJrWnVQY2N3dnhrd3dEN0xZZURpNFVCWHBxR1ZTUUFTY0s5cWsrK205VnA0Zy9UTGUKVlhNVFgyTTAzTXpOUW1ybFVES3dHdTk3U0l5MzI4NVh6aWxLVHJpcCtQTGlFTHN1QkV1eU5KeHpudHM2RmVlVwo2ejg1UDlka3U5R3FrVEMzQ1RadUNUUEtCSmtqTXRjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkxTGpFM000SThjbmN0TnpSaU56ZzJOek10TjJGbU5TMDBNVE16TFdFd05USXROemd3TmpCaU5EVXoKTW1JMkxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckkySGh3UXpueG10TUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQVk1ei9UWm1zQXIxSy9MZUlmVGVFNlFQdFZjQWRGbEhvUWpzZldJdDBwSHBvdWk3WE16bTBUClE4N3NXb1drTVhNbmsweEhvL0g0OGtTUGhiSHdZdnRveVprSi82elJEbWpQV1AvS2J3bm9kRDhBWDUzVWR6di8KTitqNWxKODBCR0J6N2RDY2Z5c05HdzVGUktEL0JWcjZMS0ZEMUtzSXhEM2lrYmJNak5uQVBGbml2ZVZqRG1sQwpCU3BYK28xbzcwcjk2TVRGNTJjeWNUWVpjQnpkN3ZKVFh6bzJkNkNIYlZsNDhyVW5kYVpDL205K05IWXFFVXlPCitaYWtldjN2SzZaMlhxNkg0Zk4yT2JkelFtS3dOa0txYmx5aW9YQWZSeFZJOE0yYTVUczBOSXAvR3QvRlVydmsKWFB3WStnbG15SVIzU2pGSCt0SzROc0ZuR2RpaGhOZmsKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVYkVjM0IxcU92MHc4QUY0d096SXpSZGpvdUZrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1qSTBXaGNOTXpNeE1ETXdNVGcxTWpJMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU90bm00TDV2ajBqWDJJblNTQXhncTBOU05TaHdtelF4QWIyeHg4elo1K3hLbERubGFCK2xwOXYKUG1MZnkzRmZJM1hqLyt5SlFjTnh3M0RVOWQ2a2pnbFNRWFQvUVpGNkFiWUxsMkF4OU9MR1RXaUFFQW5TSEU3LwowTnF6RGJ3M3JnYVpMbFFmYmFQdnZBNzRmTFJFNUZOalRBMlh5UGM0RXJra05KWjNOQnl3OEt3WThiWVVMVkswCmZ2WUZhbEZCSEdrM1pNTkZ1YXQ4VjVoYmlrTmZvYjlGT3ExbTZvL1NFUEpqazlIYXprTGJobHd0MUJ5Slp5VUIKc0psdWliOXp0YlNBMUY1Q3VIaC9WbC9nN3RRL1dPMHBrV2tmbWN3WnMrcXBjaVg2TC9iaVp2TDlkT2UwVXVHNwptcmlNaVQ4MmVlYmUyMmZVUnBXdmh1enVXMGk4WmtjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TVdGaVlqUTBaREF0T1dNMU55MDBNall4TFRsa09UWXROREE0WVRRek9USTQKWTJVMkxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm1PSmh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRRFpFaVNHakZwMVl2NjIwL1MrZzF0MUs2d2JJVS8rUzVLUklkVmJMdWlaSkRqaXVyb3dMQXhQCm0yaUdqdWJOSkJsTWIzYmlaOCsrUG5pemErclBHckN6d1pXVFdXd0ZkWng0U24zUzc5Tm5WRytlTkcxQitIa2kKTnRpc2lERCtrSWR1RUFmcGNFRVE5U3B2SGZ4eXRHYWhua3VLSyt6bmIxOWM2cTd0UUJ5SHA2WmVPcVErOEIwcApHbnlleWdzeW5sTS8xQnRzZlYzS3lja3I2V0lsRDBRemRoSUFOVWNtN1FBdzF1VEJ6a0RrdElqOHBKMndNejNEClVBME5ONDBCN2Jlb2c5N3pZRHpGWmFqQWRKNWJHT3hLaVo5V3hoUXd2KzRwNVdvMENIUXp5OVRRSTV2elpQM1MKbkNlSFM1bWN3azZDMkdKemJ5QnkxcVk1TTJ2cjlSdnQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:57:02 GMT
+      - Thu, 02 Nov 2023 18:57:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -894,7 +927,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25936771-3097-4fe4-812e-81fe565bf3a7
+      - 6f5509d6-aecc-4443-8a5e-0b29162a19ba
     status: 200 OK
     code: 200
     duration: ""
@@ -905,19 +938,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dde26e8a-871f-473d-9c6d-7651e1d0ce8b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
     method: GET
   response:
-    body: '{"endpoints":[{"id":"06519591-cf28-4a5b-8c0e-1d9e99899690","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"dde26e8a-871f-473d-9c6d-7651e1d0ce8b","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
-      - "339"
+      - "329"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:57:02 GMT
+      - Thu, 02 Nov 2023 18:57:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -927,7 +960,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc2b024f-9869-4ab0-b982-782ece084f84
+      - bae55490-85e3-4d9a-a702-41cee5c77c61
     status: 200 OK
     code: 200
     duration: ""
@@ -938,19 +971,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dde26e8a-871f-473d-9c6d-7651e1d0ce8b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
     method: GET
   response:
-    body: '{"endpoints":[{"id":"06519591-cf28-4a5b-8c0e-1d9e99899690","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"dde26e8a-871f-473d-9c6d-7651e1d0ce8b","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
-      - "339"
+      - "329"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:57:02 GMT
+      - Thu, 02 Nov 2023 18:57:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -960,7 +993,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 079d94cd-6255-4d48-8bd5-b0b584afa8d1
+      - c20545c1-cc88-4b72-9f04-69c4bf2a1d79
     status: 200 OK
     code: 200
     duration: ""
@@ -971,19 +1004,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dde26e8a-871f-473d-9c6d-7651e1d0ce8b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"06519591-cf28-4a5b-8c0e-1d9e99899690","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"dde26e8a-871f-473d-9c6d-7651e1d0ce8b","region":"fr-par","same_zone":false,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"deleting"}'
     headers:
       Content-Length:
-      - "342"
+      - "332"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:57:03 GMT
+      - Thu, 02 Nov 2023 18:57:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -993,7 +1026,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86fb8dcc-974d-4909-a496-6412afaf9fc4
+      - edaf2256-6a25-45bb-8ed8-44a331868c29
     status: 200 OK
     code: 200
     duration: ""
@@ -1004,19 +1037,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dde26e8a-871f-473d-9c6d-7651e1d0ce8b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
     method: GET
   response:
-    body: '{"endpoints":[{"id":"06519591-cf28-4a5b-8c0e-1d9e99899690","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"dde26e8a-871f-473d-9c6d-7651e1d0ce8b","region":"fr-par","same_zone":false,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"deleting"}'
     headers:
       Content-Length:
-      - "342"
+      - "332"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:57:03 GMT
+      - Thu, 02 Nov 2023 18:57:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1026,7 +1059,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3dbbd3e4-826c-404e-8d06-ca694bb2a14f
+      - 77fd0ada-da37-412b-8dd3-96837a382110
     status: 200 OK
     code: 200
     duration: ""
@@ -1037,10 +1070,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dde26e8a-871f-473d-9c6d-7651e1d0ce8b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"dde26e8a-871f-473d-9c6d-7651e1d0ce8b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"c4321b24-ff18-4265-908e-4de50dcafc55","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1049,7 +1082,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:57:33 GMT
+      - Thu, 02 Nov 2023 18:57:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1059,12 +1092,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a6c5e48-3da7-4e01-bbba-fd346657340a
+      - 8a43fef0-d3f0-4103-ac61-28f73a70fa19
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"instance_id":"74b78673-7af5-4133-a052-78060b4532b6","endpoint_spec":[{"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","ipam_config":{}}}],"same_zone":true}'
+    body: '{"instance_id":"1abb44d0-9c57-4261-9d96-408a43928ce6","endpoint_spec":[{"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","ipam_config":{}}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
@@ -1075,16 +1108,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[{"id":"281a6828-0db4-4712-995c-7b331a5b5639","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "345"
+      - "335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:57:34 GMT
+      - Thu, 02 Nov 2023 18:57:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1094,7 +1127,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ff8f824-81af-41cd-aabb-40c4188d0aad
+      - 23071623-68b0-48fc-813e-068724ffc2cf
     status: 200 OK
     code: 200
     duration: ""
@@ -1105,19 +1138,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
     method: GET
   response:
-    body: '{"endpoints":[{"id":"281a6828-0db4-4712-995c-7b331a5b5639","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "345"
+      - "335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:57:34 GMT
+      - Thu, 02 Nov 2023 18:57:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1127,7 +1160,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2232c9d0-f1a9-4e2a-a1b5-0395790f62ed
+      - 3dec8bea-f744-416a-8f15-74c14f3bb048
     status: 200 OK
     code: 200
     duration: ""
@@ -1138,19 +1171,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
     method: GET
   response:
-    body: '{"endpoints":[{"id":"281a6828-0db4-4712-995c-7b331a5b5639","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "345"
+      - "335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:58:04 GMT
+      - Thu, 02 Nov 2023 18:58:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1160,7 +1193,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28092059-eedc-41d5-85b1-931f50aa08f3
+      - 37329533-b55f-433e-91b3-b1e0933670ec
     status: 200 OK
     code: 200
     duration: ""
@@ -1171,19 +1204,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
     method: GET
   response:
-    body: '{"endpoints":[{"id":"281a6828-0db4-4712-995c-7b331a5b5639","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "345"
+      - "335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:58:34 GMT
+      - Thu, 02 Nov 2023 18:58:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1193,7 +1226,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1720720b-56b0-47dc-bc57-66b9d6f7ea62
+      - f9227799-3bea-4308-a626-2090d3d0e55b
     status: 200 OK
     code: 200
     duration: ""
@@ -1204,19 +1237,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
     method: GET
   response:
-    body: '{"endpoints":[{"id":"281a6828-0db4-4712-995c-7b331a5b5639","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "345"
+      - "335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:59:04 GMT
+      - Thu, 02 Nov 2023 18:59:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1226,7 +1259,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7591a77a-db6c-4e1f-a326-55f479d387a1
+      - a18ad616-fc8c-4b87-a071-6dd2e0096f4d
     status: 200 OK
     code: 200
     duration: ""
@@ -1237,19 +1270,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
     method: GET
   response:
-    body: '{"endpoints":[{"id":"281a6828-0db4-4712-995c-7b331a5b5639","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "338"
+      - "335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:59:34 GMT
+      - Thu, 02 Nov 2023 18:59:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1259,7 +1292,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1cf67426-e666-4cac-97b5-97d0924b13e6
+      - 37081f71-c41b-4a08-a338-de7bfad24801
     status: 200 OK
     code: 200
     duration: ""
@@ -1270,19 +1303,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
     method: GET
   response:
-    body: '{"endpoints":[{"id":"281a6828-0db4-4712-995c-7b331a5b5639","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "338"
+      - "328"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:59:35 GMT
+      - Thu, 02 Nov 2023 19:00:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1292,7 +1325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f8b21c4-1dad-44ba-8bae-8e817777c004
+      - ccf919d5-4f0a-429f-a2d8-a3ab9fb0ffbd
     status: 200 OK
     code: 200
     duration: ""
@@ -1303,19 +1336,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
     method: GET
   response:
-    body: '{"endpoints":[{"id":"281a6828-0db4-4712-995c-7b331a5b5639","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "338"
+      - "328"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:59:35 GMT
+      - Thu, 02 Nov 2023 19:00:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1325,7 +1358,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4340577b-33e3-486a-8a3f-3e21bed62ddd
+      - 015c2bba-5954-4d33-b427-04c0e7550870
     status: 200 OK
     code: 200
     duration: ""
@@ -1336,19 +1369,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/88788df1-c166-4633-8271-d9e244577053
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T13:51:52.206160Z","dhcp_enabled":true,"id":"88788df1-c166-4633-8271-d9e244577053","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:51:52.206160Z","id":"716e3f19-3a55-40d9-acba-9602513e22d9","subnet":"172.16.20.0/22","updated_at":"2023-10-20T13:51:52.206160Z"},{"created_at":"2023-10-20T13:51:52.206160Z","id":"afcc9d9c-bf6a-4f54-a2cb-a88b32349844","subnet":"fd63:256c:45f7:daf3::/64","updated_at":"2023-10-20T13:51:52.206160Z"}],"tags":[],"updated_at":"2023-10-20T13:51:52.206160Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "727"
+      - "328"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:59:35 GMT
+      - Thu, 02 Nov 2023 19:00:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1358,7 +1391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5de341ff-ad0a-478c-81ba-b31931de778d
+      - c8b02e87-ef98-4f39-af4e-a109946526a9
     status: 200 OK
     code: 200
     duration: ""
@@ -1369,19 +1402,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/88788df1-c166-4633-8271-d9e244577053
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6638dd56-857d-4602-a836-dc564d3eff6d
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T13:51:52.206160Z","dhcp_enabled":true,"id":"88788df1-c166-4633-8271-d9e244577053","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T13:51:52.206160Z","id":"716e3f19-3a55-40d9-acba-9602513e22d9","subnet":"172.16.20.0/22","updated_at":"2023-10-20T13:51:52.206160Z"},{"created_at":"2023-10-20T13:51:52.206160Z","id":"afcc9d9c-bf6a-4f54-a2cb-a88b32349844","subnet":"fd63:256c:45f7:daf3::/64","updated_at":"2023-10-20T13:51:52.206160Z"}],"tags":[],"updated_at":"2023-10-20T13:51:52.206160Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-02T18:51:42.626490Z","dhcp_enabled":true,"id":"6638dd56-857d-4602-a836-dc564d3eff6d","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:51:42.626490Z","id":"f5ebbf64-601e-4198-ac41-ec60e55600f8","subnet":"172.16.20.0/22","updated_at":"2023-11-02T18:51:42.626490Z"},{"created_at":"2023-11-02T18:51:42.626490Z","id":"5edc57aa-f173-4234-aae4-bbec1c6797d3","subnet":"fd63:256c:45f7:eb34::/64","updated_at":"2023-11-02T18:51:42.626490Z"}],"tags":[],"updated_at":"2023-11-02T18:51:42.626490Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "727"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:59:35 GMT
+      - Thu, 02 Nov 2023 19:00:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1391,7 +1424,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e760e4f0-c000-4f54-b35a-55d203ed20ce
+      - 43770051-3500-40da-bd62-90e5c1c920f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1402,19 +1435,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74b78673-7af5-4133-a052-78060b4532b6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6638dd56-857d-4602-a836-dc564d3eff6d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T13:51:52.438402Z","endpoint":{"id":"4fa52573-d70f-4a9b-a86a-16b5d4b02605","ip":"51.159.25.173","load_balancer":{},"name":null,"port":24399},"endpoints":[{"id":"4fa52573-d70f-4a9b-a86a-16b5d4b02605","ip":"51.159.25.173","load_balancer":{},"name":null,"port":24399}],"engine":"PostgreSQL-14","id":"74b78673-7af5-4133-a052-78060b4532b6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"281a6828-0db4-4712-995c-7b331a5b5639","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"created_at":"2023-11-02T18:51:42.626490Z","dhcp_enabled":true,"id":"6638dd56-857d-4602-a836-dc564d3eff6d","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:51:42.626490Z","id":"f5ebbf64-601e-4198-ac41-ec60e55600f8","subnet":"172.16.20.0/22","updated_at":"2023-11-02T18:51:42.626490Z"},{"created_at":"2023-11-02T18:51:42.626490Z","id":"5edc57aa-f173-4234-aae4-bbec1c6797d3","subnet":"fd63:256c:45f7:eb34::/64","updated_at":"2023-11-02T18:51:42.626490Z"}],"tags":[],"updated_at":"2023-11-02T18:51:42.626490Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1745"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:59:35 GMT
+      - Thu, 02 Nov 2023 19:00:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1424,7 +1457,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 966c36e8-2552-491f-86ba-b63cf28850d9
+      - aaccdb4d-d31a-4139-a122-08297621e3cf
     status: 200 OK
     code: 200
     duration: ""
@@ -1435,19 +1468,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74b78673-7af5-4133-a052-78060b4532b6/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVU2dBTDFrVXRkcnQrOHVCWXZUcjB3YzVMRE5Jd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5TlM0eE56TXdIaGNOCk1qTXhNREl3TVRNMU1qTXlXaGNOTXpNeE1ERTNNVE0xTWpNeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTFMakUzTXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUt3d3VmaThmaUlLbElFYmhZVGNCenpMN09UeDJ2K0xMd1FWMldEak5nL0dLUG5PUnQ3MUxsMUsKd3FzOE9IMnZzYlJLd3JLc3NRRUlDUERGODdYcy9YYmhMZEpsVXlzMVdmUG1nNm45dktZNWdjZm94RTZiVHpwSQpjc3h6NGZEek1tU1NXL1VpTXZPRG5lMGlTakZYRUJ4REFVbUFPMmlxK0NIeEsyMUdGQnVicXNsS2ExeUxNOCt2CnpSN2dianlCWFNzL0IrdWJrWnVQY2N3dnhrd3dEN0xZZURpNFVCWHBxR1ZTUUFTY0s5cWsrK205VnA0Zy9UTGUKVlhNVFgyTTAzTXpOUW1ybFVES3dHdTk3U0l5MzI4NVh6aWxLVHJpcCtQTGlFTHN1QkV1eU5KeHpudHM2RmVlVwo2ejg1UDlka3U5R3FrVEMzQ1RadUNUUEtCSmtqTXRjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkxTGpFM000SThjbmN0TnpSaU56ZzJOek10TjJGbU5TMDBNVE16TFdFd05USXROemd3TmpCaU5EVXoKTW1JMkxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckkySGh3UXpueG10TUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQVk1ei9UWm1zQXIxSy9MZUlmVGVFNlFQdFZjQWRGbEhvUWpzZldJdDBwSHBvdWk3WE16bTBUClE4N3NXb1drTVhNbmsweEhvL0g0OGtTUGhiSHdZdnRveVprSi82elJEbWpQV1AvS2J3bm9kRDhBWDUzVWR6di8KTitqNWxKODBCR0J6N2RDY2Z5c05HdzVGUktEL0JWcjZMS0ZEMUtzSXhEM2lrYmJNak5uQVBGbml2ZVZqRG1sQwpCU3BYK28xbzcwcjk2TVRGNTJjeWNUWVpjQnpkN3ZKVFh6bzJkNkNIYlZsNDhyVW5kYVpDL205K05IWXFFVXlPCitaYWtldjN2SzZaMlhxNkg0Zk4yT2JkelFtS3dOa0txYmx5aW9YQWZSeFZJOE0yYTVUczBOSXAvR3QvRlVydmsKWFB3WStnbG15SVIzU2pGSCt0SzROc0ZuR2RpaGhOZmsKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184},"endpoints":[{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184}],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1845"
+      - "1684"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:59:35 GMT
+      - Thu, 02 Nov 2023 19:00:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1457,7 +1490,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e0cda9a-0c82-480c-a282-b0aa75174846
+      - 05263358-2854-4efb-9472-3ea87347b2e8
     status: 200 OK
     code: 200
     duration: ""
@@ -1468,19 +1501,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6/certificate
     method: GET
   response:
-    body: '{"endpoints":[{"id":"281a6828-0db4-4712-995c-7b331a5b5639","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVYkVjM0IxcU92MHc4QUY0d096SXpSZGpvdUZrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1qSTBXaGNOTXpNeE1ETXdNVGcxTWpJMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU90bm00TDV2ajBqWDJJblNTQXhncTBOU05TaHdtelF4QWIyeHg4elo1K3hLbERubGFCK2xwOXYKUG1MZnkzRmZJM1hqLyt5SlFjTnh3M0RVOWQ2a2pnbFNRWFQvUVpGNkFiWUxsMkF4OU9MR1RXaUFFQW5TSEU3LwowTnF6RGJ3M3JnYVpMbFFmYmFQdnZBNzRmTFJFNUZOalRBMlh5UGM0RXJra05KWjNOQnl3OEt3WThiWVVMVkswCmZ2WUZhbEZCSEdrM1pNTkZ1YXQ4VjVoYmlrTmZvYjlGT3ExbTZvL1NFUEpqazlIYXprTGJobHd0MUJ5Slp5VUIKc0psdWliOXp0YlNBMUY1Q3VIaC9WbC9nN3RRL1dPMHBrV2tmbWN3WnMrcXBjaVg2TC9iaVp2TDlkT2UwVXVHNwptcmlNaVQ4MmVlYmUyMmZVUnBXdmh1enVXMGk4WmtjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TVdGaVlqUTBaREF0T1dNMU55MDBNall4TFRsa09UWXROREE0WVRRek9USTQKWTJVMkxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm1PSmh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRRFpFaVNHakZwMVl2NjIwL1MrZzF0MUs2d2JJVS8rUzVLUklkVmJMdWlaSkRqaXVyb3dMQXhQCm0yaUdqdWJOSkJsTWIzYmlaOCsrUG5pemErclBHckN6d1pXVFdXd0ZkWng0U24zUzc5Tm5WRytlTkcxQitIa2kKTnRpc2lERCtrSWR1RUFmcGNFRVE5U3B2SGZ4eXRHYWhua3VLSyt6bmIxOWM2cTd0UUJ5SHA2WmVPcVErOEIwcApHbnlleWdzeW5sTS8xQnRzZlYzS3lja3I2V0lsRDBRemRoSUFOVWNtN1FBdzF1VEJ6a0RrdElqOHBKMndNejNEClVBME5ONDBCN2Jlb2c5N3pZRHpGWmFqQWRKNWJHT3hLaVo5V3hoUXd2KzRwNVdvMENIUXp5OVRRSTV2elpQM1MKbkNlSFM1bWN3azZDMkdKemJ5QnkxcVk1TTJ2cjlSdnQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "338"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:59:35 GMT
+      - Thu, 02 Nov 2023 19:00:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1490,7 +1523,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90a23167-2942-4863-a2af-01e746b0baf4
+      - 7935fbc3-beaa-4916-9109-b6c4b395f0ec
     status: 200 OK
     code: 200
     duration: ""
@@ -1501,19 +1534,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
     method: GET
   response:
-    body: '{"endpoints":[{"id":"281a6828-0db4-4712-995c-7b331a5b5639","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "338"
+      - "328"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:59:36 GMT
+      - Thu, 02 Nov 2023 19:00:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1523,7 +1556,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a1b4f68-23a2-4147-86d8-b50d3032b83d
+      - 77a85123-b396-4691-9995-17618464fd27
     status: 200 OK
     code: 200
     duration: ""
@@ -1534,19 +1567,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "328"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 19:00:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d7e388ed-6f15-4060-8ec4-6659fc4a04c8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"281a6828-0db4-4712-995c-7b331a5b5639","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "341"
+      - "331"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:59:36 GMT
+      - Thu, 02 Nov 2023 19:00:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1556,7 +1622,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab7d00e4-dc9a-4fae-ad04-ca7048ae5ad2
+      - caef4537-3367-4942-a8a5-b27c22f10bde
     status: 200 OK
     code: 200
     duration: ""
@@ -1567,19 +1633,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
     method: GET
   response:
-    body: '{"endpoints":[{"id":"281a6828-0db4-4712-995c-7b331a5b5639","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"88788df1-c166-4633-8271-d9e244577053","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "341"
+      - "331"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 13:59:37 GMT
+      - Thu, 02 Nov 2023 19:00:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1589,7 +1655,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6aa5711-22a8-4d8c-a226-5597a68d6bab
+      - 7fa9aa72-dcc9-4c1f-845a-c6590a564e43
     status: 200 OK
     code: 200
     duration: ""
@@ -1600,10 +1666,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1612,7 +1678,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 14:00:07 GMT
+      - Thu, 02 Nov 2023 19:00:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1622,7 +1688,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08f93fb6-5bff-4f01-a761-4ce48d609be6
+      - a2461ca4-71fe-4143-8ec9-679acf29ebd1
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1633,106 +1699,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74b78673-7af5-4133-a052-78060b4532b6
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T13:51:52.438402Z","endpoint":{"id":"4fa52573-d70f-4a9b-a86a-16b5d4b02605","ip":"51.159.25.173","load_balancer":{},"name":null,"port":24399},"endpoints":[{"id":"4fa52573-d70f-4a9b-a86a-16b5d4b02605","ip":"51.159.25.173","load_balancer":{},"name":null,"port":24399}],"engine":"PostgreSQL-14","id":"74b78673-7af5-4133-a052-78060b4532b6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1407"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 14:00:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 90ace741-cefd-4e3b-9fd6-885c83dbe6aa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74b78673-7af5-4133-a052-78060b4532b6
-    method: DELETE
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T13:51:52.438402Z","endpoint":{"id":"4fa52573-d70f-4a9b-a86a-16b5d4b02605","ip":"51.159.25.173","load_balancer":{},"name":null,"port":24399},"endpoints":[{"id":"4fa52573-d70f-4a9b-a86a-16b5d4b02605","ip":"51.159.25.173","load_balancer":{},"name":null,"port":24399}],"engine":"PostgreSQL-14","id":"74b78673-7af5-4133-a052-78060b4532b6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1410"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 14:00:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 23c8ffd7-1e9b-4593-ae86-18e7687b1c77
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74b78673-7af5-4133-a052-78060b4532b6
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T13:51:52.438402Z","endpoint":{"id":"4fa52573-d70f-4a9b-a86a-16b5d4b02605","ip":"51.159.25.173","load_balancer":{},"name":null,"port":24399},"endpoints":[{"id":"4fa52573-d70f-4a9b-a86a-16b5d4b02605","ip":"51.159.25.173","load_balancer":{},"name":null,"port":24399}],"engine":"PostgreSQL-14","id":"74b78673-7af5-4133-a052-78060b4532b6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1410"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 14:00:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 43531c8b-1d4e-4039-a39c-c7559531250d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/88788df1-c166-4633-8271-d9e244577053
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6638dd56-857d-4602-a836-dc564d3eff6d
     method: DELETE
   response:
     body: ""
@@ -1742,7 +1709,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 14:00:07 GMT
+      - Thu, 02 Nov 2023 19:00:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1752,7 +1719,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 068a87a5-f6f6-4a74-adb7-c2a800c12678
+      - c4f4a9da-c31f-41d6-8696-27a3ad964270
     status: 204 No Content
     code: 204
     duration: ""
@@ -1763,19 +1730,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74b78673-7af5-4133-a052-78060b4532b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"74b78673-7af5-4133-a052-78060b4532b6","type":"not_found"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184},"endpoints":[{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184}],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "129"
+      - "1356"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 14:00:37 GMT
+      - Thu, 02 Nov 2023 19:01:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1785,7 +1752,106 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43932b04-6378-4662-8ffc-b7bff7a1f809
+      - c88247ed-cded-4916-919b-580127cd4fd2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
+    method: DELETE
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184},"endpoints":[{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184}],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1359"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 19:01:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 57453225-72f5-41b2-9dad-73458d08518b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184},"endpoints":[{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184}],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1359"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 19:01:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c0241256-7884-4015-80db-5c7e41335b22
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"1abb44d0-9c57-4261-9d96-408a43928ce6","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "129"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 19:01:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a9a2d927-dc00-461a-b4a9-e5f4d71c5f20
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1796,10 +1862,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74b78673-7af5-4133-a052-78060b4532b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"74b78673-7af5-4133-a052-78060b4532b6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"1abb44d0-9c57-4261-9d96-408a43928ce6","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1808,7 +1874,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 14:00:37 GMT
+      - Thu, 02 Nov 2023 19:01:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1818,7 +1884,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67735c08-4aeb-4622-a2bb-99c3a2785b7a
+      - 696187d2-8ace-42fc-8b0f-786c4b427e7c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1829,10 +1895,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"8c0f03c2-90c8-4b08-9c13-35ccf6d02c3d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1841,7 +1907,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 14:00:38 GMT
+      - Thu, 02 Nov 2023 19:01:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1851,7 +1917,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77096260-8da7-4cdc-8817-60fd964b4fdb
+      - b6a01ce4-79b7-4cce-94a7-868e98777ec5
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-multiple-endpoints.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-multiple-endpoints.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:08 GMT
+      - Thu, 02 Nov 2023 18:46:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4edbb8da-ab9d-43ba-b805-909ac9494333
+      - ac1e2a28-54be-4f27-988f-ecd56b30e90f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-multiple-endpoints","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-multiple-endpoints","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:51.236972Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"f92778af-b52b-498e-b1d0-8753ae6dfa6e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "803"
+      - "774"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:51 GMT
+      - Thu, 02 Nov 2023 18:53:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,12 +363,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10299a31-42dc-422a-bd1b-a1d82f94dfe3
+      - f093a8a2-6f02-42b3-8b4e-147fc6da7e17
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-pn-xenodochial-snyder","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "774"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 013f67dd-9e7f-40ee-913e-3853364d7322
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"tf-pn-silly-nobel","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -379,16 +412,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-20T15:55:50.970041Z","dhcp_enabled":true,"id":"30d188dd-5ba2-49f1-96c1-64d577dc5a01","name":"tf-pn-xenodochial-snyder","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T15:55:50.970041Z","id":"b19b99eb-c012-443d-9421-b43338b0fab5","subnet":"172.16.12.0/22","updated_at":"2023-10-20T15:55:50.970041Z"},{"created_at":"2023-10-20T15:55:50.970041Z","id":"303c8aaa-4376-4c38-925e-ee83d1a3d845","subnet":"fd63:256c:45f7:d2e0::/64","updated_at":"2023-10-20T15:55:50.970041Z"}],"tags":[],"updated_at":"2023-10-20T15:55:50.970041Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-02T18:53:32.999053Z","dhcp_enabled":true,"id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","name":"tf-pn-silly-nobel","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:53:32.999053Z","id":"9258e348-06a6-4cef-b394-bb246b05afc3","subnet":"172.16.12.0/22","updated_at":"2023-11-02T18:53:32.999053Z"},{"created_at":"2023-11-02T18:53:32.999053Z","id":"819c14be-d6ae-4bd2-bd41-e892578291d1","subnet":"fd63:256c:45f7:cd3f::/64","updated_at":"2023-11-02T18:53:32.999053Z"}],"tags":[],"updated_at":"2023-11-02T18:53:32.999053Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "725"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:51 GMT
+      - Thu, 02 Nov 2023 18:53:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -398,7 +431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8bf2949-4eca-4659-a920-8bd3fb378285
+      - b0c2d5c7-41bd-46fb-8add-71f438388e17
     status: 200 OK
     code: 200
     duration: ""
@@ -409,19 +442,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f92778af-b52b-498e-b1d0-8753ae6dfa6e
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/89c22642-6cdb-40c2-9b9c-2f582f322f59
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:51.236972Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"f92778af-b52b-498e-b1d0-8753ae6dfa6e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"created_at":"2023-11-02T18:53:32.999053Z","dhcp_enabled":true,"id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","name":"tf-pn-silly-nobel","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:53:32.999053Z","id":"9258e348-06a6-4cef-b394-bb246b05afc3","subnet":"172.16.12.0/22","updated_at":"2023-11-02T18:53:32.999053Z"},{"created_at":"2023-11-02T18:53:32.999053Z","id":"819c14be-d6ae-4bd2-bd41-e892578291d1","subnet":"fd63:256c:45f7:cd3f::/64","updated_at":"2023-11-02T18:53:32.999053Z"}],"tags":[],"updated_at":"2023-11-02T18:53:32.999053Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "803"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:51 GMT
+      - Thu, 02 Nov 2023 18:53:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -431,7 +464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f586c17-f40e-496c-883d-9621b78f0dc8
+      - 43209572-0ad0-49a7-9588-c97de022e4a9
     status: 200 OK
     code: 200
     duration: ""
@@ -442,19 +475,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/30d188dd-5ba2-49f1-96c1-64d577dc5a01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T15:55:50.970041Z","dhcp_enabled":true,"id":"30d188dd-5ba2-49f1-96c1-64d577dc5a01","name":"tf-pn-xenodochial-snyder","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T15:55:50.970041Z","id":"b19b99eb-c012-443d-9421-b43338b0fab5","subnet":"172.16.12.0/22","updated_at":"2023-10-20T15:55:50.970041Z"},{"created_at":"2023-10-20T15:55:50.970041Z","id":"303c8aaa-4376-4c38-925e-ee83d1a3d845","subnet":"fd63:256c:45f7:d2e0::/64","updated_at":"2023-10-20T15:55:50.970041Z"}],"tags":[],"updated_at":"2023-10-20T15:55:50.970041Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "725"
+      - "774"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:51 GMT
+      - Thu, 02 Nov 2023 18:54:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -464,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b87b670-3533-47c7-a452-0aaec1a8608b
+      - a0cc2d16-faa8-4f80-9fc0-b487aa3131d4
     status: 200 OK
     code: 200
     duration: ""
@@ -475,19 +508,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f92778af-b52b-498e-b1d0-8753ae6dfa6e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:51.236972Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"f92778af-b52b-498e-b1d0-8753ae6dfa6e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "803"
+      - "774"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:56:21 GMT
+      - Thu, 02 Nov 2023 18:54:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -497,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2da4ba1a-c96d-4463-9ea8-f53bf327847b
+      - 2b2aad3c-722f-442e-98bd-52afd602e988
     status: 200 OK
     code: 200
     duration: ""
@@ -508,19 +541,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f92778af-b52b-498e-b1d0-8753ae6dfa6e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:51.236972Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"f92778af-b52b-498e-b1d0-8753ae6dfa6e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "803"
+      - "774"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:56:52 GMT
+      - Thu, 02 Nov 2023 18:55:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -530,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f24b10d-9271-4cba-99b4-c9dd5b246980
+      - ec05bea0-59ce-455a-95a2-2aabb0747c27
     status: 200 OK
     code: 200
     duration: ""
@@ -541,19 +574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f92778af-b52b-498e-b1d0-8753ae6dfa6e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:51.236972Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"f92778af-b52b-498e-b1d0-8753ae6dfa6e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "803"
+      - "774"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:23 GMT
+      - Thu, 02 Nov 2023 18:55:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -563,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8557d156-97c6-4ddb-b808-0c33b423d98b
+      - 8a2c6587-2afe-452d-9a97-28574a139764
     status: 200 OK
     code: 200
     duration: ""
@@ -574,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f92778af-b52b-498e-b1d0-8753ae6dfa6e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:51.236972Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"f92778af-b52b-498e-b1d0-8753ae6dfa6e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "803"
+      - "774"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:53 GMT
+      - Thu, 02 Nov 2023 18:56:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79ed19c6-c365-4d3f-8388-ce032fd6cb15
+      - d13a0ec8-9841-4cdb-a2ea-ab12d5ca8eb7
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f92778af-b52b-498e-b1d0-8753ae6dfa6e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:51.236972Z","endpoint":{"id":"66dba1c7-8218-4094-a3f4-a74d74a0bb10","ip":"51.159.26.148","load_balancer":{},"name":null,"port":10734},"endpoints":[{"id":"66dba1c7-8218-4094-a3f4-a74d74a0bb10","ip":"51.159.26.148","load_balancer":{},"name":null,"port":10734}],"engine":"PostgreSQL-15","id":"f92778af-b52b-498e-b1d0-8753ae6dfa6e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":{"id":"1f44e058-95da-4e08-b347-9a4da0096f44","ip":"51.159.25.65","load_balancer":{},"name":null,"port":2450},"endpoints":[{"id":"1f44e058-95da-4e08-b347-9a4da0096f44","ip":"51.159.25.65","load_balancer":{},"name":null,"port":2450}],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1295"
+      - "1243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:24 GMT
+      - Thu, 02 Nov 2023 18:56:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc482b0d-6862-4a41-b8d2-965452fd8dea
+      - aaed5dc9-aeb1-4378-9d84-3d232d621823
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f92778af-b52b-498e-b1d0-8753ae6dfa6e/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVVDhFQktBWWhzVUNWQTc5UkRKUXZMZUJqWTJnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5qSTVXaGNOTXpNeE1ERTNNVFUxTmpJNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUlzbVBJRDBWdG1tVjQxbGlnZEhPVks1VDNEYTh4QjBDWGxwNUFsSVplY2d3bU53aStsa1dGMTkKNHI2NTFqRkJjdmlLeG0wbWdvQ0JmU2pUUS9yeEZPYnlSUzREL3JWdkd3QVpETlVLUUJiL09aSnRXcy9MMlUyQwpvUGVSK2RXVkp4bzBrOFZUQjRXRmJnUzI3a2lYU1E3RnZ5c1BCK3dyZE9Ba1owNWh2TU9GbVlzWVNuMzVZY04rCk0rTmp3WjliWWRCcDViQmVZL1BnWGxOOUp0UCtJbElScGp3ZFBOSzEvWjR0cE44TmNkZUcvQ1lBN0NheWhvZFkKM2hSaVNqSmpTcS9EKzU1WVVxR21FME9GNlplWU9TakorSDRFakJBbzRkeGF1aXkzR3BJQ1lINHRxUXJMVGMyQQphanZpc0Q3SGlYbnNoQVQ2Si81Yi9YcGw3KytmeVRjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0WmpreU56YzRZV1l0WWpVeVlpMDBPVGhsTFdJeFpEQXRPRGMxTTJGbE5tUm0KWVRabExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1Nqckk1b2h3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ0RGcXNxWncwd2E4dHg3b3EvRTNmSzB1K3VYTGtJNnhmNnB0RXY5a0szTnI2TDJTUE5qRE9wCmRmRTdHdWNXODhOQ01kNFBKb3hubVc4eVFMc3FXTHFmSkRmR2IrN3ZJMURDN2p6M3NSQ05wY2VCSVJUaThuSkgKNHZZTVBsWE1UZ04xOHduNENmeno1WG5MakE4ZWRJN2s4dGQ1ZXJOUGlpUkc5dEtobkJUZ09ra0Z6MStvV2luNAp0UWY1TzZhT05PWFl1cXBqZUh6ZU5mZEFuWHA1cDNqNHhJWUJIeTVycFdCNGo0amZhSWdrbUR0OHFUeVV1RitWCm13ZDFkY3YvelhEKy80ZlZFT0QzNG9nS1h4aHU5a29pUloyaDVEZUxXYTZXdkYwcjFqTUdMM1M1QWdRK1VFTmsKWXRnQkQrSGhqWklIVkplbDF6Z2tPVkFXb2oyNHVnQlIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVS29nZUFRenhWNGdrQ3ZkbThmVzJacUxhVlFnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR5TlM0Mk5UQWVGdzB5Ck16RXhNREl4T0RVME1USmFGdzB6TXpFd016QXhPRFUwTVRKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1qVXVOalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNzdmNuTWVTTGEzNm11bUxGS1J0L21wOGIzZldJTzNhNFpXdXBPbHFMdDZvaUtTZVZVSEk0UUdJeSsKYTVYWUxwdFM3ekVDYzdEZ1o2bTdvOURpNkhBYi9CVG1Ub1dMSG1JY0V4aG85dENTdFF6UWlxQXBlZ3hudngyQQp5Sldzd0xsZEkzSTJmUCtBajl1NGZvTEQ1dC9RRjY3TFRMeFJUQ3pCN1F4V2pueWxPbXdZMEJHa3BramNSRVRuCjVkMjVLNFlpaWo5S3F4NEtRWVNUYVNuS1lMckg0NGNydEl3TS9PWVNwTS9KeStqa1hmK0tpc00rYSszV1J0MmYKYytxYVBNTC9PR3kya3JtelJFNUg0WUtmWFgybFdDSzZDbGVvR3ljR0tMQjlZZkdnNDZUM21tNk5sZEQ4VEJregptZ2t0ZlhrVkczeFc1bHJacVNzRzRSVlUwMWhYQWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHlOUzQyTllJOGNuY3RPRFV3WkRFMFpXTXRaalV4TVMwME0ySXlMVGt4WTJZdE5USmhNVGxtTURVNU5UVXkKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pyS3RnaHdRem54bEJNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFCS0ZYTWVlQW5BNHBaUUZNZE94Qlg5TkNEK0l5UDRYL296R0hwRHJGS1VQdzgyMFhEcEVPSFkvdGFCCi9vbDhxTGNua0liUjJMemNKVDZ6S2JQcFZBWTdwM21yMzNKaDhycFdwdHVSaEdqMUVWOW8vOVM5YVFpcEFqR3UKVVBaR3YwWTZobXFPdHBTZEt2U2lCelFCYWNXWnk2aEgyMUczYTQvYUtjZWtPR0FzeW5DUE9yZ1VXMzY1L2pIWQpUbm1GYjBkWVltWG45ajEybFVWUVA2TC83clE2d0hUWWlTVHZDQ0lxWnFUNjF0cFk0QzZRSS9ka016NzMvRW9yCndSZy9Ldmc2UjBLMDdVMzR2RlhUUXZQOWxrUTNYeERwbFhCdVFTS3M2WEJaYk5NczFWWVMwWThRWkowQ3l0emkKOEppUkh3U1IxdXh5TmFuTXhTaHlEaEZVYXljQQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1839"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:24 GMT
+      - Thu, 02 Nov 2023 18:56:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,12 +695,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a9c7b52-bcc5-4393-a1a9-070ea3cf2e55
+      - 82e07f5f-96fc-4dc1-bbb5-dda37ca84222
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"f92778af-b52b-498e-b1d0-8753ae6dfa6e","endpoint_spec":[{"direct_access":{}},{"private_network":{"private_network_id":"30d188dd-5ba2-49f1-96c1-64d577dc5a01","service_ip":"10.12.1.0/20"}}],"same_zone":null}'
+    body: '{"instance_id":"850d14ec-f511-43b2-91cf-52a19f059552","endpoint_spec":[{"direct_access":{}},{"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20"}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
@@ -678,16 +711,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[{"id":"c2754ad4-7c1f-4195-af4c-f3f37694a293","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"30d188dd-5ba2-49f1-96c1-64d577dc5a01","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b8b7564c-5af0-4c15-a81b-7dd897208133","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "341"
+      - "331"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:25 GMT
+      - Thu, 02 Nov 2023 18:56:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -697,7 +730,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b2638bc-8b49-4c25-a918-e0f99b54b449
+      - 1983cf43-a298-49ce-a344-626edc791319
     status: 200 OK
     code: 200
     duration: ""
@@ -708,19 +741,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b8b7564c-5af0-4c15-a81b-7dd897208133
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
     method: GET
   response:
-    body: '{"endpoints":[{"id":"c2754ad4-7c1f-4195-af4c-f3f37694a293","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"30d188dd-5ba2-49f1-96c1-64d577dc5a01","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b8b7564c-5af0-4c15-a81b-7dd897208133","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "341"
+      - "331"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:25 GMT
+      - Thu, 02 Nov 2023 18:56:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -730,7 +763,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c6f5c1a-f4a9-4f4c-b40f-65fcea23686e
+      - e04c4eec-7093-4e97-b1b4-933a3d2bdc29
     status: 200 OK
     code: 200
     duration: ""
@@ -741,19 +774,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b8b7564c-5af0-4c15-a81b-7dd897208133
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
     method: GET
   response:
-    body: '{"endpoints":[{"id":"c2754ad4-7c1f-4195-af4c-f3f37694a293","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"30d188dd-5ba2-49f1-96c1-64d577dc5a01","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b8b7564c-5af0-4c15-a81b-7dd897208133","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "341"
+      - "331"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:57 GMT
+      - Thu, 02 Nov 2023 18:57:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7e4e0f4-f8de-4dd7-9edd-5b0814eb6e8a
+      - afbb66f3-f29a-44b4-b94a-9ec44574e48c
     status: 200 OK
     code: 200
     duration: ""
@@ -774,19 +807,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b8b7564c-5af0-4c15-a81b-7dd897208133
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
     method: GET
   response:
-    body: '{"endpoints":[{"id":"c2754ad4-7c1f-4195-af4c-f3f37694a293","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"30d188dd-5ba2-49f1-96c1-64d577dc5a01","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b8b7564c-5af0-4c15-a81b-7dd897208133","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "341"
+      - "331"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:28 GMT
+      - Thu, 02 Nov 2023 18:57:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21a05070-cf25-4f51-93df-8c7877226363
+      - 2716a9d9-5ccd-4a68-a5e3-3f7c3224a2b5
     status: 200 OK
     code: 200
     duration: ""
@@ -807,19 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b8b7564c-5af0-4c15-a81b-7dd897208133
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
     method: GET
   response:
-    body: '{"endpoints":[{"id":"c2754ad4-7c1f-4195-af4c-f3f37694a293","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"30d188dd-5ba2-49f1-96c1-64d577dc5a01","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"042b42c1-76dc-44c3-a4d2-05d997580ef8","ip":"51.15.237.74","name":null,"port":5432}],"id":"b8b7564c-5af0-4c15-a81b-7dd897208133","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7ccbafdb-ef50-44d2-882c-2a3d1601cb2f","ip":"51.15.131.88","name":null,"port":5432}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "455"
+      - "440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:01 GMT
+      - Thu, 02 Nov 2023 18:58:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a22d7a2-19bc-445d-96fd-445e5096e669
+      - 76703d8a-7803-443f-b526-732580dc74f0
     status: 200 OK
     code: 200
     duration: ""
@@ -840,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b8b7564c-5af0-4c15-a81b-7dd897208133
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
     method: GET
   response:
-    body: '{"endpoints":[{"id":"c2754ad4-7c1f-4195-af4c-f3f37694a293","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"30d188dd-5ba2-49f1-96c1-64d577dc5a01","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"042b42c1-76dc-44c3-a4d2-05d997580ef8","ip":"51.15.237.74","name":null,"port":5432}],"id":"b8b7564c-5af0-4c15-a81b-7dd897208133","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7ccbafdb-ef50-44d2-882c-2a3d1601cb2f","ip":"51.15.131.88","name":null,"port":5432}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "455"
+      - "440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:32 GMT
+      - Thu, 02 Nov 2023 18:58:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f337b0de-6e9a-4a0c-adaf-c9d2da6742b5
+      - 53d0a88a-20b2-4cfb-a70f-37136288e838
     status: 200 OK
     code: 200
     duration: ""
@@ -873,19 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b8b7564c-5af0-4c15-a81b-7dd897208133
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
     method: GET
   response:
-    body: '{"endpoints":[{"id":"c2754ad4-7c1f-4195-af4c-f3f37694a293","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"30d188dd-5ba2-49f1-96c1-64d577dc5a01","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"042b42c1-76dc-44c3-a4d2-05d997580ef8","ip":"51.15.237.74","name":null,"port":5432}],"id":"b8b7564c-5af0-4c15-a81b-7dd897208133","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7ccbafdb-ef50-44d2-882c-2a3d1601cb2f","ip":"51.15.131.88","name":null,"port":5432}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "448"
+      - "433"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:02 GMT
+      - Thu, 02 Nov 2023 18:59:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5279af27-428d-4df6-be06-699eb24024fd
+      - ecd5c591-a175-4e18-aecf-a7c051f29da1
     status: 200 OK
     code: 200
     duration: ""
@@ -906,19 +939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b8b7564c-5af0-4c15-a81b-7dd897208133
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
     method: GET
   response:
-    body: '{"endpoints":[{"id":"c2754ad4-7c1f-4195-af4c-f3f37694a293","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"30d188dd-5ba2-49f1-96c1-64d577dc5a01","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"042b42c1-76dc-44c3-a4d2-05d997580ef8","ip":"51.15.237.74","name":null,"port":5432}],"id":"b8b7564c-5af0-4c15-a81b-7dd897208133","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7ccbafdb-ef50-44d2-882c-2a3d1601cb2f","ip":"51.15.131.88","name":null,"port":5432}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "448"
+      - "433"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:02 GMT
+      - Thu, 02 Nov 2023 18:59:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 596a8083-ee2c-431e-ae5a-0431c4c69be4
+      - d6c66e80-db61-4f6b-9ec2-bd297bca8355
     status: 200 OK
     code: 200
     duration: ""
@@ -939,19 +972,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b8b7564c-5af0-4c15-a81b-7dd897208133
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
     method: GET
   response:
-    body: '{"endpoints":[{"id":"c2754ad4-7c1f-4195-af4c-f3f37694a293","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"30d188dd-5ba2-49f1-96c1-64d577dc5a01","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"042b42c1-76dc-44c3-a4d2-05d997580ef8","ip":"51.15.237.74","name":null,"port":5432}],"id":"b8b7564c-5af0-4c15-a81b-7dd897208133","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7ccbafdb-ef50-44d2-882c-2a3d1601cb2f","ip":"51.15.131.88","name":null,"port":5432}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "448"
+      - "433"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:02 GMT
+      - Thu, 02 Nov 2023 18:59:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c84a8a60-2f1b-49d0-9f33-d03bf298ee4a
+      - 0791e2fc-f19d-4f46-9de0-8f12b1fbe45e
     status: 200 OK
     code: 200
     duration: ""
@@ -972,19 +1005,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/30d188dd-5ba2-49f1-96c1-64d577dc5a01
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/89c22642-6cdb-40c2-9b9c-2f582f322f59
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T15:55:50.970041Z","dhcp_enabled":true,"id":"30d188dd-5ba2-49f1-96c1-64d577dc5a01","name":"tf-pn-xenodochial-snyder","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T15:55:50.970041Z","id":"b19b99eb-c012-443d-9421-b43338b0fab5","subnet":"172.16.12.0/22","updated_at":"2023-10-20T15:55:50.970041Z"},{"created_at":"2023-10-20T15:55:50.970041Z","id":"303c8aaa-4376-4c38-925e-ee83d1a3d845","subnet":"fd63:256c:45f7:d2e0::/64","updated_at":"2023-10-20T15:55:50.970041Z"}],"tags":[],"updated_at":"2023-10-20T15:55:50.970041Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-02T18:53:32.999053Z","dhcp_enabled":true,"id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","name":"tf-pn-silly-nobel","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:53:32.999053Z","id":"9258e348-06a6-4cef-b394-bb246b05afc3","subnet":"172.16.12.0/22","updated_at":"2023-11-02T18:53:32.999053Z"},{"created_at":"2023-11-02T18:53:32.999053Z","id":"819c14be-d6ae-4bd2-bd41-e892578291d1","subnet":"fd63:256c:45f7:cd3f::/64","updated_at":"2023-11-02T18:53:32.999053Z"}],"tags":[],"updated_at":"2023-11-02T18:53:32.999053Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "725"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:02 GMT
+      - Thu, 02 Nov 2023 18:59:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e500a6ad-8837-45a0-9e5f-6eb003d11bdf
+      - 94e59850-8ee9-49ad-8724-add68cdb3b08
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,19 +1038,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f92778af-b52b-498e-b1d0-8753ae6dfa6e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:51.236972Z","endpoint":{"id":"66dba1c7-8218-4094-a3f4-a74d74a0bb10","ip":"51.159.26.148","load_balancer":{},"name":null,"port":10734},"endpoints":[{"id":"66dba1c7-8218-4094-a3f4-a74d74a0bb10","ip":"51.159.26.148","load_balancer":{},"name":null,"port":10734}],"engine":"PostgreSQL-15","id":"f92778af-b52b-498e-b1d0-8753ae6dfa6e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"c2754ad4-7c1f-4195-af4c-f3f37694a293","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"30d188dd-5ba2-49f1-96c1-64d577dc5a01","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"042b42c1-76dc-44c3-a4d2-05d997580ef8","ip":"51.15.237.74","name":null,"port":5432}],"id":"b8b7564c-5af0-4c15-a81b-7dd897208133","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":{"id":"1f44e058-95da-4e08-b347-9a4da0096f44","ip":"51.159.25.65","load_balancer":{},"name":null,"port":2450},"endpoints":[{"id":"1f44e058-95da-4e08-b347-9a4da0096f44","ip":"51.159.25.65","load_balancer":{},"name":null,"port":2450}],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7ccbafdb-ef50-44d2-882c-2a3d1601cb2f","ip":"51.15.131.88","name":null,"port":5432}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1743"
+      - "1676"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:02 GMT
+      - Thu, 02 Nov 2023 18:59:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4844f836-bb7e-4a8a-92ae-c49715896820
+      - fa83ff04-e87e-4bca-9939-e0fefc7a13e7
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +1071,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f92778af-b52b-498e-b1d0-8753ae6dfa6e/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVVDhFQktBWWhzVUNWQTc5UkRKUXZMZUJqWTJnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5qSTVXaGNOTXpNeE1ERTNNVFUxTmpJNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUlzbVBJRDBWdG1tVjQxbGlnZEhPVks1VDNEYTh4QjBDWGxwNUFsSVplY2d3bU53aStsa1dGMTkKNHI2NTFqRkJjdmlLeG0wbWdvQ0JmU2pUUS9yeEZPYnlSUzREL3JWdkd3QVpETlVLUUJiL09aSnRXcy9MMlUyQwpvUGVSK2RXVkp4bzBrOFZUQjRXRmJnUzI3a2lYU1E3RnZ5c1BCK3dyZE9Ba1owNWh2TU9GbVlzWVNuMzVZY04rCk0rTmp3WjliWWRCcDViQmVZL1BnWGxOOUp0UCtJbElScGp3ZFBOSzEvWjR0cE44TmNkZUcvQ1lBN0NheWhvZFkKM2hSaVNqSmpTcS9EKzU1WVVxR21FME9GNlplWU9TakorSDRFakJBbzRkeGF1aXkzR3BJQ1lINHRxUXJMVGMyQQphanZpc0Q3SGlYbnNoQVQ2Si81Yi9YcGw3KytmeVRjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0WmpreU56YzRZV1l0WWpVeVlpMDBPVGhsTFdJeFpEQXRPRGMxTTJGbE5tUm0KWVRabExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1Nqckk1b2h3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ0RGcXNxWncwd2E4dHg3b3EvRTNmSzB1K3VYTGtJNnhmNnB0RXY5a0szTnI2TDJTUE5qRE9wCmRmRTdHdWNXODhOQ01kNFBKb3hubVc4eVFMc3FXTHFmSkRmR2IrN3ZJMURDN2p6M3NSQ05wY2VCSVJUaThuSkgKNHZZTVBsWE1UZ04xOHduNENmeno1WG5MakE4ZWRJN2s4dGQ1ZXJOUGlpUkc5dEtobkJUZ09ra0Z6MStvV2luNAp0UWY1TzZhT05PWFl1cXBqZUh6ZU5mZEFuWHA1cDNqNHhJWUJIeTVycFdCNGo0amZhSWdrbUR0OHFUeVV1RitWCm13ZDFkY3YvelhEKy80ZlZFT0QzNG9nS1h4aHU5a29pUloyaDVEZUxXYTZXdkYwcjFqTUdMM1M1QWdRK1VFTmsKWXRnQkQrSGhqWklIVkplbDF6Z2tPVkFXb2oyNHVnQlIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVS29nZUFRenhWNGdrQ3ZkbThmVzJacUxhVlFnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR5TlM0Mk5UQWVGdzB5Ck16RXhNREl4T0RVME1USmFGdzB6TXpFd016QXhPRFUwTVRKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1qVXVOalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNzdmNuTWVTTGEzNm11bUxGS1J0L21wOGIzZldJTzNhNFpXdXBPbHFMdDZvaUtTZVZVSEk0UUdJeSsKYTVYWUxwdFM3ekVDYzdEZ1o2bTdvOURpNkhBYi9CVG1Ub1dMSG1JY0V4aG85dENTdFF6UWlxQXBlZ3hudngyQQp5Sldzd0xsZEkzSTJmUCtBajl1NGZvTEQ1dC9RRjY3TFRMeFJUQ3pCN1F4V2pueWxPbXdZMEJHa3BramNSRVRuCjVkMjVLNFlpaWo5S3F4NEtRWVNUYVNuS1lMckg0NGNydEl3TS9PWVNwTS9KeStqa1hmK0tpc00rYSszV1J0MmYKYytxYVBNTC9PR3kya3JtelJFNUg0WUtmWFgybFdDSzZDbGVvR3ljR0tMQjlZZkdnNDZUM21tNk5sZEQ4VEJregptZ2t0ZlhrVkczeFc1bHJacVNzRzRSVlUwMWhYQWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHlOUzQyTllJOGNuY3RPRFV3WkRFMFpXTXRaalV4TVMwME0ySXlMVGt4WTJZdE5USmhNVGxtTURVNU5UVXkKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pyS3RnaHdRem54bEJNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFCS0ZYTWVlQW5BNHBaUUZNZE94Qlg5TkNEK0l5UDRYL296R0hwRHJGS1VQdzgyMFhEcEVPSFkvdGFCCi9vbDhxTGNua0liUjJMemNKVDZ6S2JQcFZBWTdwM21yMzNKaDhycFdwdHVSaEdqMUVWOW8vOVM5YVFpcEFqR3UKVVBaR3YwWTZobXFPdHBTZEt2U2lCelFCYWNXWnk2aEgyMUczYTQvYUtjZWtPR0FzeW5DUE9yZ1VXMzY1L2pIWQpUbm1GYjBkWVltWG45ajEybFVWUVA2TC83clE2d0hUWWlTVHZDQ0lxWnFUNjF0cFk0QzZRSS9ka016NzMvRW9yCndSZy9Ldmc2UjBLMDdVMzR2RlhUUXZQOWxrUTNYeERwbFhCdVFTS3M2WEJaYk5NczFWWVMwWThRWkowQ3l0emkKOEppUkh3U1IxdXh5TmFuTXhTaHlEaEZVYXljQQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1839"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:03 GMT
+      - Thu, 02 Nov 2023 18:59:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49a019d8-990c-4269-a675-fcf50ef73144
+      - 4f7fd89c-2918-4fe0-909c-f322821b85e6
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +1104,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b8b7564c-5af0-4c15-a81b-7dd897208133
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
     method: GET
   response:
-    body: '{"endpoints":[{"id":"c2754ad4-7c1f-4195-af4c-f3f37694a293","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"30d188dd-5ba2-49f1-96c1-64d577dc5a01","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"042b42c1-76dc-44c3-a4d2-05d997580ef8","ip":"51.15.237.74","name":null,"port":5432}],"id":"b8b7564c-5af0-4c15-a81b-7dd897208133","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7ccbafdb-ef50-44d2-882c-2a3d1601cb2f","ip":"51.15.131.88","name":null,"port":5432}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "448"
+      - "433"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:03 GMT
+      - Thu, 02 Nov 2023 18:59:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7de12b74-d90e-40f9-b30c-5a807acafc84
+      - e7780783-57a3-4446-a9ca-265ddf857141
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,19 +1137,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b8b7564c-5af0-4c15-a81b-7dd897208133
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
     method: GET
   response:
-    body: '{"endpoints":[{"id":"c2754ad4-7c1f-4195-af4c-f3f37694a293","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"30d188dd-5ba2-49f1-96c1-64d577dc5a01","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"042b42c1-76dc-44c3-a4d2-05d997580ef8","ip":"51.15.237.74","name":null,"port":5432}],"id":"b8b7564c-5af0-4c15-a81b-7dd897208133","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7ccbafdb-ef50-44d2-882c-2a3d1601cb2f","ip":"51.15.131.88","name":null,"port":5432}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "448"
+      - "433"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:03 GMT
+      - Thu, 02 Nov 2023 18:59:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db74c349-9a50-4243-9537-a581dd6b8ed2
+      - 0e674116-f60e-4123-9e11-3013b8edd29f
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,19 +1170,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b8b7564c-5af0-4c15-a81b-7dd897208133
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"c2754ad4-7c1f-4195-af4c-f3f37694a293","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"30d188dd-5ba2-49f1-96c1-64d577dc5a01","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"042b42c1-76dc-44c3-a4d2-05d997580ef8","ip":"51.15.237.74","name":null,"port":5432}],"id":"b8b7564c-5af0-4c15-a81b-7dd897208133","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7ccbafdb-ef50-44d2-882c-2a3d1601cb2f","ip":"51.15.131.88","name":null,"port":5432}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "451"
+      - "436"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:04 GMT
+      - Thu, 02 Nov 2023 18:59:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca1b6909-311f-4888-b2b6-f6a00f88c812
+      - 0d33b46e-f48b-4a20-b522-d70786e1201f
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,19 +1203,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b8b7564c-5af0-4c15-a81b-7dd897208133
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
     method: GET
   response:
-    body: '{"endpoints":[{"id":"c2754ad4-7c1f-4195-af4c-f3f37694a293","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"30d188dd-5ba2-49f1-96c1-64d577dc5a01","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"042b42c1-76dc-44c3-a4d2-05d997580ef8","ip":"51.15.237.74","name":null,"port":5432}],"id":"b8b7564c-5af0-4c15-a81b-7dd897208133","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7ccbafdb-ef50-44d2-882c-2a3d1601cb2f","ip":"51.15.131.88","name":null,"port":5432}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "451"
+      - "436"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:04 GMT
+      - Thu, 02 Nov 2023 18:59:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf70ce5a-0f12-41c2-913c-746bdf04d100
+      - 776ec3c2-e4fe-41e3-b338-2df259d482dc
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,10 +1236,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b8b7564c-5af0-4c15-a81b-7dd897208133
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"b8b7564c-5af0-4c15-a81b-7dd897208133","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1215,7 +1248,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:34 GMT
+      - Thu, 02 Nov 2023 18:59:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9fe3bdc-3270-45fd-aefe-3b0c4f62ab63
+      - 28d9ab44-1004-41a2-bf6c-1af91c17cdff
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1236,19 +1269,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f92778af-b52b-498e-b1d0-8753ae6dfa6e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:51.236972Z","endpoint":{"id":"66dba1c7-8218-4094-a3f4-a74d74a0bb10","ip":"51.159.26.148","load_balancer":{},"name":null,"port":10734},"endpoints":[{"id":"66dba1c7-8218-4094-a3f4-a74d74a0bb10","ip":"51.159.26.148","load_balancer":{},"name":null,"port":10734}],"engine":"PostgreSQL-15","id":"f92778af-b52b-498e-b1d0-8753ae6dfa6e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":{"id":"1f44e058-95da-4e08-b347-9a4da0096f44","ip":"51.159.25.65","load_balancer":{},"name":null,"port":2450},"endpoints":[{"id":"1f44e058-95da-4e08-b347-9a4da0096f44","ip":"51.159.25.65","load_balancer":{},"name":null,"port":2450}],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1295"
+      - "1243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:34 GMT
+      - Thu, 02 Nov 2023 18:59:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e207c984-9e21-4d5b-bbad-104e568389da
+      - 50b7eb46-b241-4e4f-a9bc-fa5aeed508a8
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,19 +1302,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f92778af-b52b-498e-b1d0-8753ae6dfa6e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:51.236972Z","endpoint":{"id":"66dba1c7-8218-4094-a3f4-a74d74a0bb10","ip":"51.159.26.148","load_balancer":{},"name":null,"port":10734},"endpoints":[{"id":"66dba1c7-8218-4094-a3f4-a74d74a0bb10","ip":"51.159.26.148","load_balancer":{},"name":null,"port":10734}],"engine":"PostgreSQL-15","id":"f92778af-b52b-498e-b1d0-8753ae6dfa6e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":{"id":"1f44e058-95da-4e08-b347-9a4da0096f44","ip":"51.159.25.65","load_balancer":{},"name":null,"port":2450},"endpoints":[{"id":"1f44e058-95da-4e08-b347-9a4da0096f44","ip":"51.159.25.65","load_balancer":{},"name":null,"port":2450}],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1298"
+      - "1246"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:34 GMT
+      - Thu, 02 Nov 2023 18:59:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d78145d-b227-4688-a682-16ca61a91d0c
+      - 08f40045-1fbe-440a-b9d4-e9713f095e16
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,19 +1335,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f92778af-b52b-498e-b1d0-8753ae6dfa6e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:51.236972Z","endpoint":{"id":"66dba1c7-8218-4094-a3f4-a74d74a0bb10","ip":"51.159.26.148","load_balancer":{},"name":null,"port":10734},"endpoints":[{"id":"66dba1c7-8218-4094-a3f4-a74d74a0bb10","ip":"51.159.26.148","load_balancer":{},"name":null,"port":10734}],"engine":"PostgreSQL-15","id":"f92778af-b52b-498e-b1d0-8753ae6dfa6e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":{"id":"1f44e058-95da-4e08-b347-9a4da0096f44","ip":"51.159.25.65","load_balancer":{},"name":null,"port":2450},"endpoints":[{"id":"1f44e058-95da-4e08-b347-9a4da0096f44","ip":"51.159.25.65","load_balancer":{},"name":null,"port":2450}],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1298"
+      - "1246"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:34 GMT
+      - Thu, 02 Nov 2023 18:59:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb2cee27-7663-4b2d-8669-2a09ce4c30e8
+      - 210f9b6a-efcb-42d6-9b88-95aeee58b046
     status: 200 OK
     code: 200
     duration: ""
@@ -1335,7 +1368,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/30d188dd-5ba2-49f1-96c1-64d577dc5a01
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/89c22642-6cdb-40c2-9b9c-2f582f322f59
     method: DELETE
   response:
     body: ""
@@ -1345,7 +1378,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:35 GMT
+      - Thu, 02 Nov 2023 18:59:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1355,7 +1388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4315a3e-27b5-42a8-bfdd-89992a41e2eb
+      - 43e4c46f-e059-485d-b379-7e4e7be36674
     status: 204 No Content
     code: 204
     duration: ""
@@ -1366,10 +1399,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f92778af-b52b-498e-b1d0-8753ae6dfa6e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"f92778af-b52b-498e-b1d0-8753ae6dfa6e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"850d14ec-f511-43b2-91cf-52a19f059552","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1378,7 +1411,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:05 GMT
+      - Thu, 02 Nov 2023 19:00:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1388,7 +1421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4921a3ce-0868-466e-9564-e66388eefc76
+      - 6c2f9499-95f5-4221-be4c-9322bddc6c5d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1399,10 +1432,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f92778af-b52b-498e-b1d0-8753ae6dfa6e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"f92778af-b52b-498e-b1d0-8753ae6dfa6e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"850d14ec-f511-43b2-91cf-52a19f059552","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1411,7 +1444,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:05 GMT
+      - Thu, 02 Nov 2023 19:00:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1421,7 +1454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bea1c948-0d55-482e-8c24-7d2b0f3ebf14
+      - 4f9365dd-849b-4260-bf2e-ae6f9ee51ab1
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1432,10 +1465,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b8b7564c-5af0-4c15-a81b-7dd897208133
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"b8b7564c-5af0-4c15-a81b-7dd897208133","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1444,7 +1477,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:05 GMT
+      - Thu, 02 Nov 2023 19:00:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1454,7 +1487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25d5be49-6d61-433f-a3ed-c628f2e15436
+      - 3d0c9e7f-b449-475c-b9fb-288d4084f904
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-private-network.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-private-network.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:07 GMT
+      - Thu, 02 Nov 2023 18:46:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,47 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db13c0d9-42e7-4115-80cc-cbe9dbe8e8f4
+      - bf344db8-3699-43db-a4c8-2ed7d56f6914
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-pn","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
-    method: POST
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:54.539813Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c71d53bd-7f5a-4410-8652-a9e22dab39d1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "787"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:55:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5503d837-f469-462e-8341-e1370d9ed042
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"tf-pn-hungry-dijkstra","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"tf-pn-adoring-thompson","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -379,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-20T15:55:54.202572Z","dhcp_enabled":true,"id":"dd5c02b3-e130-41c4-829d-fdf6fc56fb15","name":"tf-pn-hungry-dijkstra","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T15:55:54.202572Z","id":"7f1eeccb-f53f-4ec0-9ed6-8efed0f3d3c0","subnet":"172.16.4.0/22","updated_at":"2023-10-20T15:55:54.202572Z"},{"created_at":"2023-10-20T15:55:54.202572Z","id":"9a555652-9a24-4353-bdc0-2aaa3b1bd246","subnet":"fd63:256c:45f7:dce0::/64","updated_at":"2023-10-20T15:55:54.202572Z"}],"tags":[],"updated_at":"2023-10-20T15:55:54.202572Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-02T18:53:50.869634Z","dhcp_enabled":true,"id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","name":"tf-pn-adoring-thompson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:53:50.869634Z","id":"05c26b20-f19f-4986-8cff-3a475a41e04e","subnet":"172.16.24.0/22","updated_at":"2023-11-02T18:53:50.869634Z"},{"created_at":"2023-11-02T18:53:50.869634Z","id":"3405fa12-08a2-45c7-97e2-51ec63b1ebea","subnet":"fd63:256c:45f7:be55::/64","updated_at":"2023-11-02T18:53:50.869634Z"}],"tags":[],"updated_at":"2023-11-02T18:53:50.869634Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "721"
+      - "706"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:55 GMT
+      - Thu, 02 Nov 2023 18:53:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -398,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2805f0d-63da-43a6-9e83-3a4907c26631
+      - d0d754d8-df35-400c-bf5a-260a9f73cc9d
     status: 200 OK
     code: 200
     duration: ""
@@ -409,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dd5c02b3-e130-41c4-829d-fdf6fc56fb15
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b16795ce-01f0-46f5-b9f5-c22b5c649a0d
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T15:55:54.202572Z","dhcp_enabled":true,"id":"dd5c02b3-e130-41c4-829d-fdf6fc56fb15","name":"tf-pn-hungry-dijkstra","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T15:55:54.202572Z","id":"7f1eeccb-f53f-4ec0-9ed6-8efed0f3d3c0","subnet":"172.16.4.0/22","updated_at":"2023-10-20T15:55:54.202572Z"},{"created_at":"2023-10-20T15:55:54.202572Z","id":"9a555652-9a24-4353-bdc0-2aaa3b1bd246","subnet":"fd63:256c:45f7:dce0::/64","updated_at":"2023-10-20T15:55:54.202572Z"}],"tags":[],"updated_at":"2023-10-20T15:55:54.202572Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-02T18:53:50.869634Z","dhcp_enabled":true,"id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","name":"tf-pn-adoring-thompson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:53:50.869634Z","id":"05c26b20-f19f-4986-8cff-3a475a41e04e","subnet":"172.16.24.0/22","updated_at":"2023-11-02T18:53:50.869634Z"},{"created_at":"2023-11-02T18:53:50.869634Z","id":"3405fa12-08a2-45c7-97e2-51ec63b1ebea","subnet":"fd63:256c:45f7:be55::/64","updated_at":"2023-11-02T18:53:50.869634Z"}],"tags":[],"updated_at":"2023-11-02T18:53:50.869634Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "721"
+      - "706"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:55 GMT
+      - Thu, 02 Nov 2023 18:53:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -431,7 +396,42 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c0d4e14-e0b1-4e8f-9c74-3c898692b3c4
+      - b01fb3ac-f034-4a1c-9ef9-0a43f9d82104
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-pn","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
+    method: POST
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "758"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:53:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - de4a28bf-35fc-45db-a871-62a77bc93d25
     status: 200 OK
     code: 200
     duration: ""
@@ -442,19 +442,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c71d53bd-7f5a-4410-8652-a9e22dab39d1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:54.539813Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c71d53bd-7f5a-4410-8652-a9e22dab39d1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "758"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:55 GMT
+      - Thu, 02 Nov 2023 18:53:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -464,7 +464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 075ecb1c-29fb-48db-8a46-3d8258466977
+      - 1e4aee33-d0fe-4cd0-9c76-c890f1877f6e
     status: 200 OK
     code: 200
     duration: ""
@@ -475,19 +475,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c71d53bd-7f5a-4410-8652-a9e22dab39d1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:54.539813Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c71d53bd-7f5a-4410-8652-a9e22dab39d1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "758"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:56:26 GMT
+      - Thu, 02 Nov 2023 18:54:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -497,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d58b6d8-9e25-4281-9156-5ecb215eb0c8
+      - 2f86b223-cafc-431a-b56d-2da308542b1e
     status: 200 OK
     code: 200
     duration: ""
@@ -508,19 +508,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c71d53bd-7f5a-4410-8652-a9e22dab39d1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:54.539813Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c71d53bd-7f5a-4410-8652-a9e22dab39d1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "758"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:56:56 GMT
+      - Thu, 02 Nov 2023 18:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -530,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f279fb75-01b9-4e2d-9560-d6e114ba9003
+      - e1e32c25-8bf7-487e-84bf-04876e6f285d
     status: 200 OK
     code: 200
     duration: ""
@@ -541,19 +541,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c71d53bd-7f5a-4410-8652-a9e22dab39d1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:54.539813Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c71d53bd-7f5a-4410-8652-a9e22dab39d1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "758"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:26 GMT
+      - Thu, 02 Nov 2023 18:55:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -563,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3a4bbc0-fce8-4506-8161-f02988764b2b
+      - 8628bcde-92e9-41e2-8d2a-5e2def95264a
     status: 200 OK
     code: 200
     duration: ""
@@ -574,19 +574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c71d53bd-7f5a-4410-8652-a9e22dab39d1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:54.539813Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c71d53bd-7f5a-4410-8652-a9e22dab39d1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "758"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:57 GMT
+      - Thu, 02 Nov 2023 18:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5f86e6c-c54a-40e5-ba44-e25f80e0a887
+      - 39498382-8132-4ecf-99ca-9707312b8c10
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c71d53bd-7f5a-4410-8652-a9e22dab39d1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:54.539813Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c71d53bd-7f5a-4410-8652-a9e22dab39d1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "758"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:27 GMT
+      - Thu, 02 Nov 2023 18:56:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75b57bf6-a7c9-489b-b88e-75edeb504543
+      - 0ddb8959-a14d-4130-be53-6d9020e3c0a8
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c71d53bd-7f5a-4410-8652-a9e22dab39d1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:54.539813Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c71d53bd-7f5a-4410-8652-a9e22dab39d1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":{"id":"04bd8220-0459-4467-bb84-801aab9cebee","ip":"51.159.205.115","load_balancer":{},"name":null,"port":5303},"endpoints":[{"id":"04bd8220-0459-4467-bb84-801aab9cebee","ip":"51.159.205.115","load_balancer":{},"name":null,"port":5303}],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "1231"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:58 GMT
+      - Thu, 02 Nov 2023 18:56:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69e57fbc-ce51-43fb-a13e-fc0789813fb4
+      - e1bc5848-cbdd-41a6-914d-f9527b2b5cf0
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c71d53bd-7f5a-4410-8652-a9e22dab39d1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:54.539813Z","endpoint":{"id":"196543e5-f119-409a-ab9d-13084910f795","ip":"51.159.205.143","load_balancer":{},"name":null,"port":18668},"endpoints":[{"id":"196543e5-f119-409a-ab9d-13084910f795","ip":"51.159.205.143","load_balancer":{},"name":null,"port":18668}],"engine":"PostgreSQL-15","id":"c71d53bd-7f5a-4410-8652-a9e22dab39d1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSlE2TU4ydTBUY2ZpSUlRUmJENkp1UzU5NTc4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURVdU1URTFNQjRYCkRUSXpNVEV3TWpFNE5UUXpNRm9YRFRNek1UQXpNREU0TlRRek1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRFV1TVRFMU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXRzMCtEeEUxVzJkSndkcE80bUR3M0VqdUFvUXN4MnlGLzA5RzFYVWpmVDFsNUJybWFRYXIKS2lyMEMwTmRiUTF3emVQZjU3OU1PZWJIWFdKbVZGM2xjRG9MTnRacnEyUzF0bU9UdjRGZFZOU29RK0hiVXg4NwowN3cyVHJWb3Bwa0VVZ25JRFBKbE5QWjZuTGxLNm55eVVDbHROb3hVOUprN21QTkR2TEg0M0xRcDFCYXVSWFZPCnA4dmhMd3lhb3dFdHlDdzNvWnJDdXdNenZuVWlCZWtzZmI3NlJRRlRpZ3dVVVdXSldzbGdjalhnSmh3YTRuckEKOEZzZy94aWlFaCtGcFREYkNyWXFYQ3RIdXVuK3dwU0pUZGp3dm5uclh2Z0V5ZVNaUm5oOWJHem1FaHBRckJMcQpUTk5aMi9jVndsSnp1b2pSVjVhcDhkMHJLUEJ4R1gyeW9RSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBMUxqRXhOWUk4Y25jdE9XTmhNR1F4WVRrdE9XTTNOaTAwWW1WakxXSTNPV1l0TVRobVpUa3gKTmpGbU9UTTVMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrVjVod1F6bjgxek1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUMwVkE0YTlzbjkrMUpHYnJzSXUxV1l0ZS80czJMMXFYOGJXeldjZjVNUHNIdTJQRk1zCk5UT3NKZmVvaDJNU01HajhaMUxvM3lxaGVlMkpOMXpnbldWT2JCaFBMWnhRTkNSTjJXNnVqc2dpeEZTT3NuM2QKRVBuTUx4cXJwN0RDZjlwNzIzVXJJR1YyU0F5YWJpVXRuZWYzMndIeWZiRWRUQTFwRERtUS9UbStnUHdZM3AxWAppRzAwMjdCZ1haV21UeTFwT0RGcGFYTVlmNk91YnlhYmZKU0hRK2NUSHRMVUdrNXE1bEVEeGMzRU4xbEtQYzRLCnp4SS9wR01XeGo4MHVqejJjQ290TWg1dmI1aHNqb2Y5SWdNbTAwenNzMnFUSFd2V2kyKzJ2bzhncVZHYVZUTGEKQWcxUGRJUTg2THVrNzlIVTNia1FKZ0tWUFk5UStBQ0sydXNECi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1281"
+      - "1847"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:28 GMT
+      - Thu, 02 Nov 2023 18:56:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,45 +695,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97b21a5e-ca2f-4011-9264-659441675c37
+      - e7698600-b013-4c56-b5d6-bca2f9a0e77c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c71d53bd-7f5a-4410-8652-a9e22dab39d1/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVS21DVXdVVWVDNGZMeHB1V241dFAxNUVpaXNZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURVdU1UUXpNQjRYCkRUSXpNVEF5TURFMU5UYzBNbG9YRFRNek1UQXhOekUxTlRjME1sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRFV1TVRRek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXlUaFlvaEQ4cm44OW1nQnE1MlAwNHNPcHRXUG15bFM5eTdRaWRJQmppRXpWTGJPMzUrV1EKY0RVZ3E0dmpUeE1jYXo5L2g5THRGdEpVaFpzc2lIR2t3RTZSbjRjVFNyYjdHT3NEbzgrSUh0WFpSR2c5b3dyZgpzS1VrSS83ZmFPNGN6Qmo2bGhEbVJpMEhYQTRpczJVUXNaZHRNbWVTYmk3K1lyMTV1Um9IdldlK25vVU9oM1ZxCmdWSTgyc1BwQ3hQL3BKT0lFNkJrRFZzSndsRWNoR3BXeGpPRjZQd21teEErNVJBMGVycmQ1NGp0enNuQm0xYTkKdGo5SHkyRUpQNEpqSTdzbWVYZUlFU3pTc3JrbkhDRzVhQnczRm9WZDJmR1hVVi9XUGV5K0hhbCs1UnZmL2toegpEVDI0TXdKRzA1QjJiV1B1QVNiYVo4bFNWSjdLZEpGbVJRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBMUxqRTBNNEk4Y25jdFl6Y3haRFV6WW1RdE4yWTFZUzAwTkRFd0xUZzJOVEl0WVRsbE1qSmsKWVdJek9XUXhMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5tSCtod1F6bjgyUE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUFWNXoxUXcrbkhIbFJnME9tdGlqRFRpN0VSSCs0YTVoSVRsbG00K0lZMjZ5K2pPUGM2Ck1xdVYzNzRGT1NHek5YT3NWbUhBS0Zudi82cUd3WGFVbTlSa0FEbFFzL2dhR3d2ZVgyWXZhV1A0MG4vOHlnMVUKZ1FQQ1prcjNUL3JpRk1Mb3Y2ZTRWWFN2bnpwRWcyVWNCT21lUCt0czlUVjM3bUdkUlRwb0NQR2IxUWl4bjVpcwpsdmVmbWZPMy81SDVQN3lsY0JqcVJWRjQxdWFXWTYvSmlIc3lGY2FrMW14ZVRaa2w0YlJ3eUZPaVFuMDg4T1pvCmpZYWNRN0NLdkZmQ3B4VEd0eXkxcU5QNUxzZ1ZaNHpKQmp1dlhSNVc2eTdXMUVPdHlkNUJjZHpPSEl5NGtBRjMKcmh5QXVIOE9yZlhjdURmdm9SSEtla0RweUNuUVhyTkw3RFdWCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1849"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:59:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 29d522d6-2f3f-4c60-8562-384dd1c25830
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"instance_id":"c71d53bd-7f5a-4410-8652-a9e22dab39d1","endpoint_spec":[{"private_network":{"private_network_id":"dd5c02b3-e130-41c4-829d-fdf6fc56fb15","service_ip":"10.12.1.0/20"}}],"same_zone":null}'
+    body: '{"instance_id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","endpoint_spec":[{"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20"}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
@@ -744,16 +711,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[{"id":"fc320e32-0a68-4341-ac02-be45c90b944c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"dd5c02b3-e130-41c4-829d-fdf6fc56fb15","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b2d9f7c1-d718-4b79-b538-c6ffce216eb2","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "341"
+      - "331"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:29 GMT
+      - Thu, 02 Nov 2023 18:56:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +730,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 604529ca-c479-4d28-b82e-b1b93371e7b1
+      - 5e4f6c81-d9ed-49b7-b3ff-8235a13318c0
     status: 200 OK
     code: 200
     duration: ""
@@ -774,19 +741,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b2d9f7c1-d718-4b79-b538-c6ffce216eb2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc320e32-0a68-4341-ac02-be45c90b944c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"dd5c02b3-e130-41c4-829d-fdf6fc56fb15","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b2d9f7c1-d718-4b79-b538-c6ffce216eb2","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "341"
+      - "331"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:29 GMT
+      - Thu, 02 Nov 2023 18:56:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +763,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74b37a43-45b0-41c3-9e13-8a7b0f289609
+      - 9b83e704-baed-4741-bd0c-9e7f2addbca0
     status: 200 OK
     code: 200
     duration: ""
@@ -807,19 +774,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b2d9f7c1-d718-4b79-b538-c6ffce216eb2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc320e32-0a68-4341-ac02-be45c90b944c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"dd5c02b3-e130-41c4-829d-fdf6fc56fb15","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b2d9f7c1-d718-4b79-b538-c6ffce216eb2","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "341"
+      - "331"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:59 GMT
+      - Thu, 02 Nov 2023 18:57:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6279a6d0-8cd1-413a-9987-b6bfa2092000
+      - c321f66f-ae5f-4e54-84e3-93e26808b8bb
     status: 200 OK
     code: 200
     duration: ""
@@ -840,19 +807,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b2d9f7c1-d718-4b79-b538-c6ffce216eb2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc320e32-0a68-4341-ac02-be45c90b944c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"dd5c02b3-e130-41c4-829d-fdf6fc56fb15","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b2d9f7c1-d718-4b79-b538-c6ffce216eb2","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "341"
+      - "331"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:29 GMT
+      - Thu, 02 Nov 2023 18:57:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e3c6ac6-379a-4b86-a231-8469adfea2eb
+      - 62b40ebb-f929-42a9-8587-be531e8e5af2
     status: 200 OK
     code: 200
     duration: ""
@@ -873,19 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b2d9f7c1-d718-4b79-b538-c6ffce216eb2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc320e32-0a68-4341-ac02-be45c90b944c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"dd5c02b3-e130-41c4-829d-fdf6fc56fb15","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b2d9f7c1-d718-4b79-b538-c6ffce216eb2","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "341"
+      - "331"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:59 GMT
+      - Thu, 02 Nov 2023 18:58:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f6ee0fa-ff2b-4f0c-b094-08a7280ebe32
+      - f88224dd-3b29-4138-8693-126517f09d1c
     status: 200 OK
     code: 200
     duration: ""
@@ -906,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b2d9f7c1-d718-4b79-b538-c6ffce216eb2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc320e32-0a68-4341-ac02-be45c90b944c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"dd5c02b3-e130-41c4-829d-fdf6fc56fb15","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b2d9f7c1-d718-4b79-b538-c6ffce216eb2","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "341"
+      - "331"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:29 GMT
+      - Thu, 02 Nov 2023 18:58:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e82478f6-10fa-407d-9c60-699ce2354f9f
+      - 0f62ba6e-49bb-4de7-830e-03910182d674
     status: 200 OK
     code: 200
     duration: ""
@@ -939,19 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b2d9f7c1-d718-4b79-b538-c6ffce216eb2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc320e32-0a68-4341-ac02-be45c90b944c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"dd5c02b3-e130-41c4-829d-fdf6fc56fb15","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b2d9f7c1-d718-4b79-b538-c6ffce216eb2","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "334"
+      - "324"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:59 GMT
+      - Thu, 02 Nov 2023 18:59:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75e11d4e-f266-43dd-b475-b74ead25aa16
+      - 5355c474-c84e-4e3c-968a-4d0f3505c065
     status: 200 OK
     code: 200
     duration: ""
@@ -972,19 +939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b2d9f7c1-d718-4b79-b538-c6ffce216eb2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc320e32-0a68-4341-ac02-be45c90b944c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"dd5c02b3-e130-41c4-829d-fdf6fc56fb15","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b2d9f7c1-d718-4b79-b538-c6ffce216eb2","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "334"
+      - "324"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:00 GMT
+      - Thu, 02 Nov 2023 18:59:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27394752-515e-4d18-a9ac-235bf9c49718
+      - b54b0cfb-95d3-4233-b0df-0a2c8d9c86ed
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,19 +972,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b2d9f7c1-d718-4b79-b538-c6ffce216eb2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc320e32-0a68-4341-ac02-be45c90b944c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"dd5c02b3-e130-41c4-829d-fdf6fc56fb15","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b2d9f7c1-d718-4b79-b538-c6ffce216eb2","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "334"
+      - "324"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:00 GMT
+      - Thu, 02 Nov 2023 18:59:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 562dfe6e-3b9c-4e43-bd24-0a2cfd770e62
+      - 3ab57b79-551c-467d-abc4-a8f46d4213e6
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +1005,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dd5c02b3-e130-41c4-829d-fdf6fc56fb15
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b16795ce-01f0-46f5-b9f5-c22b5c649a0d
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T15:55:54.202572Z","dhcp_enabled":true,"id":"dd5c02b3-e130-41c4-829d-fdf6fc56fb15","name":"tf-pn-hungry-dijkstra","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T15:55:54.202572Z","id":"7f1eeccb-f53f-4ec0-9ed6-8efed0f3d3c0","subnet":"172.16.4.0/22","updated_at":"2023-10-20T15:55:54.202572Z"},{"created_at":"2023-10-20T15:55:54.202572Z","id":"9a555652-9a24-4353-bdc0-2aaa3b1bd246","subnet":"fd63:256c:45f7:dce0::/64","updated_at":"2023-10-20T15:55:54.202572Z"}],"tags":[],"updated_at":"2023-10-20T15:55:54.202572Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-02T18:53:50.869634Z","dhcp_enabled":true,"id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","name":"tf-pn-adoring-thompson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:53:50.869634Z","id":"05c26b20-f19f-4986-8cff-3a475a41e04e","subnet":"172.16.24.0/22","updated_at":"2023-11-02T18:53:50.869634Z"},{"created_at":"2023-11-02T18:53:50.869634Z","id":"3405fa12-08a2-45c7-97e2-51ec63b1ebea","subnet":"fd63:256c:45f7:be55::/64","updated_at":"2023-11-02T18:53:50.869634Z"}],"tags":[],"updated_at":"2023-11-02T18:53:50.869634Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "721"
+      - "706"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:00 GMT
+      - Thu, 02 Nov 2023 18:59:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e37f4a9c-ed8e-4a9b-a272-f46658f972e2
+      - f23c9e22-7d9e-4c14-9ddb-d69604255aba
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +1038,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c71d53bd-7f5a-4410-8652-a9e22dab39d1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:54.539813Z","endpoint":{"id":"196543e5-f119-409a-ab9d-13084910f795","ip":"51.159.205.143","load_balancer":{},"name":null,"port":18668},"endpoints":[{"id":"196543e5-f119-409a-ab9d-13084910f795","ip":"51.159.205.143","load_balancer":{},"name":null,"port":18668}],"engine":"PostgreSQL-15","id":"c71d53bd-7f5a-4410-8652-a9e22dab39d1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"fc320e32-0a68-4341-ac02-be45c90b944c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"dd5c02b3-e130-41c4-829d-fdf6fc56fb15","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b2d9f7c1-d718-4b79-b538-c6ffce216eb2","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":{"id":"04bd8220-0459-4467-bb84-801aab9cebee","ip":"51.159.205.115","load_balancer":{},"name":null,"port":5303},"endpoints":[{"id":"04bd8220-0459-4467-bb84-801aab9cebee","ip":"51.159.205.115","load_balancer":{},"name":null,"port":5303}],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1615"
+      - "1555"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:00 GMT
+      - Thu, 02 Nov 2023 18:59:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 164a3e8e-3ea8-45bd-9165-96b868924e4a
+      - 3c44e694-ffb9-4b3d-ab66-183f0df47844
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,19 +1071,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c71d53bd-7f5a-4410-8652-a9e22dab39d1/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVS21DVXdVVWVDNGZMeHB1V241dFAxNUVpaXNZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURVdU1UUXpNQjRYCkRUSXpNVEF5TURFMU5UYzBNbG9YRFRNek1UQXhOekUxTlRjME1sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRFV1TVRRek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXlUaFlvaEQ4cm44OW1nQnE1MlAwNHNPcHRXUG15bFM5eTdRaWRJQmppRXpWTGJPMzUrV1EKY0RVZ3E0dmpUeE1jYXo5L2g5THRGdEpVaFpzc2lIR2t3RTZSbjRjVFNyYjdHT3NEbzgrSUh0WFpSR2c5b3dyZgpzS1VrSS83ZmFPNGN6Qmo2bGhEbVJpMEhYQTRpczJVUXNaZHRNbWVTYmk3K1lyMTV1Um9IdldlK25vVU9oM1ZxCmdWSTgyc1BwQ3hQL3BKT0lFNkJrRFZzSndsRWNoR3BXeGpPRjZQd21teEErNVJBMGVycmQ1NGp0enNuQm0xYTkKdGo5SHkyRUpQNEpqSTdzbWVYZUlFU3pTc3JrbkhDRzVhQnczRm9WZDJmR1hVVi9XUGV5K0hhbCs1UnZmL2toegpEVDI0TXdKRzA1QjJiV1B1QVNiYVo4bFNWSjdLZEpGbVJRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBMUxqRTBNNEk4Y25jdFl6Y3haRFV6WW1RdE4yWTFZUzAwTkRFd0xUZzJOVEl0WVRsbE1qSmsKWVdJek9XUXhMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5tSCtod1F6bjgyUE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUFWNXoxUXcrbkhIbFJnME9tdGlqRFRpN0VSSCs0YTVoSVRsbG00K0lZMjZ5K2pPUGM2Ck1xdVYzNzRGT1NHek5YT3NWbUhBS0Zudi82cUd3WGFVbTlSa0FEbFFzL2dhR3d2ZVgyWXZhV1A0MG4vOHlnMVUKZ1FQQ1prcjNUL3JpRk1Mb3Y2ZTRWWFN2bnpwRWcyVWNCT21lUCt0czlUVjM3bUdkUlRwb0NQR2IxUWl4bjVpcwpsdmVmbWZPMy81SDVQN3lsY0JqcVJWRjQxdWFXWTYvSmlIc3lGY2FrMW14ZVRaa2w0YlJ3eUZPaVFuMDg4T1pvCmpZYWNRN0NLdkZmQ3B4VEd0eXkxcU5QNUxzZ1ZaNHpKQmp1dlhSNVc2eTdXMUVPdHlkNUJjZHpPSEl5NGtBRjMKcmh5QXVIOE9yZlhjdURmdm9SSEtla0RweUNuUVhyTkw3RFdWCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSlE2TU4ydTBUY2ZpSUlRUmJENkp1UzU5NTc4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURVdU1URTFNQjRYCkRUSXpNVEV3TWpFNE5UUXpNRm9YRFRNek1UQXpNREU0TlRRek1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRFV1TVRFMU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXRzMCtEeEUxVzJkSndkcE80bUR3M0VqdUFvUXN4MnlGLzA5RzFYVWpmVDFsNUJybWFRYXIKS2lyMEMwTmRiUTF3emVQZjU3OU1PZWJIWFdKbVZGM2xjRG9MTnRacnEyUzF0bU9UdjRGZFZOU29RK0hiVXg4NwowN3cyVHJWb3Bwa0VVZ25JRFBKbE5QWjZuTGxLNm55eVVDbHROb3hVOUprN21QTkR2TEg0M0xRcDFCYXVSWFZPCnA4dmhMd3lhb3dFdHlDdzNvWnJDdXdNenZuVWlCZWtzZmI3NlJRRlRpZ3dVVVdXSldzbGdjalhnSmh3YTRuckEKOEZzZy94aWlFaCtGcFREYkNyWXFYQ3RIdXVuK3dwU0pUZGp3dm5uclh2Z0V5ZVNaUm5oOWJHem1FaHBRckJMcQpUTk5aMi9jVndsSnp1b2pSVjVhcDhkMHJLUEJ4R1gyeW9RSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBMUxqRXhOWUk4Y25jdE9XTmhNR1F4WVRrdE9XTTNOaTAwWW1WakxXSTNPV1l0TVRobVpUa3gKTmpGbU9UTTVMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrVjVod1F6bjgxek1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUMwVkE0YTlzbjkrMUpHYnJzSXUxV1l0ZS80czJMMXFYOGJXeldjZjVNUHNIdTJQRk1zCk5UT3NKZmVvaDJNU01HajhaMUxvM3lxaGVlMkpOMXpnbldWT2JCaFBMWnhRTkNSTjJXNnVqc2dpeEZTT3NuM2QKRVBuTUx4cXJwN0RDZjlwNzIzVXJJR1YyU0F5YWJpVXRuZWYzMndIeWZiRWRUQTFwRERtUS9UbStnUHdZM3AxWAppRzAwMjdCZ1haV21UeTFwT0RGcGFYTVlmNk91YnlhYmZKU0hRK2NUSHRMVUdrNXE1bEVEeGMzRU4xbEtQYzRLCnp4SS9wR01XeGo4MHVqejJjQ290TWg1dmI1aHNqb2Y5SWdNbTAwenNzMnFUSFd2V2kyKzJ2bzhncVZHYVZUTGEKQWcxUGRJUTg2THVrNzlIVTNia1FKZ0tWUFk5UStBQ0sydXNECi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1849"
+      - "1847"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:01 GMT
+      - Thu, 02 Nov 2023 18:59:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 635241ee-b728-424a-9abd-977c4f8e3421
+      - 309c48b6-e07b-4966-8f66-2848837afb03
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,19 +1104,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b2d9f7c1-d718-4b79-b538-c6ffce216eb2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc320e32-0a68-4341-ac02-be45c90b944c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"dd5c02b3-e130-41c4-829d-fdf6fc56fb15","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b2d9f7c1-d718-4b79-b538-c6ffce216eb2","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "334"
+      - "324"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:01 GMT
+      - Thu, 02 Nov 2023 18:59:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b86ded75-4b1b-43ab-8d52-2bea04bc81cb
+      - 502b9593-09b2-4dc8-9446-dcfa5087fa31
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,19 +1137,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b2d9f7c1-d718-4b79-b538-c6ffce216eb2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc320e32-0a68-4341-ac02-be45c90b944c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"dd5c02b3-e130-41c4-829d-fdf6fc56fb15","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b2d9f7c1-d718-4b79-b538-c6ffce216eb2","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "334"
+      - "324"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:02 GMT
+      - Thu, 02 Nov 2023 18:59:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93775ba7-516d-4ca4-968e-8a6b72c587db
+      - 9df0c6f4-e0cb-4c3a-8768-8742a88a6b1f
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,19 +1170,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b2d9f7c1-d718-4b79-b538-c6ffce216eb2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"fc320e32-0a68-4341-ac02-be45c90b944c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"dd5c02b3-e130-41c4-829d-fdf6fc56fb15","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b2d9f7c1-d718-4b79-b538-c6ffce216eb2","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "337"
+      - "327"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:02 GMT
+      - Thu, 02 Nov 2023 18:59:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72123095-072c-4cbc-9ee1-70b1ee0bc36a
+      - 9d1d3b04-7199-4cc2-9669-1947760509d8
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,19 +1203,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b2d9f7c1-d718-4b79-b538-c6ffce216eb2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc320e32-0a68-4341-ac02-be45c90b944c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"dd5c02b3-e130-41c4-829d-fdf6fc56fb15","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b2d9f7c1-d718-4b79-b538-c6ffce216eb2","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "337"
+      - "327"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:02 GMT
+      - Thu, 02 Nov 2023 18:59:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66d2fd5b-f201-4625-b92a-1228aa181a75
+      - 935f8560-5152-4e6f-a7a0-f5c351823d7d
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,10 +1236,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b2d9f7c1-d718-4b79-b538-c6ffce216eb2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"b2d9f7c1-d718-4b79-b538-c6ffce216eb2","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1281,7 +1248,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:32 GMT
+      - Thu, 02 Nov 2023 19:00:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a44e5bd2-927d-4874-9445-056535e93c04
+      - 3317156a-ab25-4d36-a313-8aa8bfd56010
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1302,19 +1269,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c71d53bd-7f5a-4410-8652-a9e22dab39d1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:54.539813Z","endpoint":{"id":"196543e5-f119-409a-ab9d-13084910f795","ip":"51.159.205.143","load_balancer":{},"name":null,"port":18668},"endpoints":[{"id":"196543e5-f119-409a-ab9d-13084910f795","ip":"51.159.205.143","load_balancer":{},"name":null,"port":18668}],"engine":"PostgreSQL-15","id":"c71d53bd-7f5a-4410-8652-a9e22dab39d1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":{"id":"04bd8220-0459-4467-bb84-801aab9cebee","ip":"51.159.205.115","load_balancer":{},"name":null,"port":5303},"endpoints":[{"id":"04bd8220-0459-4467-bb84-801aab9cebee","ip":"51.159.205.115","load_balancer":{},"name":null,"port":5303}],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1281"
+      - "1231"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:32 GMT
+      - Thu, 02 Nov 2023 19:00:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16704885-ed32-4df9-85c0-4c47258dfc27
+      - 4b88d7bd-440f-4a24-8408-a3bb6de21fa8
     status: 200 OK
     code: 200
     duration: ""
@@ -1335,73 +1302,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c71d53bd-7f5a-4410-8652-a9e22dab39d1
-    method: DELETE
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:54.539813Z","endpoint":{"id":"196543e5-f119-409a-ab9d-13084910f795","ip":"51.159.205.143","load_balancer":{},"name":null,"port":18668},"endpoints":[{"id":"196543e5-f119-409a-ab9d-13084910f795","ip":"51.159.205.143","load_balancer":{},"name":null,"port":18668}],"engine":"PostgreSQL-15","id":"c71d53bd-7f5a-4410-8652-a9e22dab39d1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1284"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:02:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 193692fa-5e80-4edc-9c4e-3d065aa9005f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c71d53bd-7f5a-4410-8652-a9e22dab39d1
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:54.539813Z","endpoint":{"id":"196543e5-f119-409a-ab9d-13084910f795","ip":"51.159.205.143","load_balancer":{},"name":null,"port":18668},"endpoints":[{"id":"196543e5-f119-409a-ab9d-13084910f795","ip":"51.159.205.143","load_balancer":{},"name":null,"port":18668}],"engine":"PostgreSQL-15","id":"c71d53bd-7f5a-4410-8652-a9e22dab39d1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1284"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:02:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b171acc9-e1a3-400d-a5a3-0c17986dfebe
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dd5c02b3-e130-41c4-829d-fdf6fc56fb15
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b16795ce-01f0-46f5-b9f5-c22b5c649a0d
     method: DELETE
   response:
     body: ""
@@ -1411,7 +1312,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:33 GMT
+      - Thu, 02 Nov 2023 19:00:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1421,7 +1322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c036e53-994b-4158-80ab-deb58344a731
+      - 6ae30cd0-aeec-4e02-98d4-6c55ca27a503
     status: 204 No Content
     code: 204
     duration: ""
@@ -1432,19 +1333,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c71d53bd-7f5a-4410-8652-a9e22dab39d1
-    method: GET
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
+    method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"c71d53bd-7f5a-4410-8652-a9e22dab39d1","type":"not_found"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":{"id":"04bd8220-0459-4467-bb84-801aab9cebee","ip":"51.159.205.115","load_balancer":{},"name":null,"port":5303},"endpoints":[{"id":"04bd8220-0459-4467-bb84-801aab9cebee","ip":"51.159.205.115","load_balancer":{},"name":null,"port":5303}],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "129"
+      - "1234"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:03 GMT
+      - Thu, 02 Nov 2023 19:00:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1454,7 +1355,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1430a270-5277-4ced-8163-eba962426b62
+      - fe894d0e-df43-4818-938a-9a354b86ffc3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":{"id":"04bd8220-0459-4467-bb84-801aab9cebee","ip":"51.159.205.115","load_balancer":{},"name":null,"port":5303},"endpoints":[{"id":"04bd8220-0459-4467-bb84-801aab9cebee","ip":"51.159.205.115","load_balancer":{},"name":null,"port":5303}],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1234"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 19:00:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 86219815-f32b-48fb-a084-39baf157e0b1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "129"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 19:00:32 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fe345dda-ace8-4b87-9500-44c1d545d8f3
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1465,10 +1432,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c71d53bd-7f5a-4410-8652-a9e22dab39d1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"c71d53bd-7f5a-4410-8652-a9e22dab39d1","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1477,7 +1444,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:03 GMT
+      - Thu, 02 Nov 2023 19:00:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1487,7 +1454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 769e2bdd-541a-49b9-9c59-8e055c1a8ccb
+      - 9eae72ef-71ce-4fce-bbac-f58c7577dbc2
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1498,10 +1465,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b2d9f7c1-d718-4b79-b538-c6ffce216eb2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"b2d9f7c1-d718-4b79-b538-c6ffce216eb2","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1510,7 +1477,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:03 GMT
+      - Thu, 02 Nov 2023 19:00:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1520,7 +1487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92fe951c-81c1-4888-b75d-faa024618be3
+      - de1e00aa-9ea1-4569-b562-6528dccde418
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-update.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-update.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:08 GMT
+      - Thu, 02 Nov 2023 18:46:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e95fedc1-9f04-4f8b-8823-cfa04b4f302a
+      - 2b2a69d2-5064-44eb-9a54-923268ee0baf
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-update","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-update","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:53.108227Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"f567cd2f-4547-4ca3-93ba-204c68fc4bbf","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "791"
+      - "762"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:53 GMT
+      - Thu, 02 Nov 2023 18:53:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72a30d5f-3b30-4f77-bb0f-b30c6b6e2407
+      - a68f6c50-04bd-4fde-ae4c-4cfb5a22e142
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f567cd2f-4547-4ca3-93ba-204c68fc4bbf
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:53.108227Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"f567cd2f-4547-4ca3-93ba-204c68fc4bbf","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "791"
+      - "762"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:55:53 GMT
+      - Thu, 02 Nov 2023 18:53:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80aebf86-8301-4353-bcf7-93c193c2c9a6
+      - 8c3777a1-8156-4d19-a7b0-00852ba7a49b
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f567cd2f-4547-4ca3-93ba-204c68fc4bbf
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:53.108227Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"f567cd2f-4547-4ca3-93ba-204c68fc4bbf","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "791"
+      - "762"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:56:23 GMT
+      - Thu, 02 Nov 2023 18:54:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1533f75d-508e-42ba-bb68-3f14727df4e2
+      - f8a677b6-542f-4b35-ac84-e2b080b9893d
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f567cd2f-4547-4ca3-93ba-204c68fc4bbf
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:53.108227Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"f567cd2f-4547-4ca3-93ba-204c68fc4bbf","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "791"
+      - "762"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:56:53 GMT
+      - Thu, 02 Nov 2023 18:54:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6ec6797-10cd-412f-8904-1025fb5f8d94
+      - 1a53e15d-02c0-4be5-9f54-f27469abaf7e
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f567cd2f-4547-4ca3-93ba-204c68fc4bbf
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:53.108227Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"f567cd2f-4547-4ca3-93ba-204c68fc4bbf","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "791"
+      - "762"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:23 GMT
+      - Thu, 02 Nov 2023 18:55:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 514ef9d3-69c4-4040-9cab-40f01559a8d7
+      - 26595a61-2a19-4130-afdd-05b536ec26ff
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f567cd2f-4547-4ca3-93ba-204c68fc4bbf
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:53.108227Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"f567cd2f-4547-4ca3-93ba-204c68fc4bbf","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "791"
+      - "762"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:57:54 GMT
+      - Thu, 02 Nov 2023 18:55:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93369c9a-01ac-4c61-a1eb-cf2dcd1ca913
+      - d0abfc73-69cd-40ea-b88d-8cc11d059bef
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f567cd2f-4547-4ca3-93ba-204c68fc4bbf
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:53.108227Z","endpoint":{"id":"f232b40c-55e4-4733-8d7d-a0c47f018416","ip":"51.159.26.148","load_balancer":{},"name":null,"port":9075},"endpoints":[{"id":"f232b40c-55e4-4733-8d7d-a0c47f018416","ip":"51.159.26.148","load_balancer":{},"name":null,"port":9075}],"engine":"PostgreSQL-15","id":"f567cd2f-4547-4ca3-93ba-204c68fc4bbf","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1281"
+      - "762"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:24 GMT
+      - Thu, 02 Nov 2023 18:56:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c667ec7-948f-405f-835b-0cd59c7c08f5
+      - a5d40455-f784-450d-8811-cf91e2f963de
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f567cd2f-4547-4ca3-93ba-204c68fc4bbf/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTExkWWlBVHVSNmY0Wll2eTU5U1Zha1JJQ1Bjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5qTXhXaGNOTXpNeE1ERTNNVFUxTmpNeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpuR2N2YzBMSlJLb1RUeTd4SXB2WjZyVllYS3hpcTVOQlpBZEZieW54RVBnR3pwcVk3TW81OFYKTWxmVUZFRVN6SkFpUHBCYXVnUTVGYUJOWk5hNUdyR0VITlFtay9NZk5HbnJNR0JMUldhZ0VuRXE4SVU1anZWMgpYd0d6M3MyM01EWjBQSjdZQzN0MkVsVmFMdFNjWE9QS1hjMnFnQUtJYlk1anE1eStvN0FQK2ltRXd5Q0UxNVhICkx4dVZRRis5a3VDREVmMkJpYVMxVkVLbkRZWk95NWhOVDNIOU9ZVHhNTFdMU1ArVzZMWVRKdHd6UGJJblUzUFQKRlBEYmlTR2xwUXY2Y0NRVzF2bU1YYksxUFUyVVNBRHpGbGNQS2k4ZFdqYlNNR3d2WlBvQlc0Zno3cHJzVSs5VwpFcmEvaE1KM1YrQ0tyK2c1aVJ6WlhDT2hUaHJjaGxjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0WmpVMk4yTmtNbVl0TkRVME55MDBZMkV6TFRrelltRXRNakEwWXpZNFptTTAKWW1KbUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bmtWQWh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQThXM2FxbGRIY3pvY05xR0RpanNlL2NmY0VReG50UnZpT0ZxTHpEQzNSR2hyaEZLSXJKbVVaCmJ5WlhZWVVOSkVtN3Zqc2xpZ1NQUVFoRk1YZWRXVEtkcmNLYjluSUR2UjR4S2xsZjM5bWtNUU9rMmVRQUFoVzAKb2NKc3N2UUNyMVZwejRmd2VvQjlnbWxvSDlLM05mSDg4T3R3UTgzYkRNKzN5cURsRmk4bzhXclhNZkJvaHgvSQpOZkw1RmZoNHVVWWZIQnRlYldBcDVsd0Z4Qk44dVJaVGVoR0JKUGdqV0hpOC9KN0hSd1ZGRzN5QnpZbnFjVHJUCkV5dnlWRHh5YjUvYW5IRnF4Q3NMaDR0bG1TZ0s1SFYzSGF4RkE5dnAvSDloRFc3ZW5VZGIwaXF1WUh5R1RUYXgKNXY0NzF2aXQyWHNQaUFHSWFRWlgyYmw5Wmw3bnhrUEoKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888},"endpoints":[{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888}],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1845"
+      - "1233"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:24 GMT
+      - Thu, 02 Nov 2023 18:56:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,12 +594,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a515ec8-8134-4272-8da9-ffbff2ec5333
+      - 3cec5cb3-70b9-4fb0-8cdf-fdcd15d09c5c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"f567cd2f-4547-4ca3-93ba-204c68fc4bbf","endpoint_spec":[{"direct_access":{}}],"same_zone":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVSXdEL2ZLYUhGVlFDYzhiSWFXbUJiQW82VlN3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR5TlM0Mk5UQWVGdzB5Ck16RXhNREl4T0RVME1UVmFGdzB6TXpFd016QXhPRFUwTVRWYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1qVXVOalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURqcWZQTDBZWHIwcDNhZjhSNnJuOGdCbXRMMlYvTm5GSldxd0h0MDJ2ZUlaWmRZNC90NVE1ejAzcmYKNUpTNDlPZDRMK1ZpN2dCdkpaaG85dHJFK0t4dlBUY0pVQnJqQmdQaGwvMnpxMHE1R3BqLytYdE5GRFByRGpESwpoZVU1SWF4QlhuUHFGNi8reGsvdnUwVEh3dUlBTFp1dk5rRzg2N0lrZjlWYVhmVnFGSndBbzNVWDFwUWZFQmRSCkVTR0RUMEYwemphc0NBc2RmRWFsWXdVaWJHUWFuWkdmZ3l6TVA3NXJmVFUrQUU1TS9ya0JpOEp0ZFM5cU1Tc24KU1M4WDdQYTJHZGx0R3J6OUMxM2VHb2JEbWFMTkwwc3M4WitrYnZlc1E4WE9JVERsNFRyWHI4WTZjTlBBSjNEWApuK2JlMVZxc1cyVmVWSldOcFlEL2k0aEFBbnl6QWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHlOUzQyTllJOGNuY3RPR013WVdZMk5USXRObVEyTWkwMFl6YzBMV0ptWkRBdFkySTJPR1JtWkRjelptWTMKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVMK3JCaHdRem54bEJNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFBLzJlbVd4c3JiRVN2eVVtTFRkWmpxcUx5cXhMQVZuNVV4Q1RvejVaRm1LbTI1R0VTTzBnZkc5UndSCktRTFlnS0NuQ0Nyd2NjcFJYK0lkbFVoaTBwcmZaSzRVSisrTEpoQklyWWhVMFRzUzFzdlpuNGp3ck90aDk0dCsKa2FnS2ZlL0pqQ1hqcVhzNnN5Q0lCQlppMlBNSmZWckY5K0czSGZYSCtBUlJVUGg3elNHNXViL0lFY3lnT3pKagpOZGtxOWJESE9YYnRYa2t5dk50cEQ1M1N6T1Q2VnVKSkx0SS9GaGY5bktJTnoybTc4NXZYNHNacm5WOXQ1MjZOCjlCSUF0YjMrR21GbnFKNDlHNytOYUF3WE91bEZFWTIrMlprUEowM1Irb0R1NHVKekxpNytRVVJDQ1d5cVdmQk8KZWZYUkdYUXVrNGlMY1czL2xZZE11aDdRUXlIVwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1839"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:56:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2fc08a53-315b-499b-8857-699c7dfb5433
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"instance_id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","endpoint_spec":[{"direct_access":{}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
@@ -610,16 +643,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "123"
+      - "119"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:24 GMT
+      - Thu, 02 Nov 2023 18:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7b065a8-1111-41e9-8704-498c0ebe2a6e
+      - 1de1079c-6eeb-4ca2-89d1-7cfd209beb02
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: GET
   response:
-    body: '{"endpoints":[],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "123"
+      - "119"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:58:25 GMT
+      - Thu, 02 Nov 2023 18:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b491d54a-39e2-4f98-a297-ec2311796aef
+      - 4f06d3f0-6378-4e92-8724-6b4a015f8122
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"a50fdeb3-1840-44d5-9700-0cc89ad5fb39","ip":"51.15.226.11","name":null,"port":5432}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "235"
+      - "119"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:00 GMT
+      - Thu, 02 Nov 2023 18:57:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59c43ebe-62ba-4494-8548-f42a7d393cbd
+      - 555cf194-5a7d-4999-970c-213a0d62bcff
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"a50fdeb3-1840-44d5-9700-0cc89ad5fb39","ip":"51.15.226.11","name":null,"port":5432}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "235"
+      - "229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:59:30 GMT
+      - Thu, 02 Nov 2023 18:57:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bda8e6ff-cd3c-41be-93f9-0e1c1c48e19d
+      - f5988220-0403-4354-9337-8e2d75cc62d9
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"a50fdeb3-1840-44d5-9700-0cc89ad5fb39","ip":"51.15.226.11","name":null,"port":5432}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "235"
+      - "229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:01 GMT
+      - Thu, 02 Nov 2023 18:58:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56ca0086-51fd-4b79-8c5e-f1c3220d2a6d
+      - 0068a6e0-2005-4641-9e36-cec4c1f080aa
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"a50fdeb3-1840-44d5-9700-0cc89ad5fb39","ip":"51.15.226.11","name":null,"port":5432}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "235"
+      - "229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:00:31 GMT
+      - Thu, 02 Nov 2023 18:58:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 377b37a2-cda2-42ad-ad79-e9964a40f1fd
+      - fac3b7d1-4b20-496e-9ef8-80bf679f5732
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"a50fdeb3-1840-44d5-9700-0cc89ad5fb39","ip":"51.15.226.11","name":null,"port":5432}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "235"
+      - "222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:01 GMT
+      - Thu, 02 Nov 2023 18:59:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62eed522-f7bd-4624-8e9d-478a0f000aeb
+      - e0ead0f0-4e8c-4656-bd02-23161f65461d
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"a50fdeb3-1840-44d5-9700-0cc89ad5fb39","ip":"51.15.226.11","name":null,"port":5432}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "228"
+      - "222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:31 GMT
+      - Thu, 02 Nov 2023 18:59:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2cb69855-3a94-430e-a369-d7c7aecd3aa2
+      - 74891469-e897-477b-af9d-f1514e5e69ab
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"a50fdeb3-1840-44d5-9700-0cc89ad5fb39","ip":"51.15.226.11","name":null,"port":5432}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "228"
+      - "222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:31 GMT
+      - Thu, 02 Nov 2023 18:59:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ffb5fb6d-252e-4aa6-92e5-92344071b6ed
+      - 543890dd-28b2-441d-a28e-840644cd4076
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"a50fdeb3-1840-44d5-9700-0cc89ad5fb39","ip":"51.15.226.11","name":null,"port":5432}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888},"endpoints":[{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888}],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "228"
+      - "1455"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:31 GMT
+      - Thu, 02 Nov 2023 18:59:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02b3c39e-6868-45ed-b88b-5a2c76d8c8e3
+      - 2e163107-5905-439b-bebf-b19a34173d4b
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f567cd2f-4547-4ca3-93ba-204c68fc4bbf
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:53.108227Z","endpoint":{"id":"f232b40c-55e4-4733-8d7d-a0c47f018416","ip":"51.159.26.148","load_balancer":{},"name":null,"port":9075},"endpoints":[{"id":"f232b40c-55e4-4733-8d7d-a0c47f018416","ip":"51.159.26.148","load_balancer":{},"name":null,"port":9075}],"engine":"PostgreSQL-15","id":"f567cd2f-4547-4ca3-93ba-204c68fc4bbf","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"direct_access":{},"id":"a50fdeb3-1840-44d5-9700-0cc89ad5fb39","ip":"51.15.226.11","name":null,"port":5432}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVSXdEL2ZLYUhGVlFDYzhiSWFXbUJiQW82VlN3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR5TlM0Mk5UQWVGdzB5Ck16RXhNREl4T0RVME1UVmFGdzB6TXpFd016QXhPRFUwTVRWYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1qVXVOalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURqcWZQTDBZWHIwcDNhZjhSNnJuOGdCbXRMMlYvTm5GSldxd0h0MDJ2ZUlaWmRZNC90NVE1ejAzcmYKNUpTNDlPZDRMK1ZpN2dCdkpaaG85dHJFK0t4dlBUY0pVQnJqQmdQaGwvMnpxMHE1R3BqLytYdE5GRFByRGpESwpoZVU1SWF4QlhuUHFGNi8reGsvdnUwVEh3dUlBTFp1dk5rRzg2N0lrZjlWYVhmVnFGSndBbzNVWDFwUWZFQmRSCkVTR0RUMEYwemphc0NBc2RmRWFsWXdVaWJHUWFuWkdmZ3l6TVA3NXJmVFUrQUU1TS9ya0JpOEp0ZFM5cU1Tc24KU1M4WDdQYTJHZGx0R3J6OUMxM2VHb2JEbWFMTkwwc3M4WitrYnZlc1E4WE9JVERsNFRyWHI4WTZjTlBBSjNEWApuK2JlMVZxc1cyVmVWSldOcFlEL2k0aEFBbnl6QWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHlOUzQyTllJOGNuY3RPR013WVdZMk5USXRObVEyTWkwMFl6YzBMV0ptWkRBdFkySTJPR1JtWkRjelptWTMKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVMK3JCaHdRem54bEJNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFBLzJlbVd4c3JiRVN2eVVtTFRkWmpxcUx5cXhMQVZuNVV4Q1RvejVaRm1LbTI1R0VTTzBnZkc5UndSCktRTFlnS0NuQ0Nyd2NjcFJYK0lkbFVoaTBwcmZaSzRVSisrTEpoQklyWWhVMFRzUzFzdlpuNGp3ck90aDk0dCsKa2FnS2ZlL0pqQ1hqcVhzNnN5Q0lCQlppMlBNSmZWckY5K0czSGZYSCtBUlJVUGg3elNHNXViL0lFY3lnT3pKagpOZGtxOWJESE9YYnRYa2t5dk50cEQ1M1N6T1Q2VnVKSkx0SS9GaGY5bktJTnoybTc4NXZYNHNacm5WOXQ1MjZOCjlCSUF0YjMrR21GbnFKNDlHNytOYUF3WE91bEZFWTIrMlprUEowM1Irb0R1NHVKekxpNytRVVJDQ1d5cVdmQk8KZWZYUkdYUXVrNGlMY1czL2xZZE11aDdRUXlIVwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1509"
+      - "1839"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:32 GMT
+      - Thu, 02 Nov 2023 18:59:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ae5f6e2-3f10-4959-bc47-07852746a0b2
+      - 52a88946-412d-4869-9be0-ba891e146653
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +1003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f567cd2f-4547-4ca3-93ba-204c68fc4bbf/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTExkWWlBVHVSNmY0Wll2eTU5U1Zha1JJQ1Bjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5qTXhXaGNOTXpNeE1ERTNNVFUxTmpNeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpuR2N2YzBMSlJLb1RUeTd4SXB2WjZyVllYS3hpcTVOQlpBZEZieW54RVBnR3pwcVk3TW81OFYKTWxmVUZFRVN6SkFpUHBCYXVnUTVGYUJOWk5hNUdyR0VITlFtay9NZk5HbnJNR0JMUldhZ0VuRXE4SVU1anZWMgpYd0d6M3MyM01EWjBQSjdZQzN0MkVsVmFMdFNjWE9QS1hjMnFnQUtJYlk1anE1eStvN0FQK2ltRXd5Q0UxNVhICkx4dVZRRis5a3VDREVmMkJpYVMxVkVLbkRZWk95NWhOVDNIOU9ZVHhNTFdMU1ArVzZMWVRKdHd6UGJJblUzUFQKRlBEYmlTR2xwUXY2Y0NRVzF2bU1YYksxUFUyVVNBRHpGbGNQS2k4ZFdqYlNNR3d2WlBvQlc0Zno3cHJzVSs5VwpFcmEvaE1KM1YrQ0tyK2c1aVJ6WlhDT2hUaHJjaGxjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0WmpVMk4yTmtNbVl0TkRVME55MDBZMkV6TFRrelltRXRNakEwWXpZNFptTTAKWW1KbUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bmtWQWh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQThXM2FxbGRIY3pvY05xR0RpanNlL2NmY0VReG50UnZpT0ZxTHpEQzNSR2hyaEZLSXJKbVVaCmJ5WlhZWVVOSkVtN3Zqc2xpZ1NQUVFoRk1YZWRXVEtkcmNLYjluSUR2UjR4S2xsZjM5bWtNUU9rMmVRQUFoVzAKb2NKc3N2UUNyMVZwejRmd2VvQjlnbWxvSDlLM05mSDg4T3R3UTgzYkRNKzN5cURsRmk4bzhXclhNZkJvaHgvSQpOZkw1RmZoNHVVWWZIQnRlYldBcDVsd0Z4Qk44dVJaVGVoR0JKUGdqV0hpOC9KN0hSd1ZGRzN5QnpZbnFjVHJUCkV5dnlWRHh5YjUvYW5IRnF4Q3NMaDR0bG1TZ0s1SFYzSGF4RkE5dnAvSDloRFc3ZW5VZGIwaXF1WUh5R1RUYXgKNXY0NzF2aXQyWHNQaUFHSWFRWlgyYmw5Wmw3bnhrUEoKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "1845"
+      - "222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:32 GMT
+      - Thu, 02 Nov 2023 18:59:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82dcd334-22b3-4cdb-821f-502c01d3429a
+      - 9b575e97-c976-4a0c-b715-c48074176ac4
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,19 +1036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"a50fdeb3-1840-44d5-9700-0cc89ad5fb39","ip":"51.15.226.11","name":null,"port":5432}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888},"endpoints":[{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888}],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "228"
+      - "1455"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:32 GMT
+      - Thu, 02 Nov 2023 18:59:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d33ae608-b370-43e9-8c35-7dae5aa9a7de
+      - 17dd8174-4ab2-4091-a99a-b1159c43e042
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,19 +1069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f567cd2f-4547-4ca3-93ba-204c68fc4bbf
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:53.108227Z","endpoint":{"id":"f232b40c-55e4-4733-8d7d-a0c47f018416","ip":"51.159.26.148","load_balancer":{},"name":null,"port":9075},"endpoints":[{"id":"f232b40c-55e4-4733-8d7d-a0c47f018416","ip":"51.159.26.148","load_balancer":{},"name":null,"port":9075}],"engine":"PostgreSQL-15","id":"f567cd2f-4547-4ca3-93ba-204c68fc4bbf","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"direct_access":{},"id":"a50fdeb3-1840-44d5-9700-0cc89ad5fb39","ip":"51.15.226.11","name":null,"port":5432}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVSXdEL2ZLYUhGVlFDYzhiSWFXbUJiQW82VlN3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR5TlM0Mk5UQWVGdzB5Ck16RXhNREl4T0RVME1UVmFGdzB6TXpFd016QXhPRFUwTVRWYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1qVXVOalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURqcWZQTDBZWHIwcDNhZjhSNnJuOGdCbXRMMlYvTm5GSldxd0h0MDJ2ZUlaWmRZNC90NVE1ejAzcmYKNUpTNDlPZDRMK1ZpN2dCdkpaaG85dHJFK0t4dlBUY0pVQnJqQmdQaGwvMnpxMHE1R3BqLytYdE5GRFByRGpESwpoZVU1SWF4QlhuUHFGNi8reGsvdnUwVEh3dUlBTFp1dk5rRzg2N0lrZjlWYVhmVnFGSndBbzNVWDFwUWZFQmRSCkVTR0RUMEYwemphc0NBc2RmRWFsWXdVaWJHUWFuWkdmZ3l6TVA3NXJmVFUrQUU1TS9ya0JpOEp0ZFM5cU1Tc24KU1M4WDdQYTJHZGx0R3J6OUMxM2VHb2JEbWFMTkwwc3M4WitrYnZlc1E4WE9JVERsNFRyWHI4WTZjTlBBSjNEWApuK2JlMVZxc1cyVmVWSldOcFlEL2k0aEFBbnl6QWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHlOUzQyTllJOGNuY3RPR013WVdZMk5USXRObVEyTWkwMFl6YzBMV0ptWkRBdFkySTJPR1JtWkRjelptWTMKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVMK3JCaHdRem54bEJNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFBLzJlbVd4c3JiRVN2eVVtTFRkWmpxcUx5cXhMQVZuNVV4Q1RvejVaRm1LbTI1R0VTTzBnZkc5UndSCktRTFlnS0NuQ0Nyd2NjcFJYK0lkbFVoaTBwcmZaSzRVSisrTEpoQklyWWhVMFRzUzFzdlpuNGp3ck90aDk0dCsKa2FnS2ZlL0pqQ1hqcVhzNnN5Q0lCQlppMlBNSmZWckY5K0czSGZYSCtBUlJVUGg3elNHNXViL0lFY3lnT3pKagpOZGtxOWJESE9YYnRYa2t5dk50cEQ1M1N6T1Q2VnVKSkx0SS9GaGY5bktJTnoybTc4NXZYNHNacm5WOXQ1MjZOCjlCSUF0YjMrR21GbnFKNDlHNytOYUF3WE91bEZFWTIrMlprUEowM1Irb0R1NHVKekxpNytRVVJDQ1d5cVdmQk8KZWZYUkdYUXVrNGlMY1czL2xZZE11aDdRUXlIVwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1509"
+      - "1839"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:32 GMT
+      - Thu, 02 Nov 2023 18:59:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1058,7 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50d584b2-234d-4f89-aac5-6173ed1501c8
+      - 7e696613-44a2-4077-bcda-2246976c9163
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,19 +1102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f567cd2f-4547-4ca3-93ba-204c68fc4bbf/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTExkWWlBVHVSNmY0Wll2eTU5U1Zha1JJQ1Bjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5qTXhXaGNOTXpNeE1ERTNNVFUxTmpNeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpuR2N2YzBMSlJLb1RUeTd4SXB2WjZyVllYS3hpcTVOQlpBZEZieW54RVBnR3pwcVk3TW81OFYKTWxmVUZFRVN6SkFpUHBCYXVnUTVGYUJOWk5hNUdyR0VITlFtay9NZk5HbnJNR0JMUldhZ0VuRXE4SVU1anZWMgpYd0d6M3MyM01EWjBQSjdZQzN0MkVsVmFMdFNjWE9QS1hjMnFnQUtJYlk1anE1eStvN0FQK2ltRXd5Q0UxNVhICkx4dVZRRis5a3VDREVmMkJpYVMxVkVLbkRZWk95NWhOVDNIOU9ZVHhNTFdMU1ArVzZMWVRKdHd6UGJJblUzUFQKRlBEYmlTR2xwUXY2Y0NRVzF2bU1YYksxUFUyVVNBRHpGbGNQS2k4ZFdqYlNNR3d2WlBvQlc0Zno3cHJzVSs5VwpFcmEvaE1KM1YrQ0tyK2c1aVJ6WlhDT2hUaHJjaGxjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0WmpVMk4yTmtNbVl0TkRVME55MDBZMkV6TFRrelltRXRNakEwWXpZNFptTTAKWW1KbUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bmtWQWh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQThXM2FxbGRIY3pvY05xR0RpanNlL2NmY0VReG50UnZpT0ZxTHpEQzNSR2hyaEZLSXJKbVVaCmJ5WlhZWVVOSkVtN3Zqc2xpZ1NQUVFoRk1YZWRXVEtkcmNLYjluSUR2UjR4S2xsZjM5bWtNUU9rMmVRQUFoVzAKb2NKc3N2UUNyMVZwejRmd2VvQjlnbWxvSDlLM05mSDg4T3R3UTgzYkRNKzN5cURsRmk4bzhXclhNZkJvaHgvSQpOZkw1RmZoNHVVWWZIQnRlYldBcDVsd0Z4Qk44dVJaVGVoR0JKUGdqV0hpOC9KN0hSd1ZGRzN5QnpZbnFjVHJUCkV5dnlWRHh5YjUvYW5IRnF4Q3NMaDR0bG1TZ0s1SFYzSGF4RkE5dnAvSDloRFc3ZW5VZGIwaXF1WUh5R1RUYXgKNXY0NzF2aXQyWHNQaUFHSWFRWlgyYmw5Wmw3bnhrUEoKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "1845"
+      - "222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:33 GMT
+      - Thu, 02 Nov 2023 18:59:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1091,45 +1124,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 108d6b28-0665-438b-a21a-87a15cf6e8e5
+      - aade5a5c-3d26-44be-be45-e66a20cc34e7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
-    method: GET
-  response:
-    body: '{"endpoints":[{"direct_access":{},"id":"a50fdeb3-1840-44d5-9700-0cc89ad5fb39","ip":"51.15.226.11","name":null,"port":5432}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"ready"}'
-    headers:
-      Content-Length:
-      - "228"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:01:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ca9e744b-f861-428e-b1ac-63cb296d0035
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"tf-pn-gifted-shockley","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"tf-pn-vigilant-ellis","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -1140,16 +1140,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-20T16:01:34.075821Z","dhcp_enabled":true,"id":"032c5275-f0d7-4e6b-a64a-7891ae199bc4","name":"tf-pn-gifted-shockley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T16:01:34.075821Z","id":"e29b5809-10c8-452f-9479-37959b7698d7","subnet":"172.16.16.0/22","updated_at":"2023-10-20T16:01:34.075821Z"},{"created_at":"2023-10-20T16:01:34.075821Z","id":"adc42253-1a32-4cbf-9e48-9a11774c29e9","subnet":"fd63:256c:45f7:1af4::/64","updated_at":"2023-10-20T16:01:34.075821Z"}],"tags":[],"updated_at":"2023-10-20T16:01:34.075821Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-02T18:59:11.152006Z","dhcp_enabled":true,"id":"81776f3f-28a0-4cb6-9898-aec76cfea602","name":"tf-pn-vigilant-ellis","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:59:11.152006Z","id":"7882cbae-fbc1-458a-b1dc-23b1a8268f1a","subnet":"172.16.32.0/22","updated_at":"2023-11-02T18:59:11.152006Z"},{"created_at":"2023-11-02T18:59:11.152006Z","id":"741d48a2-c9b3-4a07-94a7-6b9ff99e03cd","subnet":"fd63:256c:45f7:9ea8::/64","updated_at":"2023-11-02T18:59:11.152006Z"}],"tags":[],"updated_at":"2023-11-02T18:59:11.152006Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "722"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:35 GMT
+      - Thu, 02 Nov 2023 18:59:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef7f19db-5c9b-4b5c-a080-30cfff26e250
+      - 3f561db1-9436-4c79-8f0b-8af284086246
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,19 +1170,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/032c5275-f0d7-4e6b-a64a-7891ae199bc4
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/81776f3f-28a0-4cb6-9898-aec76cfea602
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:01:34.075821Z","dhcp_enabled":true,"id":"032c5275-f0d7-4e6b-a64a-7891ae199bc4","name":"tf-pn-gifted-shockley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T16:01:34.075821Z","id":"e29b5809-10c8-452f-9479-37959b7698d7","subnet":"172.16.16.0/22","updated_at":"2023-10-20T16:01:34.075821Z"},{"created_at":"2023-10-20T16:01:34.075821Z","id":"adc42253-1a32-4cbf-9e48-9a11774c29e9","subnet":"fd63:256c:45f7:1af4::/64","updated_at":"2023-10-20T16:01:34.075821Z"}],"tags":[],"updated_at":"2023-10-20T16:01:34.075821Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-02T18:59:11.152006Z","dhcp_enabled":true,"id":"81776f3f-28a0-4cb6-9898-aec76cfea602","name":"tf-pn-vigilant-ellis","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:59:11.152006Z","id":"7882cbae-fbc1-458a-b1dc-23b1a8268f1a","subnet":"172.16.32.0/22","updated_at":"2023-11-02T18:59:11.152006Z"},{"created_at":"2023-11-02T18:59:11.152006Z","id":"741d48a2-c9b3-4a07-94a7-6b9ff99e03cd","subnet":"fd63:256c:45f7:9ea8::/64","updated_at":"2023-11-02T18:59:11.152006Z"}],"tags":[],"updated_at":"2023-11-02T18:59:11.152006Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "722"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:35 GMT
+      - Thu, 02 Nov 2023 18:59:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7000a000-e9af-4690-8f74-847eb8090f03
+      - e2788f67-cd7c-48f8-b5b1-1f6f47526d77
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,10 +1203,74 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"a50fdeb3-1840-44d5-9700-0cc89ad5fb39","ip":"51.15.226.11","name":null,"port":5432}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "222"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:59:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b50ab3eb-990b-40cd-a3d2-753b38acad90
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/7ce62594-a076-4680-8a1a-9facf153ca7e
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:59:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d757aece-73f7-44f0-87fe-234f6c9eac9a
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    method: GET
+  response:
+    body: '{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"configuring"}'
     headers:
       Content-Length:
       - "228"
@@ -1215,7 +1279,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:35 GMT
+      - Thu, 02 Nov 2023 18:59:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df5efaf0-874b-4d27-aa03-1e3916e6a1f0
+      - 9fea6edd-681f-4d15-a8df-f66fab414792
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,50 +1300,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/a50fdeb3-1840-44d5-9700-0cc89ad5fb39
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:01:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fd583141-9808-4f48-b353-7a154d8dde61
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"a50fdeb3-1840-44d5-9700-0cc89ad5fb39","ip":"51.15.226.11","name":null,"port":5432}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"configuring"}'
+    body: '{"endpoints":[],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "234"
+      - "112"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:01:36 GMT
+      - Thu, 02 Nov 2023 18:59:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1289,45 +1322,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66e1b90a-f529-4b32-8156-97e96c06fa56
+      - f47a7fe8-40da-49f1-aaa1-261cf029ba87
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
-    method: GET
-  response:
-    body: '{"endpoints":[],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"ready"}'
-    headers:
-      Content-Length:
-      - "116"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:02:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 03c5e882-4a07-4718-acdb-6f76ba21d53f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"032c5275-f0d7-4e6b-a64a-7891ae199bc4","service_ip":"10.12.1.0/20"}}]}'
+    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20"}}]}'
     form: {}
     headers:
       Content-Type:
@@ -1335,19 +1335,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da/endpoints
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b/endpoints
     method: POST
   response:
-    body: '{"endpoints":[{"id":"e126f2dc-4781-4ab4-b02f-9175552daf4b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"032c5275-f0d7-4e6b-a64a-7891ae199bc4","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"ab597724-0016-49e5-a00a-5bc697b32921","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "341"
+      - "331"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:06 GMT
+      - Thu, 02 Nov 2023 18:59:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09e24bc0-777b-414c-8f31-7b826871d57d
+      - 0be8444b-5d7f-419f-aa7d-c13a9b272f86
     status: 200 OK
     code: 200
     duration: ""
@@ -1368,19 +1368,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: GET
   response:
-    body: '{"endpoints":[{"id":"e126f2dc-4781-4ab4-b02f-9175552daf4b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"032c5275-f0d7-4e6b-a64a-7891ae199bc4","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"ab597724-0016-49e5-a00a-5bc697b32921","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "341"
+      - "331"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:06 GMT
+      - Thu, 02 Nov 2023 18:59:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7efb99f4-c16b-4f7f-a4da-1452f32c9ebc
+      - 1edb5434-2cd3-49fd-b7ae-d016b60f86b5
     status: 200 OK
     code: 200
     duration: ""
@@ -1401,19 +1401,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: GET
   response:
-    body: '{"endpoints":[{"id":"e126f2dc-4781-4ab4-b02f-9175552daf4b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"032c5275-f0d7-4e6b-a64a-7891ae199bc4","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"ab597724-0016-49e5-a00a-5bc697b32921","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "334"
+      - "324"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:36 GMT
+      - Thu, 02 Nov 2023 19:00:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1423,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba794247-2cd6-4732-9ae1-d3f91512af31
+      - e8ddc763-0747-4d83-bc23-6d96e7107164
     status: 200 OK
     code: 200
     duration: ""
@@ -1434,19 +1434,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: GET
   response:
-    body: '{"endpoints":[{"id":"e126f2dc-4781-4ab4-b02f-9175552daf4b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"032c5275-f0d7-4e6b-a64a-7891ae199bc4","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"ab597724-0016-49e5-a00a-5bc697b32921","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "334"
+      - "324"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:36 GMT
+      - Thu, 02 Nov 2023 19:00:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1baaf1b-e89f-45f4-a66f-107daf27ed7e
+      - 45112172-4b36-427b-887d-6d28a73174d6
     status: 200 OK
     code: 200
     duration: ""
@@ -1467,19 +1467,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: GET
   response:
-    body: '{"endpoints":[{"id":"e126f2dc-4781-4ab4-b02f-9175552daf4b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"032c5275-f0d7-4e6b-a64a-7891ae199bc4","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"ab597724-0016-49e5-a00a-5bc697b32921","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "334"
+      - "324"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:37 GMT
+      - Thu, 02 Nov 2023 19:00:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5bb11e1-76f7-4f78-9101-887abd75263d
+      - db085c77-aead-451d-8c59-2091e886c2a2
     status: 200 OK
     code: 200
     duration: ""
@@ -1500,19 +1500,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/032c5275-f0d7-4e6b-a64a-7891ae199bc4
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/81776f3f-28a0-4cb6-9898-aec76cfea602
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:01:34.075821Z","dhcp_enabled":true,"id":"032c5275-f0d7-4e6b-a64a-7891ae199bc4","name":"tf-pn-gifted-shockley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-20T16:01:34.075821Z","id":"e29b5809-10c8-452f-9479-37959b7698d7","subnet":"172.16.16.0/22","updated_at":"2023-10-20T16:01:34.075821Z"},{"created_at":"2023-10-20T16:01:34.075821Z","id":"adc42253-1a32-4cbf-9e48-9a11774c29e9","subnet":"fd63:256c:45f7:1af4::/64","updated_at":"2023-10-20T16:01:34.075821Z"}],"tags":[],"updated_at":"2023-10-20T16:01:34.075821Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-02T18:59:11.152006Z","dhcp_enabled":true,"id":"81776f3f-28a0-4cb6-9898-aec76cfea602","name":"tf-pn-vigilant-ellis","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:59:11.152006Z","id":"7882cbae-fbc1-458a-b1dc-23b1a8268f1a","subnet":"172.16.32.0/22","updated_at":"2023-11-02T18:59:11.152006Z"},{"created_at":"2023-11-02T18:59:11.152006Z","id":"741d48a2-c9b3-4a07-94a7-6b9ff99e03cd","subnet":"fd63:256c:45f7:9ea8::/64","updated_at":"2023-11-02T18:59:11.152006Z"}],"tags":[],"updated_at":"2023-11-02T18:59:11.152006Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "722"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:37 GMT
+      - Thu, 02 Nov 2023 19:00:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b598230-5522-4203-bf06-13624108a998
+      - b9ee3d2f-01b0-4488-a63b-671dbac29f04
     status: 200 OK
     code: 200
     duration: ""
@@ -1533,19 +1533,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f567cd2f-4547-4ca3-93ba-204c68fc4bbf
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:53.108227Z","endpoint":{"id":"f232b40c-55e4-4733-8d7d-a0c47f018416","ip":"51.159.26.148","load_balancer":{},"name":null,"port":9075},"endpoints":[{"id":"f232b40c-55e4-4733-8d7d-a0c47f018416","ip":"51.159.26.148","load_balancer":{},"name":null,"port":9075}],"engine":"PostgreSQL-15","id":"f567cd2f-4547-4ca3-93ba-204c68fc4bbf","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"e126f2dc-4781-4ab4-b02f-9175552daf4b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"032c5275-f0d7-4e6b-a64a-7891ae199bc4","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888},"endpoints":[{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888}],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"ab597724-0016-49e5-a00a-5bc697b32921","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1615"
+      - "1557"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:37 GMT
+      - Thu, 02 Nov 2023 19:00:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1555,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d714ac8e-e069-4fae-93c6-28637a3a8d17
+      - 8538c67a-4640-4087-a35e-2b4fb332732f
     status: 200 OK
     code: 200
     duration: ""
@@ -1566,19 +1566,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f567cd2f-4547-4ca3-93ba-204c68fc4bbf/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTExkWWlBVHVSNmY0Wll2eTU5U1Zha1JJQ1Bjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU5qTXhXaGNOTXpNeE1ERTNNVFUxTmpNeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpuR2N2YzBMSlJLb1RUeTd4SXB2WjZyVllYS3hpcTVOQlpBZEZieW54RVBnR3pwcVk3TW81OFYKTWxmVUZFRVN6SkFpUHBCYXVnUTVGYUJOWk5hNUdyR0VITlFtay9NZk5HbnJNR0JMUldhZ0VuRXE4SVU1anZWMgpYd0d6M3MyM01EWjBQSjdZQzN0MkVsVmFMdFNjWE9QS1hjMnFnQUtJYlk1anE1eStvN0FQK2ltRXd5Q0UxNVhICkx4dVZRRis5a3VDREVmMkJpYVMxVkVLbkRZWk95NWhOVDNIOU9ZVHhNTFdMU1ArVzZMWVRKdHd6UGJJblUzUFQKRlBEYmlTR2xwUXY2Y0NRVzF2bU1YYksxUFUyVVNBRHpGbGNQS2k4ZFdqYlNNR3d2WlBvQlc0Zno3cHJzVSs5VwpFcmEvaE1KM1YrQ0tyK2c1aVJ6WlhDT2hUaHJjaGxjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0WmpVMk4yTmtNbVl0TkRVME55MDBZMkV6TFRrelltRXRNakEwWXpZNFptTTAKWW1KbUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bmtWQWh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQThXM2FxbGRIY3pvY05xR0RpanNlL2NmY0VReG50UnZpT0ZxTHpEQzNSR2hyaEZLSXJKbVVaCmJ5WlhZWVVOSkVtN3Zqc2xpZ1NQUVFoRk1YZWRXVEtkcmNLYjluSUR2UjR4S2xsZjM5bWtNUU9rMmVRQUFoVzAKb2NKc3N2UUNyMVZwejRmd2VvQjlnbWxvSDlLM05mSDg4T3R3UTgzYkRNKzN5cURsRmk4bzhXclhNZkJvaHgvSQpOZkw1RmZoNHVVWWZIQnRlYldBcDVsd0Z4Qk44dVJaVGVoR0JKUGdqV0hpOC9KN0hSd1ZGRzN5QnpZbnFjVHJUCkV5dnlWRHh5YjUvYW5IRnF4Q3NMaDR0bG1TZ0s1SFYzSGF4RkE5dnAvSDloRFc3ZW5VZGIwaXF1WUh5R1RUYXgKNXY0NzF2aXQyWHNQaUFHSWFRWlgyYmw5Wmw3bnhrUEoKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVSXdEL2ZLYUhGVlFDYzhiSWFXbUJiQW82VlN3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR5TlM0Mk5UQWVGdzB5Ck16RXhNREl4T0RVME1UVmFGdzB6TXpFd016QXhPRFUwTVRWYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1qVXVOalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURqcWZQTDBZWHIwcDNhZjhSNnJuOGdCbXRMMlYvTm5GSldxd0h0MDJ2ZUlaWmRZNC90NVE1ejAzcmYKNUpTNDlPZDRMK1ZpN2dCdkpaaG85dHJFK0t4dlBUY0pVQnJqQmdQaGwvMnpxMHE1R3BqLytYdE5GRFByRGpESwpoZVU1SWF4QlhuUHFGNi8reGsvdnUwVEh3dUlBTFp1dk5rRzg2N0lrZjlWYVhmVnFGSndBbzNVWDFwUWZFQmRSCkVTR0RUMEYwemphc0NBc2RmRWFsWXdVaWJHUWFuWkdmZ3l6TVA3NXJmVFUrQUU1TS9ya0JpOEp0ZFM5cU1Tc24KU1M4WDdQYTJHZGx0R3J6OUMxM2VHb2JEbWFMTkwwc3M4WitrYnZlc1E4WE9JVERsNFRyWHI4WTZjTlBBSjNEWApuK2JlMVZxc1cyVmVWSldOcFlEL2k0aEFBbnl6QWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHlOUzQyTllJOGNuY3RPR013WVdZMk5USXRObVEyTWkwMFl6YzBMV0ptWkRBdFkySTJPR1JtWkRjelptWTMKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVMK3JCaHdRem54bEJNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFBLzJlbVd4c3JiRVN2eVVtTFRkWmpxcUx5cXhMQVZuNVV4Q1RvejVaRm1LbTI1R0VTTzBnZkc5UndSCktRTFlnS0NuQ0Nyd2NjcFJYK0lkbFVoaTBwcmZaSzRVSisrTEpoQklyWWhVMFRzUzFzdlpuNGp3ck90aDk0dCsKa2FnS2ZlL0pqQ1hqcVhzNnN5Q0lCQlppMlBNSmZWckY5K0czSGZYSCtBUlJVUGg3elNHNXViL0lFY3lnT3pKagpOZGtxOWJESE9YYnRYa2t5dk50cEQ1M1N6T1Q2VnVKSkx0SS9GaGY5bktJTnoybTc4NXZYNHNacm5WOXQ1MjZOCjlCSUF0YjMrR21GbnFKNDlHNytOYUF3WE91bEZFWTIrMlprUEowM1Irb0R1NHVKekxpNytRVVJDQ1d5cVdmQk8KZWZYUkdYUXVrNGlMY1czL2xZZE11aDdRUXlIVwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1839"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:37 GMT
+      - Thu, 02 Nov 2023 19:00:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed7a6eed-401a-423e-b398-775ba0d506ec
+      - e3c9ba45-908b-474b-b848-b68e5c740492
     status: 200 OK
     code: 200
     duration: ""
@@ -1599,19 +1599,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: GET
   response:
-    body: '{"endpoints":[{"id":"e126f2dc-4781-4ab4-b02f-9175552daf4b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"032c5275-f0d7-4e6b-a64a-7891ae199bc4","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"ab597724-0016-49e5-a00a-5bc697b32921","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "334"
+      - "324"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:37 GMT
+      - Thu, 02 Nov 2023 19:00:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1621,7 +1621,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93f00edc-6266-4a01-9c46-d5bd16272885
+      - 6201d6ec-228f-4abf-afc0-91ceaec19d16
     status: 200 OK
     code: 200
     duration: ""
@@ -1632,19 +1632,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: GET
   response:
-    body: '{"endpoints":[{"id":"e126f2dc-4781-4ab4-b02f-9175552daf4b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"032c5275-f0d7-4e6b-a64a-7891ae199bc4","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"ab597724-0016-49e5-a00a-5bc697b32921","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "334"
+      - "324"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:38 GMT
+      - Thu, 02 Nov 2023 19:00:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1654,7 +1654,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ba7d229-c127-46be-ae03-303eba3220a4
+      - f93749b5-184c-4369-b0d9-2c17e6dd5628
     status: 200 OK
     code: 200
     duration: ""
@@ -1665,19 +1665,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"e126f2dc-4781-4ab4-b02f-9175552daf4b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"032c5275-f0d7-4e6b-a64a-7891ae199bc4","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"ab597724-0016-49e5-a00a-5bc697b32921","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "337"
+      - "327"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:38 GMT
+      - Thu, 02 Nov 2023 19:00:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1687,7 +1687,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c6d8d90-0611-4c76-8b44-148abe40d294
+      - 640c4866-325d-4c8c-b3f8-dba08ffbf343
     status: 200 OK
     code: 200
     duration: ""
@@ -1698,19 +1698,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: GET
   response:
-    body: '{"endpoints":[{"id":"e126f2dc-4781-4ab4-b02f-9175552daf4b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"032c5275-f0d7-4e6b-a64a-7891ae199bc4","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"ab597724-0016-49e5-a00a-5bc697b32921","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "337"
+      - "327"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:02:38 GMT
+      - Thu, 02 Nov 2023 19:00:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1720,7 +1720,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4eaa8ae9-a638-4c2d-8157-69ecdfb50394
+      - 8b0673f7-4064-4ff0-97f4-4a9d0f637996
     status: 200 OK
     code: 200
     duration: ""
@@ -1731,10 +1731,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1743,7 +1743,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:09 GMT
+      - Thu, 02 Nov 2023 19:00:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1753,7 +1753,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78ce6190-c3a2-488b-8044-e4255f594457
+      - bb397076-65c6-4af5-9065-906e5134f102
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1764,19 +1764,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f567cd2f-4547-4ca3-93ba-204c68fc4bbf
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:53.108227Z","endpoint":{"id":"f232b40c-55e4-4733-8d7d-a0c47f018416","ip":"51.159.26.148","load_balancer":{},"name":null,"port":9075},"endpoints":[{"id":"f232b40c-55e4-4733-8d7d-a0c47f018416","ip":"51.159.26.148","load_balancer":{},"name":null,"port":9075}],"engine":"PostgreSQL-15","id":"f567cd2f-4547-4ca3-93ba-204c68fc4bbf","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888},"endpoints":[{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888}],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1281"
+      - "1233"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:09 GMT
+      - Thu, 02 Nov 2023 19:00:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1786,7 +1786,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fe8007c-5ec4-4dc9-9295-0fefe8e84146
+      - b5d3d155-fe23-4ab4-bd24-5cc7de9d2a53
     status: 200 OK
     code: 200
     duration: ""
@@ -1797,73 +1797,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f567cd2f-4547-4ca3-93ba-204c68fc4bbf
-    method: DELETE
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:53.108227Z","endpoint":{"id":"f232b40c-55e4-4733-8d7d-a0c47f018416","ip":"51.159.26.148","load_balancer":{},"name":null,"port":9075},"endpoints":[{"id":"f232b40c-55e4-4733-8d7d-a0c47f018416","ip":"51.159.26.148","load_balancer":{},"name":null,"port":9075}],"engine":"PostgreSQL-15","id":"f567cd2f-4547-4ca3-93ba-204c68fc4bbf","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1284"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:03:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ac6c5d58-9be4-42e1-9fcb-871810338015
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f567cd2f-4547-4ca3-93ba-204c68fc4bbf
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T15:55:53.108227Z","endpoint":{"id":"f232b40c-55e4-4733-8d7d-a0c47f018416","ip":"51.159.26.148","load_balancer":{},"name":null,"port":9075},"endpoints":[{"id":"f232b40c-55e4-4733-8d7d-a0c47f018416","ip":"51.159.26.148","load_balancer":{},"name":null,"port":9075}],"engine":"PostgreSQL-15","id":"f567cd2f-4547-4ca3-93ba-204c68fc4bbf","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1284"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:03:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 87a0f6ac-0342-4147-b9de-7d3227426e4d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/032c5275-f0d7-4e6b-a64a-7891ae199bc4
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/81776f3f-28a0-4cb6-9898-aec76cfea602
     method: DELETE
   response:
     body: ""
@@ -1873,7 +1807,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:09 GMT
+      - Thu, 02 Nov 2023 19:00:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1883,7 +1817,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6c4be29-9ef7-4bd5-9d18-85790d682cd3
+      - 67778ed4-1ebb-4ab1-9ea6-14a58bd3d451
     status: 204 No Content
     code: 204
     duration: ""
@@ -1894,19 +1828,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f567cd2f-4547-4ca3-93ba-204c68fc4bbf
-    method: GET
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
+    method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"f567cd2f-4547-4ca3-93ba-204c68fc4bbf","type":"not_found"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888},"endpoints":[{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888}],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "129"
+      - "1236"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:39 GMT
+      - Thu, 02 Nov 2023 19:00:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1916,7 +1850,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9bb3b8e-4511-4ae7-af4f-cac928396ca1
+      - d7afeb0b-b13e-445f-a64a-c98f3595fa06
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888},"endpoints":[{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888}],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1236"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 19:00:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ea475439-a441-4df1-a575-98c85e86ae0d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "129"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 19:01:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 83518b9c-a5ee-470e-a7e9-6c19b698d158
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1927,10 +1927,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f567cd2f-4547-4ca3-93ba-204c68fc4bbf
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"f567cd2f-4547-4ca3-93ba-204c68fc4bbf","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1939,7 +1939,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:39 GMT
+      - Thu, 02 Nov 2023 19:01:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1949,7 +1949,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41e17338-3a5e-4fe6-85d2-e21e3b296513
+      - 4fa46af6-097a-4fb3-9b48-471003a27e36
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1960,10 +1960,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/dea7335a-1acc-46cd-8bfb-f5c7094502da
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"dea7335a-1acc-46cd-8bfb-f5c7094502da","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1972,7 +1972,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:03:40 GMT
+      - Thu, 02 Nov 2023 19:01:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1982,7 +1982,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d54a6017-b2bb-4df4-b776-15d9b86a3cba
+      - a967a96b-0967-464d-95af-79ac489fd166
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-user-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-user-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:08 GMT
+      - Thu, 02 Nov 2023 18:46:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01b95a21-f3e4-46e1-afcc-3254b9e0cd45
+      - 862a3090-59ab-450c-8a56-b09afe903c58
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayRdbUser_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayRdbUser_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "819"
+      - "790"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:10 GMT
+      - Thu, 02 Nov 2023 18:51:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9bc421ba-7867-44c4-b226-9a1cc1d9aab0
+      - bada1925-10cb-4c5a-8ef2-c33b7fce516b
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "819"
+      - "790"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:10 GMT
+      - Thu, 02 Nov 2023 18:51:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69a43320-57d2-4137-bc4c-def19eb81510
+      - 9cf7825e-6417-485d-9639-ad9cacdaf105
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "819"
+      - "790"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:51:40 GMT
+      - Thu, 02 Nov 2023 18:51:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c2b5ca5-10fb-4edc-b6c4-b3c22fece94a
+      - 1caca6fd-507d-46ea-a456-c8cb4024f404
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "819"
+      - "790"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:52:10 GMT
+      - Thu, 02 Nov 2023 18:52:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c9a2c93-4928-4a90-a1ff-caee9cf24bfc
+      - daf720f8-2408-4d00-82f5-721b0d07fbda
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "819"
+      - "790"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:52:41 GMT
+      - Thu, 02 Nov 2023 18:52:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aecc693a-036d-4e8a-9fa9-3f73c26bcfe6
+      - 28ef35d0-44f0-4a30-90b8-b15d09879058
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "819"
+      - "790"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:53:11 GMT
+      - Thu, 02 Nov 2023 18:53:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0c78e0b-2411-410c-befa-f49fceaffcc2
+      - 646a6fcf-0920-4cd2-b912-38ecd8a88a22
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "819"
+      - "790"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:53:41 GMT
+      - Thu, 02 Nov 2023 18:53:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc121e23-aab3-44ed-be9c-91ed848ec2c2
+      - 0117998e-b8b4-45d1-be37-00b08270d91a
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603},"endpoints":[{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603}],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1311"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:54:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,12 +594,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5432a239-5479-4902-86ca-1f6435a2cdbc
+      - 14b9364d-0d1a-4b56-917b-38581e80bf15
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"backup_schedule_frequency":null,"backup_schedule_retention":null,"is_backup_schedule_disabled":false,"name":null,"tags":null,"logs_policy":null,"backup_same_region":false,"backup_schedule_start_hour":null}'
+    body: '{"is_backup_schedule_disabled":false,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -607,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603},"endpoints":[{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603}],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1311"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 053c4437-2e33-4d9d-b8db-37ebc6fd1fcb
+      - f99040bb-8034-4ac1-9d26-7df60ec96016
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603},"endpoints":[{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603}],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1311"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4810a5ed-c51a-433d-89c2-6575666ba6ab
+      - 5e3f8371-1f6a-484f-a6bb-a908ebb0c317
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVVktOYnN4NnhieGZLcUdnVjdJNUw5Tmo2dGhvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU1qQTFXaGNOTXpNeE1ERTNNVFUxTWpBMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUowMnY4Mmo5ODFQL0pYOFNqUU9CUHVGa2picmtMbTF2ZWF2Y3hIS3FMU0FlSkY3aitHV3MveGwKRlpBeDZsek9WdHhJNEZzell4UzZRdWNWSDI0M0FuY3Nza3F4cDhISlFBcnppVjQ2WGh2VnlDVWpKRklRelprVgo5KzB4MzJYS1NZdUFQaFNLcjFKbEdoSmVsVU5qTW0xVVh5UHg3ZTlXNHlGOGpPdXJWbjdENGxSaWQyY055M0ViCmlZOVlBYVVrVXdZU3d4Tm4rTDhiOERLa0k3VnFYa2k2aFZJUnlDaldPcEUzMGFOYms5RGhZNkYwT3RtMDBOeFUKT1B1MndINDRveC8zKzY3cXo3bnFvQlJzTGY0Z3dod0lrTUFSUUJreDQ0Y2lSZXU0Yk15Mk1ZQWx2Tm1ETXVCSwp0ckVkN3JYU1U1bVZ0bnAwOHM4MlFHZW5VWGxseFdjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0TmpJeFkyWXhNbVF0TkRVMVlpMDBaR0ptTFdFME1qSXRPVE0xWXpGbE9XSmwKTXpVekxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhEWGh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQUhQN2FYeWczd1UzckQ4WXNub1BXQWtZQm5GSERJbDVWWmlIYk84ajlsejNtYnRYdHJ3UDhxCmU3V3laVHB4MTZ4VmwrN3YvQS9paTdUb3lCaTFQbkticTZKcHoxb3czTU40Tmx2Qi9lN3VydTV5Qy9FT0wxdjUKS0h4TEtqckpTS1ZKbFF3SUhCWHE5eXRqa3kyZjRMS25WVlQ4dzlvRG5EdnMvQ1hQS09NdDJOaTdUSlc2dFRCQwpzek5PODl0RnpmZnhnQ010R1Q1UjBhaHlmV3ZVTHowMnM0bEt4Y21ZdE5mNmNtUE5NdGY5dksxaHp5T09FQUROCk01YXJIclBITWhWMTQrbUV4WDg1WVc2MHNvYmp4NFZPTlZUYkR3UnJCRXBycXppNkZkcnUweW0rMjNvQ2Q2TU8KN0p6L1llcUtMem1wR3pNNFZBYmNaOFNEMjJoQjVrTnAKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVR1ducURFcUk0c2FnSGxWcFY4cUF1UFdWSmZZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1qQXdXaGNOTXpNeE1ETXdNVGcxTWpBd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1JOFhCSndVdnFBR2taT3MxNGwxcHN1MmRIdnlCUzJxNWNmQXlsOHpEeE1BMjVrM0tBTk1rUUcKUHowaTIreWwrOHBzNEtmUXdyT2VRVnh6Vm9nR2tMSDhUK0drRERvcEQwaFNPVUh5bDVtK2hiSW5KV2hPSjlHQwpnNHBjdVQ0NFNIMnVLb1hFR3pCMHRLbTZ6NllDT21MZGhVRGNsZkFBQ0Z1WUEwVDF3ZjRQNUtoTXBQR3BQL2tlCjJ4bHFwVUljN1prUzVrbWtPc2Jab2VYb05rM0F3QjUzaXFPTmRtRnhMbjVYeHgzMGd0K2UxamtPdHVqTUFwQ2wKTFFaQ01UY01hcmFsdlVxOElsNmhJcTBQb2tZSURteTYyL0RyZ3ZnREM3b0ZoK3VuNWtYWG5jNFo4TTVCSWNpdwptTWMvUzNlQ1hvNHVuWWIyWFc0WkEvZ2s5RG5YUDBNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TURoak1UVmhOR0l0TVdRMFpDMDBaak5rTFdGa1lUWXRNakV5TkdFek16UmgKTnpZeUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDROWWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ2daaWNwU3lIQWlQSkdLcmxxNk90ZTRvUmY5T3lITXMrSGtyaUpuaHRwRU9rbXllVHoweWlkCjYrUWRxOUlSckNCbUxhQTZwWVJhRWNVNENVS1Rtb0JPYzBFdUptOTlBdlBvSFFXN3JnQnU1VjNZY0hUSHVlMWgKY1llTUkxYzMzZWp5OGFTdjZaZGFUaGdjeEFOdzQvajNJdUs0VTFNYVlNVmxlditkUHVHdDA0aWhkUEtyUkN4ZApSR1ZETWg2ZzFqdnpzQ05uQU5wMEM2QVNRN21SR1JtRllYZkVPMTJTWTNhdjVoZVhVbnNDY2VGWmdZR3NyWlltCitYVVh6a1JMVzFLc3lNY3k2RTJBaVJVaHJ4a2hXQVgyWVpId3BoSVE3QXJCQkNzaVUrMlpGN2JnYSthR0RIb0UKMmxZd1RFMVpZWjBsT3VPN21Mam1DTmlEaWdYTkJKZ2kKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:11 GMT
+      - Thu, 02 Nov 2023 18:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea1d92a7-4fd8-4da9-b0a8-bf1765fed106
+      - 80ed5aa0-f1e5-422a-9665-834a752a5d11
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603},"endpoints":[{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603}],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1311"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:12 GMT
+      - Thu, 02 Nov 2023 18:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d43c001-c282-4812-8e0b-168298717b49
+      - a0cf8d69-ca2a-41f8-a691-a9df59e01021
     status: 200 OK
     code: 200
     duration: ""
@@ -741,19 +741,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users
     method: POST
   response:
     body: '{"is_admin":true,"name":"foo"}'
     headers:
       Content-Length:
-      - "31"
+      - "30"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:12 GMT
+      - Thu, 02 Nov 2023 18:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +763,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5650a03-6478-45e4-b435-48092912a061
+      - 46481c28-8ae2-4443-bec2-b307ecae4144
     status: 200 OK
     code: 200
     duration: ""
@@ -774,19 +774,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603},"endpoints":[{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603}],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1311"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:12 GMT
+      - Thu, 02 Nov 2023 18:54:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09ece1a3-1c98-4ed6-a4c7-f778ca83e5a6
+      - 2e4bc8b2-4f4e-45b9-a638-55568871ec84
     status: 200 OK
     code: 200
     duration: ""
@@ -807,52 +807,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "60"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2458eb37-dce5-449a-9376-bd18546a360e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "60"
+      - "58"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:12 GMT
+      - Thu, 02 Nov 2023 18:54:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2052d07-ad66-4c6f-b432-8bea8b760d6a
+      - 63811a6e-42ab-42ee-b75a-0d9ff987760b
     status: 200 OK
     code: 200
     duration: ""
@@ -873,118 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603},"endpoints":[{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603}],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1311"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 775bb3cc-9cb1-4a20-9e9f-6fee9a21ac28
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVVktOYnN4NnhieGZLcUdnVjdJNUw5Tmo2dGhvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU1qQTFXaGNOTXpNeE1ERTNNVFUxTWpBMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUowMnY4Mmo5ODFQL0pYOFNqUU9CUHVGa2picmtMbTF2ZWF2Y3hIS3FMU0FlSkY3aitHV3MveGwKRlpBeDZsek9WdHhJNEZzell4UzZRdWNWSDI0M0FuY3Nza3F4cDhISlFBcnppVjQ2WGh2VnlDVWpKRklRelprVgo5KzB4MzJYS1NZdUFQaFNLcjFKbEdoSmVsVU5qTW0xVVh5UHg3ZTlXNHlGOGpPdXJWbjdENGxSaWQyY055M0ViCmlZOVlBYVVrVXdZU3d4Tm4rTDhiOERLa0k3VnFYa2k2aFZJUnlDaldPcEUzMGFOYms5RGhZNkYwT3RtMDBOeFUKT1B1MndINDRveC8zKzY3cXo3bnFvQlJzTGY0Z3dod0lrTUFSUUJreDQ0Y2lSZXU0Yk15Mk1ZQWx2Tm1ETXVCSwp0ckVkN3JYU1U1bVZ0bnAwOHM4MlFHZW5VWGxseFdjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0TmpJeFkyWXhNbVF0TkRVMVlpMDBaR0ptTFdFME1qSXRPVE0xWXpGbE9XSmwKTXpVekxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhEWGh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQUhQN2FYeWczd1UzckQ4WXNub1BXQWtZQm5GSERJbDVWWmlIYk84ajlsejNtYnRYdHJ3UDhxCmU3V3laVHB4MTZ4VmwrN3YvQS9paTdUb3lCaTFQbkticTZKcHoxb3czTU40Tmx2Qi9lN3VydTV5Qy9FT0wxdjUKS0h4TEtqckpTS1ZKbFF3SUhCWHE5eXRqa3kyZjRMS25WVlQ4dzlvRG5EdnMvQ1hQS09NdDJOaTdUSlc2dFRCQwpzek5PODl0RnpmZnhnQ010R1Q1UjBhaHlmV3ZVTHowMnM0bEt4Y21ZdE5mNmNtUE5NdGY5dksxaHp5T09FQUROCk01YXJIclBITWhWMTQrbUV4WDg1WVc2MHNvYmp4NFZPTlZUYkR3UnJCRXBycXppNkZkcnUweW0rMjNvQ2Q2TU8KN0p6L1llcUtMem1wR3pNNFZBYmNaOFNEMjJoQjVrTnAKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1845"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2b70706d-916c-43bc-b49e-b50753162855
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603},"endpoints":[{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603}],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1311"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9e03e97b-3275-42b2-a9fc-07db610bcfda
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "60"
+      - "58"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:13 GMT
+      - Thu, 02 Nov 2023 18:54:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2855048-a286-41ac-a30e-70f6989fddde
+      - 3cd959ad-bce6-44d2-8e77-756e73a9fd0e
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603},"endpoints":[{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603}],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1311"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 18:54:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96ae8f49-bba1-4d76-a76f-97891af9978f
+      - 812284a6-60b1-46bc-b4aa-9f67e03b943c
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVVktOYnN4NnhieGZLcUdnVjdJNUw5Tmo2dGhvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU1qQTFXaGNOTXpNeE1ERTNNVFUxTWpBMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUowMnY4Mmo5ODFQL0pYOFNqUU9CUHVGa2picmtMbTF2ZWF2Y3hIS3FMU0FlSkY3aitHV3MveGwKRlpBeDZsek9WdHhJNEZzell4UzZRdWNWSDI0M0FuY3Nza3F4cDhISlFBcnppVjQ2WGh2VnlDVWpKRklRelprVgo5KzB4MzJYS1NZdUFQaFNLcjFKbEdoSmVsVU5qTW0xVVh5UHg3ZTlXNHlGOGpPdXJWbjdENGxSaWQyY055M0ViCmlZOVlBYVVrVXdZU3d4Tm4rTDhiOERLa0k3VnFYa2k2aFZJUnlDaldPcEUzMGFOYms5RGhZNkYwT3RtMDBOeFUKT1B1MndINDRveC8zKzY3cXo3bnFvQlJzTGY0Z3dod0lrTUFSUUJreDQ0Y2lSZXU0Yk15Mk1ZQWx2Tm1ETXVCSwp0ckVkN3JYU1U1bVZ0bnAwOHM4MlFHZW5VWGxseFdjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0TmpJeFkyWXhNbVF0TkRVMVlpMDBaR0ptTFdFME1qSXRPVE0xWXpGbE9XSmwKTXpVekxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhEWGh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQUhQN2FYeWczd1UzckQ4WXNub1BXQWtZQm5GSERJbDVWWmlIYk84ajlsejNtYnRYdHJ3UDhxCmU3V3laVHB4MTZ4VmwrN3YvQS9paTdUb3lCaTFQbkticTZKcHoxb3czTU40Tmx2Qi9lN3VydTV5Qy9FT0wxdjUKS0h4TEtqckpTS1ZKbFF3SUhCWHE5eXRqa3kyZjRMS25WVlQ4dzlvRG5EdnMvQ1hQS09NdDJOaTdUSlc2dFRCQwpzek5PODl0RnpmZnhnQ010R1Q1UjBhaHlmV3ZVTHowMnM0bEt4Y21ZdE5mNmNtUE5NdGY5dksxaHp5T09FQUROCk01YXJIclBITWhWMTQrbUV4WDg1WVc2MHNvYmp4NFZPTlZUYkR3UnJCRXBycXppNkZkcnUweW0rMjNvQ2Q2TU8KN0p6L1llcUtMem1wR3pNNFZBYmNaOFNEMjJoQjVrTnAKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVR1ducURFcUk0c2FnSGxWcFY4cUF1UFdWSmZZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1qQXdXaGNOTXpNeE1ETXdNVGcxTWpBd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1JOFhCSndVdnFBR2taT3MxNGwxcHN1MmRIdnlCUzJxNWNmQXlsOHpEeE1BMjVrM0tBTk1rUUcKUHowaTIreWwrOHBzNEtmUXdyT2VRVnh6Vm9nR2tMSDhUK0drRERvcEQwaFNPVUh5bDVtK2hiSW5KV2hPSjlHQwpnNHBjdVQ0NFNIMnVLb1hFR3pCMHRLbTZ6NllDT21MZGhVRGNsZkFBQ0Z1WUEwVDF3ZjRQNUtoTXBQR3BQL2tlCjJ4bHFwVUljN1prUzVrbWtPc2Jab2VYb05rM0F3QjUzaXFPTmRtRnhMbjVYeHgzMGd0K2UxamtPdHVqTUFwQ2wKTFFaQ01UY01hcmFsdlVxOElsNmhJcTBQb2tZSURteTYyL0RyZ3ZnREM3b0ZoK3VuNWtYWG5jNFo4TTVCSWNpdwptTWMvUzNlQ1hvNHVuWWIyWFc0WkEvZ2s5RG5YUDBNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TURoak1UVmhOR0l0TVdRMFpDMDBaak5rTFdGa1lUWXRNakV5TkdFek16UmgKTnpZeUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDROWWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ2daaWNwU3lIQWlQSkdLcmxxNk90ZTRvUmY5T3lITXMrSGtyaUpuaHRwRU9rbXllVHoweWlkCjYrUWRxOUlSckNCbUxhQTZwWVJhRWNVNENVS1Rtb0JPYzBFdUptOTlBdlBvSFFXN3JnQnU1VjNZY0hUSHVlMWgKY1llTUkxYzMzZWp5OGFTdjZaZGFUaGdjeEFOdzQvajNJdUs0VTFNYVlNVmxlditkUHVHdDA0aWhkUEtyUkN4ZApSR1ZETWg2ZzFqdnpzQ05uQU5wMEM2QVNRN21SR1JtRllYZkVPMTJTWTNhdjVoZVhVbnNDY2VGWmdZR3NyWlltCitYVVh6a1JMVzFLc3lNY3k2RTJBaVJVaHJ4a2hXQVgyWVpId3BoSVE3QXJCQkNzaVUrMlpGN2JnYSthR0RIb0UKMmxZd1RFMVpZWjBsT3VPN21Mam1DTmlEaWdYTkJKZ2kKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1845"
+      - "1843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 18:54:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57fee5f2-8607-45b7-b561-cc68307e848a
+      - ee6ca65d-84da-4038-b9cb-84610d4c5dc9
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603},"endpoints":[{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603}],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1311"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 18:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9dc5435-e9dc-4ffb-b9f7-14a067318691
+      - 25fd4aff-c8d2-4e58-b1b8-42291110dc4f
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,19 +972,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "60"
+      - "58"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:14 GMT
+      - Thu, 02 Nov 2023 18:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b9c856b-064b-4fd8-9bdd-0d859497e2bc
+      - c286e22d-9906-4bca-854a-d198c7822b5d
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,19 +1005,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603},"endpoints":[{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603}],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1311"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:15 GMT
+      - Thu, 02 Nov 2023 18:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2260bb1a-dc94-4c12-9b43-2542cbcbcb99
+      - d0e04036-f356-41c8-807e-ea89a6d50563
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,7 +1038,139 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353/users/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVR1ducURFcUk0c2FnSGxWcFY4cUF1UFdWSmZZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1qQXdXaGNOTXpNeE1ETXdNVGcxTWpBd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1JOFhCSndVdnFBR2taT3MxNGwxcHN1MmRIdnlCUzJxNWNmQXlsOHpEeE1BMjVrM0tBTk1rUUcKUHowaTIreWwrOHBzNEtmUXdyT2VRVnh6Vm9nR2tMSDhUK0drRERvcEQwaFNPVUh5bDVtK2hiSW5KV2hPSjlHQwpnNHBjdVQ0NFNIMnVLb1hFR3pCMHRLbTZ6NllDT21MZGhVRGNsZkFBQ0Z1WUEwVDF3ZjRQNUtoTXBQR3BQL2tlCjJ4bHFwVUljN1prUzVrbWtPc2Jab2VYb05rM0F3QjUzaXFPTmRtRnhMbjVYeHgzMGd0K2UxamtPdHVqTUFwQ2wKTFFaQ01UY01hcmFsdlVxOElsNmhJcTBQb2tZSURteTYyL0RyZ3ZnREM3b0ZoK3VuNWtYWG5jNFo4TTVCSWNpdwptTWMvUzNlQ1hvNHVuWWIyWFc0WkEvZ2s5RG5YUDBNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TURoak1UVmhOR0l0TVdRMFpDMDBaak5rTFdGa1lUWXRNakV5TkdFek16UmgKTnpZeUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDROWWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ2daaWNwU3lIQWlQSkdLcmxxNk90ZTRvUmY5T3lITXMrSGtyaUpuaHRwRU9rbXllVHoweWlkCjYrUWRxOUlSckNCbUxhQTZwWVJhRWNVNENVS1Rtb0JPYzBFdUptOTlBdlBvSFFXN3JnQnU1VjNZY0hUSHVlMWgKY1llTUkxYzMzZWp5OGFTdjZaZGFUaGdjeEFOdzQvajNJdUs0VTFNYVlNVmxlditkUHVHdDA0aWhkUEtyUkN4ZApSR1ZETWg2ZzFqdnpzQ05uQU5wMEM2QVNRN21SR1JtRllYZkVPMTJTWTNhdjVoZVhVbnNDY2VGWmdZR3NyWlltCitYVVh6a1JMVzFLc3lNY3k2RTJBaVJVaHJ4a2hXQVgyWVpId3BoSVE3QXJCQkNzaVUrMlpGN2JnYSthR0RIb0UKMmxZd1RFMVpZWjBsT3VPN21Mam1DTmlEaWdYTkJKZ2kKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1843"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:54:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 74b5836d-7142-45af-ada4-bf1da663b115
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1263"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:54:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f9cccbf4-9c28-4bec-a0c3-d07a1245bdbd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "58"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:54:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 22147d25-9ae3-4537-b8bf-05831158b81c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1263"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:54:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7089b9f4-793c-4e8d-8910-a4faa56c273b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users/foo
     method: DELETE
   response:
     body: ""
@@ -1180,7 +1180,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:15 GMT
+      - Thu, 02 Nov 2023 18:54:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +1190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6279bce-9f8a-4545-9a0f-ba1cad4f1749
+      - 229ba6c6-e3a8-4b0b-a010-f142c0a3c1a7
     status: 204 No Content
     code: 204
     duration: ""
@@ -1201,19 +1201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603},"endpoints":[{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603}],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1311"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:15 GMT
+      - Thu, 02 Nov 2023 18:54:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d47539c-8ab2-4ff3-8a7c-c825be5bc77d
+      - 50863d72-94dc-49d8-98e1-6b5cb8d708ed
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,19 +1236,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users
     method: POST
   response:
     body: '{"is_admin":false,"name":"bar"}'
     headers:
       Content-Length:
-      - "32"
+      - "31"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:15 GMT
+      - Thu, 02 Nov 2023 18:54:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1739d586-2dc6-4932-b430-b0f9b6842360
+      - 2eb86600-8b0c-4666-95b4-13411526c92a
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,19 +1269,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603},"endpoints":[{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603}],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1311"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:15 GMT
+      - Thu, 02 Nov 2023 18:54:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c673db09-b3e8-4176-a69f-eff128ee9592
+      - fef063f1-70b5-4c02-9870-578f9b0fa59a
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,52 +1302,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353/users?name=bar&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"bar"}]}'
-    headers:
-      Content-Length:
-      - "61"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e9754937-5904-457d-9874-4d62c7a0e4c4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353/users?name=bar&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users?name=bar&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bar"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:16 GMT
+      - Thu, 02 Nov 2023 18:54:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc8b814e-724f-4deb-9002-da60f15c6cc1
+      - 2c2bdc02-e19b-40c0-8908-9125d04f7f8d
     status: 200 OK
     code: 200
     duration: ""
@@ -1368,118 +1335,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603},"endpoints":[{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603}],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1311"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b32093af-4752-4bae-abb7-cce8ef1d352b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVVktOYnN4NnhieGZLcUdnVjdJNUw5Tmo2dGhvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eE5EZ3dIaGNOCk1qTXhNREl3TVRVMU1qQTFXaGNOTXpNeE1ERTNNVFUxTWpBMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakUwT0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUowMnY4Mmo5ODFQL0pYOFNqUU9CUHVGa2picmtMbTF2ZWF2Y3hIS3FMU0FlSkY3aitHV3MveGwKRlpBeDZsek9WdHhJNEZzell4UzZRdWNWSDI0M0FuY3Nza3F4cDhISlFBcnppVjQ2WGh2VnlDVWpKRklRelprVgo5KzB4MzJYS1NZdUFQaFNLcjFKbEdoSmVsVU5qTW0xVVh5UHg3ZTlXNHlGOGpPdXJWbjdENGxSaWQyY055M0ViCmlZOVlBYVVrVXdZU3d4Tm4rTDhiOERLa0k3VnFYa2k2aFZJUnlDaldPcEUzMGFOYms5RGhZNkYwT3RtMDBOeFUKT1B1MndINDRveC8zKzY3cXo3bnFvQlJzTGY0Z3dod0lrTUFSUUJreDQ0Y2lSZXU0Yk15Mk1ZQWx2Tm1ETXVCSwp0ckVkN3JYU1U1bVZ0bnAwOHM4MlFHZW5VWGxseFdjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpFME9JSThjbmN0TmpJeFkyWXhNbVF0TkRVMVlpMDBaR0ptTFdFME1qSXRPVE0xWXpGbE9XSmwKTXpVekxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDhEWGh3UXpueHFVTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQUhQN2FYeWczd1UzckQ4WXNub1BXQWtZQm5GSERJbDVWWmlIYk84ajlsejNtYnRYdHJ3UDhxCmU3V3laVHB4MTZ4VmwrN3YvQS9paTdUb3lCaTFQbkticTZKcHoxb3czTU40Tmx2Qi9lN3VydTV5Qy9FT0wxdjUKS0h4TEtqckpTS1ZKbFF3SUhCWHE5eXRqa3kyZjRMS25WVlQ4dzlvRG5EdnMvQ1hQS09NdDJOaTdUSlc2dFRCQwpzek5PODl0RnpmZnhnQ010R1Q1UjBhaHlmV3ZVTHowMnM0bEt4Y21ZdE5mNmNtUE5NdGY5dksxaHp5T09FQUROCk01YXJIclBITWhWMTQrbUV4WDg1WVc2MHNvYmp4NFZPTlZUYkR3UnJCRXBycXppNkZkcnUweW0rMjNvQ2Q2TU8KN0p6L1llcUtMem1wR3pNNFZBYmNaOFNEMjJoQjVrTnAKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1845"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2676b804-0906-4219-a2c5-8935cf1f42c9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603},"endpoints":[{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603}],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1311"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 15:54:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8a84bf39-17e8-4ecf-99e8-fff705e36dbc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353/users?name=bar&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users?name=bar&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bar"}]}'
     headers:
       Content-Length:
-      - "61"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:16 GMT
+      - Thu, 02 Nov 2023 18:54:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10001cfa-579b-47e8-bc24-2d6f8857f639
+      - a51b7d47-ed0b-49cd-8fd3-241beece5ca9
     status: 200 OK
     code: 200
     duration: ""
@@ -1500,19 +1368,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603},"endpoints":[{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603}],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1311"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:17 GMT
+      - Thu, 02 Nov 2023 18:54:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03337d77-edf1-4a1f-b2ee-55831ab9d48f
+      - eb53cdce-f0c8-480d-aa16-621773fb41c9
     status: 200 OK
     code: 200
     duration: ""
@@ -1533,7 +1401,139 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353/users/bar
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVR1ducURFcUk0c2FnSGxWcFY4cUF1UFdWSmZZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1qQXdXaGNOTXpNeE1ETXdNVGcxTWpBd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1JOFhCSndVdnFBR2taT3MxNGwxcHN1MmRIdnlCUzJxNWNmQXlsOHpEeE1BMjVrM0tBTk1rUUcKUHowaTIreWwrOHBzNEtmUXdyT2VRVnh6Vm9nR2tMSDhUK0drRERvcEQwaFNPVUh5bDVtK2hiSW5KV2hPSjlHQwpnNHBjdVQ0NFNIMnVLb1hFR3pCMHRLbTZ6NllDT21MZGhVRGNsZkFBQ0Z1WUEwVDF3ZjRQNUtoTXBQR3BQL2tlCjJ4bHFwVUljN1prUzVrbWtPc2Jab2VYb05rM0F3QjUzaXFPTmRtRnhMbjVYeHgzMGd0K2UxamtPdHVqTUFwQ2wKTFFaQ01UY01hcmFsdlVxOElsNmhJcTBQb2tZSURteTYyL0RyZ3ZnREM3b0ZoK3VuNWtYWG5jNFo4TTVCSWNpdwptTWMvUzNlQ1hvNHVuWWIyWFc0WkEvZ2s5RG5YUDBNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TURoak1UVmhOR0l0TVdRMFpDMDBaak5rTFdGa1lUWXRNakV5TkdFek16UmgKTnpZeUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDROWWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ2daaWNwU3lIQWlQSkdLcmxxNk90ZTRvUmY5T3lITXMrSGtyaUpuaHRwRU9rbXllVHoweWlkCjYrUWRxOUlSckNCbUxhQTZwWVJhRWNVNENVS1Rtb0JPYzBFdUptOTlBdlBvSFFXN3JnQnU1VjNZY0hUSHVlMWgKY1llTUkxYzMzZWp5OGFTdjZaZGFUaGdjeEFOdzQvajNJdUs0VTFNYVlNVmxlditkUHVHdDA0aWhkUEtyUkN4ZApSR1ZETWg2ZzFqdnpzQ05uQU5wMEM2QVNRN21SR1JtRllYZkVPMTJTWTNhdjVoZVhVbnNDY2VGWmdZR3NyWlltCitYVVh6a1JMVzFLc3lNY3k2RTJBaVJVaHJ4a2hXQVgyWVpId3BoSVE3QXJCQkNzaVUrMlpGN2JnYSthR0RIb0UKMmxZd1RFMVpZWjBsT3VPN21Mam1DTmlEaWdYTkJKZ2kKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1843"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:54:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - aa2db832-ab6b-4591-ba74-28b1d3942aa3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1263"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:54:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 410069b5-6080-48d6-ab23-0129d809d7fa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users?name=bar&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"bar"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:54:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1ea86754-0000-4fc0-87ba-9e9adb2ccf36
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1263"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 18:54:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cce5a100-4c3d-4cd5-acf8-d609999522bb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users/bar
     method: DELETE
   response:
     body: ""
@@ -1543,7 +1543,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:17 GMT
+      - Thu, 02 Nov 2023 18:54:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1553,7 +1553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e65b03c1-7bb2-4561-b203-fe575178d715
+      - 845a8847-c00b-405f-8bbc-a0b9b508edd3
     status: 204 No Content
     code: 204
     duration: ""
@@ -1564,19 +1564,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603},"endpoints":[{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603}],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1311"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:17 GMT
+      - Thu, 02 Nov 2023 18:54:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1586,7 +1586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d1d7676-ef42-4cdb-8338-e76587f4fc9c
+      - 5a8b6f1b-85fd-45a3-8fdb-ffd6a954e053
     status: 200 OK
     code: 200
     duration: ""
@@ -1597,19 +1597,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603},"endpoints":[{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603}],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1314"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:18 GMT
+      - Thu, 02 Nov 2023 18:54:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1619,7 +1619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0cff9879-9790-4c55-9425-6829342a4838
+      - e336d0ef-f20e-4435-adb8-831d202d6ca2
     status: 200 OK
     code: 200
     duration: ""
@@ -1630,19 +1630,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-10-21T15:51:10.362366Z","retention":7},"created_at":"2023-10-20T15:51:10.362366Z","endpoint":{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603},"endpoints":[{"id":"4c4bd544-c8da-4d1c-b3c6-2a3fb191dfd8","ip":"51.159.26.148","load_balancer":{},"name":null,"port":23603}],"engine":"PostgreSQL-15","id":"621cf12d-455b-4dbf-a422-935c1e9be353","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1314"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:18 GMT
+      - Thu, 02 Nov 2023 18:54:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1652,7 +1652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a14a43e-0643-42a2-bb76-d6f1c188b1c0
+      - a123b506-e191-4a98-865c-13e7daafa76b
     status: 200 OK
     code: 200
     duration: ""
@@ -1663,10 +1663,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"621cf12d-455b-4dbf-a422-935c1e9be353","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1675,7 +1675,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:48 GMT
+      - Thu, 02 Nov 2023 18:55:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1685,7 +1685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47c1d32d-7c87-4faa-b916-0aa0b4a2e0fe
+      - d9775f1c-6757-4102-b36c-a89e9fec8bc6
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1696,10 +1696,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/621cf12d-455b-4dbf-a422-935c1e9be353
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"621cf12d-455b-4dbf-a422-935c1e9be353","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1708,7 +1708,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 15:54:50 GMT
+      - Thu, 02 Nov 2023 18:55:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1718,7 +1718,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f595bd8e-4428-4827-82cd-b4adb6837ff3
+      - 6ac8e397-7483-4b6a-8bb9-9523d7623a35
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
Closes #2046 

The provider didn't allow changes to `node_type` or `volume_size_in_gb` once the instance reached `disk_full` status. This is because both these attributes belong in the upgrades category and it tried to perform the updates before, which failed since the resource is in a transient state.

This PR fixes the issue by performing the upgrades first and adds a bit of documentation on how to deal with a `disk_full` situation with Terraform.